### PR TITLE
feat: direct chatgpt.com backend client + 9 GET tools

### DIFF
--- a/openai_mcp/auth.py
+++ b/openai_mcp/auth.py
@@ -21,7 +21,11 @@ def _from_codex() -> dict | None:
         return None
     try:
         data = json.loads(p.read_text())
-        token = data.get("accessToken") or data.get("access_token")
+        token = (
+            (data.get("tokens") or {}).get("access_token")
+            or data.get("accessToken")
+            or data.get("access_token")
+        )
         if token:
             return {"access_token": token, "source": "codex"}
     except Exception:

--- a/openai_mcp/backend.py
+++ b/openai_mcp/backend.py
@@ -1,0 +1,74 @@
+"""Direct chatgpt.com backend client — no proxy, no API key."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+from curl_cffi import requests
+
+
+_BASE = "https://chatgpt.com"
+_CLIENT_VERSION = "prod-be885abbfcfe7b1f511e88b3003d9ee44757fbad"
+_CLIENT_BUILD = "5955942"
+
+
+def _load_token() -> str:
+    p = Path.home() / ".codex" / "auth.json"
+    if not p.exists():
+        raise RuntimeError("~/.codex/auth.json not found — run `codex login` first")
+    try:
+        data = json.loads(p.read_text())
+        token = (data.get("tokens") or {}).get("access_token")
+        if not token:
+            raise RuntimeError("tokens.access_token missing in ~/.codex/auth.json")
+        return token
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(f"Failed to read ~/.codex/auth.json: {exc}") from exc
+
+
+class BackendClient:
+    def __init__(self) -> None:
+        token = _load_token()
+        self._session = requests.Session(impersonate="edge101", verify=True)
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 Chrome/143 Edg/143",
+                "Authorization": f"Bearer {token}",
+                "OAI-Device-Id": str(uuid.uuid4()),
+                "OAI-Session-Id": str(uuid.uuid4()),
+                "OAI-Language": "en-US",
+                "OAI-Client-Version": _CLIENT_VERSION,
+                "OAI-Client-Build-Number": _CLIENT_BUILD,
+                "Origin": _BASE,
+                "Referer": _BASE + "/",
+                "Accept": "*/*",
+            }
+        )
+
+    def get(
+        self,
+        path: str,
+        target_path: str | None = None,
+        target_route: str | None = None,
+    ) -> Any:
+        extra: dict[str, str] = {}
+        if target_path is not None:
+            extra["X-OpenAI-Target-Path"] = target_path
+        if target_route is not None:
+            extra["X-OpenAI-Target-Route"] = target_route
+
+        r = self._session.get(_BASE + path, headers=extra, timeout=20)
+
+        if r.status_code == 401:
+            raise RuntimeError("401 Unauthorized — token expired, run `codex login`")
+        if r.status_code == 403:
+            raise RuntimeError(f"403 Forbidden for {path}")
+        if r.status_code == 404:
+            raise RuntimeError(f"404 Not Found: {path}")
+        if r.status_code != 200:
+            raise RuntimeError(f"HTTP {r.status_code} for {path}")
+
+        return r.json()

--- a/openai_mcp/server.py
+++ b/openai_mcp/server.py
@@ -102,6 +102,16 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
             )
             return f"data:image/png;base64,{resp.data[0].b64_json}"
 
+    try:
+        from openai_mcp.backend import BackendClient
+        from openai_mcp.tools import register_all
+
+        register_all(mcp, BackendClient())
+    except Exception as _exc:
+        import logging
+
+        logging.getLogger(__name__).warning("backend tools unavailable: %s", _exc)
+
     return mcp
 
 

--- a/openai_mcp/tools/__init__.py
+++ b/openai_mcp/tools/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools import (
+    account,
+    apps,
+    codex,
+    conversations,
+    gpts,
+    instructions,
+    memory,
+)
+
+
+def register_all(mcp, client: BackendClient) -> None:
+    """Register every backend tool on *mcp*."""
+    account.register(mcp, client)
+    memory.register(mcp, client)
+    instructions.register(mcp, client)
+    codex.register(mcp, client)
+    gpts.register(mcp, client)
+    conversations.register(mcp, client)
+    apps.register(mcp, client)

--- a/openai_mcp/tools/_redact.py
+++ b/openai_mcp/tools/_redact.py
@@ -1,0 +1,9 @@
+import re
+
+
+def redact(s: object) -> object:
+    if not isinstance(s, str):
+        return s
+    s = re.sub(r"[\w.+-]+@[\w-]+\.[\w.-]+", "<EMAIL>", s)
+    s = re.sub(r"\+?\d[\d ()\-]{8,}\d", "<PHONE>", s)
+    return s

--- a/openai_mcp/tools/account.py
+++ b/openai_mcp/tools/account.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def account_status() -> dict:
+        """Return ChatGPT account info: subscription plan, features, and model list."""
+        me = client.get("/backend-api/me", target_path="/backend-api/me")
+        check = client.get(
+            "/backend-api/accounts/check/v4-2023-04-27",
+            target_path="/backend-api/accounts/check/v4-2023-04-27",
+        )
+        acc_keys = list((check.get("accounts") or {}).keys())
+        first = (check.get("accounts") or {}).get(acc_keys[0], {}) if acc_keys else {}
+        ent = first.get("entitlement") or {}
+        return {
+            "email": redact(me.get("email") or ""),
+            "country": me.get("country"),
+            "groups": me.get("groups"),
+            "subscription": ent.get("subscription_plan"),
+            "has_active_subscription": ent.get("has_active_subscription"),
+            "expires_at": ent.get("expires_at"),
+            "features_count": len(first.get("features") or []),
+        }
+
+    @mcp.tool()
+    def list_models() -> list:
+        """Return all available ChatGPT models."""
+        data = client.get(
+            "/backend-api/models?history_and_training_disabled=false",
+            target_path="/backend-api/models",
+        )
+        return [
+            {
+                "slug": m.get("slug"),
+                "title": m.get("title"),
+                "max_tokens": m.get("max_tokens"),
+                "reasoning_type": m.get("reasoning_type"),
+            }
+            for m in (data.get("models") or [])
+        ]

--- a/openai_mcp/tools/apps.py
+++ b/openai_mcp/tools/apps.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+
+
+def _classify(app_id: str) -> str:
+    if app_id.startswith("connector_"):
+        return "official_connector"
+    if app_id.startswith("asdk_app_"):
+        return "third_party_sdk"
+    return "unknown"
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def list_apps() -> list:
+        """Return ChatGPT connected apps/connectors. Names unresolvable — IDs with type classification returned."""
+        data = client.get(
+            "/backend-api/apps/list",
+            target_path="/backend-api/apps/list",
+        )
+        return [
+            {
+                "id": a.get("id"),
+                "type": _classify(a.get("id") or ""),
+                "enabled": a.get("enabled"),
+                "connected": a.get("is_connected") or a.get("connected"),
+            }
+            for a in (data.get("apps") or [])
+            if isinstance(a, dict)
+        ]

--- a/openai_mcp/tools/codex.py
+++ b/openai_mcp/tools/codex.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def list_codex_envs() -> list:
+        """Return Codex environments (label, repos, network access)."""
+        data = client.get(
+            "/backend-api/codex/environments",
+            target_path="/backend-api/codex/environments",
+        )
+        envs = data if isinstance(data, list) else (data.get("environments") or [])
+        return [
+            {
+                "id": e.get("id"),
+                "label": e.get("label"),
+                "workspace_dir": e.get("workspace_dir"),
+                "agent_network_access": e.get("agent_network_access"),
+                "repo_count": len(e.get("repos") or []),
+            }
+            for e in envs
+        ]
+
+    @mcp.tool()
+    def list_codex_tasks(limit: int = 10) -> list:
+        """Return recent Codex tasks (title + status). Content is PII-redacted."""
+        data = client.get(
+            f"/backend-api/codex/tasks?limit={limit}",
+            target_path="/backend-api/codex/tasks",
+        )
+        items = data.get("items") or []
+        return [
+            {
+                "id": (t.get("task") or t).get("id") if isinstance(t, dict) else None,
+                "title": redact(
+                    ((t.get("task") or t).get("title") or "")
+                    if isinstance(t, dict)
+                    else ""
+                ),
+                "status": (t.get("turn") or {}).get("turn_status")
+                if isinstance(t, dict)
+                else None,
+            }
+            for t in items[:limit]
+        ]

--- a/openai_mcp/tools/conversations.py
+++ b/openai_mcp/tools/conversations.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def list_conversations(limit: int = 20) -> list:
+        """Return recent ChatGPT conversations (titles PII-redacted)."""
+        data = client.get(
+            f"/backend-api/conversations?offset=0&limit={limit}&order=updated",
+            target_path="/backend-api/conversations",
+        )
+        return [
+            {
+                "id": c.get("id"),
+                "title": redact(c.get("title") or ""),
+                "update_time": c.get("update_time"),
+                "is_archived": c.get("is_archived"),
+                "gizmo_id": c.get("gizmo_id"),
+            }
+            for c in (data.get("items") or [])
+        ]
+
+    @mcp.tool()
+    def list_tasks(limit: int = 20) -> list:
+        """Return scheduled/completed ChatGPT tasks (titles PII-redacted)."""
+        data = client.get(
+            f"/backend-api/tasks?limit={limit}",
+            target_path="/backend-api/tasks",
+        )
+        return [
+            {
+                "title": redact(t.get("title") or ""),
+                "status": t.get("status"),
+                "created_at": t.get("created_at"),
+            }
+            for t in (data.get("tasks") or [])[:limit]
+        ]

--- a/openai_mcp/tools/gpts.py
+++ b/openai_mcp/tools/gpts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def list_custom_gpts() -> list:
+        """Return private custom GPTs from the ChatGPT sidebar."""
+        data = client.get(
+            "/backend-api/gizmos/snorlax/sidebar",
+            target_path="/backend-api/gizmos/snorlax/sidebar",
+        )
+        return [
+            {
+                "name": redact((item.get("gizmo") or {}).get("name") or ""),
+                "short_url": (item.get("gizmo") or {}).get("short_url"),
+            }
+            for item in (data.get("items") or [])
+        ]

--- a/openai_mcp/tools/instructions.py
+++ b/openai_mcp/tools/instructions.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def custom_instructions_get() -> dict:
+        """Return ChatGPT custom instructions (PII redacted)."""
+        ci = client.get(
+            "/backend-api/user_system_messages",
+            target_path="/backend-api/user_system_messages",
+        )
+        return {
+            "enabled": ci.get("enabled"),
+            "traits_enabled": ci.get("traits_enabled"),
+            "personality_type": ci.get("personality_type_selection"),
+            "about_user": redact(ci.get("about_user_message") or ""),
+            "about_model": redact(ci.get("about_model_message") or ""),
+        }

--- a/openai_mcp/tools/memory.py
+++ b/openai_mcp/tools/memory.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from openai_mcp.backend import BackendClient
+from openai_mcp.tools._redact import redact
+
+
+def _fetch_memories(client: BackendClient) -> list[dict]:
+    data = client.get("/backend-api/memories", target_path="/backend-api/memories")
+    return data.get("memories") or []
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool()
+    def memory_list() -> list:
+        """Return all ChatGPT memories (PII redacted)."""
+        return [
+            {
+                "id": m.get("id"),
+                "status": m.get("status"),
+                "content": redact(m.get("content") or ""),
+                "created_timestamp": m.get("created_timestamp"),
+            }
+            for m in _fetch_memories(client)
+        ]
+
+    @mcp.tool()
+    def memory_search(query: str) -> list:
+        """Keyword search over ChatGPT memories. Returns matching entries (PII redacted)."""
+        q = query.lower()
+        return [
+            {
+                "id": m.get("id"),
+                "content": redact(m.get("content") or ""),
+                "created_timestamp": m.get("created_timestamp"),
+            }
+            for m in _fetch_memories(client)
+            if q in (m.get("content") or "").lower()
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "openai>=1.0.0",
     "uvicorn>=0.30.0",
     "tomli>=2.0.0; python_version < '3.11'",
+    "curl_cffi>=0.7.0",
 ]
 
 [project.scripts]

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -1,0 +1,35 @@
+"""Integration test: BackendClient.account_status() against live chatgpt.com.
+
+Skipped automatically when ~/.codex/auth.json is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    not (Path.home() / ".codex" / "auth.json").exists(),
+    reason="~/.codex/auth.json not present",
+)
+def test_account_status_has_subscription() -> None:
+    from openai_mcp.backend import BackendClient
+
+    client = BackendClient()
+
+    # call the raw backend methods directly — no MCP runtime needed
+    me = client.get("/backend-api/me", target_path="/backend-api/me")
+    check = client.get(
+        "/backend-api/accounts/check/v4-2023-04-27",
+        target_path="/backend-api/accounts/check/v4-2023-04-27",
+    )
+
+    acc_keys = list((check.get("accounts") or {}).keys())
+    assert acc_keys, "accounts dict is empty"
+    first = (check.get("accounts") or {}).get(acc_keys[0], {})
+    ent = first.get("entitlement") or {}
+
+    assert "subscription_plan" in ent, f"subscription field missing; entitlement={ent}"
+    assert ent.get("subscription_plan"), "subscription_plan is empty"


### PR DESCRIPTION
## Summary
- Adds `openai_mcp/backend.py` — native `curl_cffi` client to chatgpt.com (edge101 impersonate, token reused from `~/.codex/auth.json`)
- Adds `openai_mcp/tools/` package with 9 MCP tools over verified GET endpoints: `account_status`, `list_models`, `memory_list`, `memory_search`, `custom_instructions_get`, `list_codex_envs`, `list_codex_tasks`, `list_custom_gpts`, `list_conversations`, `list_tasks`, `list_apps`
- Fixes `auth.py` codex-token path (nested `tokens.access_token`)
- Graceful degradation if no codex token — existing chat/research/image_gen unaffected
- PII redaction on memory / conversations / codex tasks

## Test plan
- [x] `pytest tests/test_backend_tools.py -v` — live against chatgpt.com, verifies `subscription_plan=chatgptpro`
- [ ] Manual: restart MCP server + list tools in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Direct ChatGPT backend access without proxy or API key requirements
  - New tools to retrieve account status, available models, connected apps, conversations, custom GPTs, custom instructions, memories, and Codex environments and tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->