### PR TITLE
feat(sse): native Deep Research + Pro-tier model support

### DIFF
--- a/openai_mcp/server.py
+++ b/openai_mcp/server.py
@@ -73,9 +73,35 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         """Search the web and synthesize a detailed report with citations.
 
         Best for: current events, literature review, market research.
-        Takes 30–90 seconds.
+        Takes 30–120 seconds. Uses model='research' + system_hints=['research'].
         """
-        return await conv.complete("research", [{"role": "user", "content": query}])
+        final_text = ""
+        tool_calls: list[str] = []
+        refs: list = []
+        groups: list = []
+
+        async for event in conv.deep_research(query):
+            if event["type"] == "tool":
+                tool_calls.append(event["call"])
+            elif event["type"] == "done":
+                final_text = event["text"]
+                refs = event.get("content_references", [])
+                groups = event.get("search_result_groups", [])
+
+        # Append a brief sources section if citations were returned
+        if refs:
+            lines = ["\n\n---\n**Sources:**"]
+            seen: set[str] = set()
+            for ref in refs:
+                for item in ref.get("items", []):
+                    url = item.get("url", "")
+                    title = item.get("title", url)
+                    if url and url not in seen:
+                        seen.add(url)
+                        lines.append(f"- [{title}]({url})")
+            final_text += "\n".join(lines)
+
+        return final_text or "(no response)"
 
     # image_gen intentionally unregistered in 0.0.1 — the gpt-image-2 endpoint
     # is unverified in the native SSE build. Tracked for PR5. Re-add the

--- a/openai_mcp/server.py
+++ b/openai_mcp/server.py
@@ -103,6 +103,33 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
         return final_text or "(no response)"
 
+    @mcp.tool()
+    async def deep_research_heavy(query: str) -> str:
+        """Long-form Deep Research using gpt-5-5-pro (5–30 min, uses monthly DR quota — check /backend-api/conversation/init for remaining). For short web-augmented answers use `deep_research` instead."""
+        final_text = ""
+        refs: list = []
+        groups: list = []
+
+        async for event in conv.deep_research_heavy(query):
+            if event["type"] == "done":
+                final_text = event["text"]
+                refs = event.get("content_references", [])
+                groups = event.get("search_result_groups", [])
+
+        if refs:
+            lines = ["\n\n---\n**Sources:**"]
+            seen: set[str] = set()
+            for ref in refs:
+                for item in ref.get("items", []):
+                    url = item.get("url", "")
+                    title = item.get("title", url)
+                    if url and url not in seen:
+                        seen.add(url)
+                        lines.append(f"- [{title}]({url})")
+            final_text += "\n".join(lines)
+
+        return final_text or "(no response)"
+
     # image_gen intentionally unregistered in 0.0.1 — the gpt-image-2 endpoint
     # is unverified in the native SSE build. Tracked for PR5. Re-add the
     # `@mcp.tool()` decorator once the endpoint is implemented and tested.

--- a/openai_mcp/sse.py
+++ b/openai_mcp/sse.py
@@ -352,62 +352,74 @@ class ConversationClient:
                 )
 
             last_text = ""
-            async for raw_line in resp.aiter_lines():
-                if isinstance(raw_line, bytes):
-                    raw_line = raw_line.decode("utf-8", errors="replace")
-                line = raw_line.strip()
-                if not line or not line.startswith("data:"):
-                    continue
-                data = line[5:].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    obj = json.loads(data)
-                except json.JSONDecodeError:
-                    continue
+            done_emitted = False
+            try:
+                async for raw_line in resp.aiter_lines():
+                    if isinstance(raw_line, bytes):
+                        raw_line = raw_line.decode("utf-8", errors="replace")
+                    line = raw_line.strip()
+                    if not line or not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        obj = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
 
-                msg = obj.get("message", {})
-                if not isinstance(msg, dict):
-                    continue
+                    msg = obj.get("message", {})
+                    if not isinstance(msg, dict):
+                        continue
 
-                role = msg.get("author", {}).get("role", "")
-                content = msg.get("content", {})
-                ct = content.get("content_type", "")
-                status = msg.get("status", "")
-                meta = msg.get("metadata", {})
+                    role = msg.get("author", {}).get("role", "")
+                    content = msg.get("content", {})
+                    ct = content.get("content_type", "")
+                    status = msg.get("status", "")
+                    meta = msg.get("metadata", {})
 
-                # Tool invocation events (search/browse)
-                if ct == "code" and role == "assistant":
-                    call_text = content.get("text", "")
-                    if call_text:
-                        yield {"type": "tool", "call": call_text}
-                    continue
+                    # Tool invocation events (search/browse)
+                    if ct == "code" and role == "assistant":
+                        call_text = content.get("text", "")
+                        if call_text:
+                            yield {"type": "tool", "call": call_text}
+                        continue
 
-                # Text streaming — assistant in-progress or finished
-                if role == "assistant" and ct == "text":
-                    parts = content.get("parts") or []
-                    new = parts[0] if parts and isinstance(parts[0], str) else ""
+                    # Text streaming — assistant in-progress or finished
+                    if role == "assistant" and ct == "text":
+                        parts = content.get("parts") or []
+                        new = parts[0] if parts and isinstance(parts[0], str) else ""
 
-                    if status == "finished_successfully":
-                        # Emit final done event with citations
-                        yield {
-                            "type": "done",
-                            "text": new,
-                            "content_references": meta.get("content_references", []),
-                            "search_result_groups": meta.get(
-                                "search_result_groups", []
-                            ),
-                        }
-                        last_text = new
-                    elif status == "in_progress" and new:
-                        # Emit incremental text delta
-                        if new.startswith(last_text):
-                            delta = new[len(last_text) :]
-                            if delta:
-                                yield {"type": "progress", "text": delta}
-                        else:
-                            yield {"type": "progress", "text": new}
-                        last_text = new
+                        if status == "finished_successfully":
+                            # Emit final done event with citations
+                            yield {
+                                "type": "done",
+                                "text": new,
+                                "content_references": meta.get("content_references", []),
+                                "search_result_groups": meta.get(
+                                    "search_result_groups", []
+                                ),
+                            }
+                            done_emitted = True
+                            last_text = new
+                        elif status == "in_progress" and new:
+                            # Emit incremental text delta
+                            if new.startswith(last_text):
+                                delta = new[len(last_text):]
+                                if delta:
+                                    yield {"type": "progress", "text": delta}
+                            else:
+                                yield {"type": "progress", "text": new}
+                            last_text = new
+            finally:
+                if last_text and not done_emitted:
+                    yield {
+                        "type": "done",
+                        "text": last_text,
+                        "content_references": [],
+                        "search_result_groups": [],
+                        "terminated_abnormally": True,
+                    }
 
     async def deep_research_heavy(self, query: str) -> AsyncIterator[dict]:
         """Stream true Pro-tier Deep Research events for *query*.
@@ -477,62 +489,74 @@ class ConversationClient:
                 )
 
             last_text = ""
-            async for raw_line in resp.aiter_lines():
-                if isinstance(raw_line, bytes):
-                    raw_line = raw_line.decode("utf-8", errors="replace")
-                line = raw_line.strip()
-                if not line or not line.startswith("data:"):
-                    continue
-                data = line[5:].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    obj = json.loads(data)
-                except json.JSONDecodeError:
-                    continue
+            done_emitted = False
+            try:
+                async for raw_line in resp.aiter_lines():
+                    if isinstance(raw_line, bytes):
+                        raw_line = raw_line.decode("utf-8", errors="replace")
+                    line = raw_line.strip()
+                    if not line or not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        obj = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
 
-                # Server-side telemetry / metadata event
-                if obj.get("type") == "server_ste_metadata":
-                    yield {"type": "meta", "data": obj.get("metadata", {})}
-                    continue
+                    # Server-side telemetry / metadata event
+                    if obj.get("type") == "server_ste_metadata":
+                        yield {"type": "meta", "data": obj.get("metadata", {})}
+                        continue
 
-                msg = obj.get("message", {})
-                if not isinstance(msg, dict):
-                    continue
+                    msg = obj.get("message", {})
+                    if not isinstance(msg, dict):
+                        continue
 
-                role = msg.get("author", {}).get("role", "")
-                content = msg.get("content", {})
-                ct = content.get("content_type", "")
-                status = msg.get("status", "")
-                meta = msg.get("metadata", {})
+                    role = msg.get("author", {}).get("role", "")
+                    content = msg.get("content", {})
+                    ct = content.get("content_type", "")
+                    status = msg.get("status", "")
+                    meta = msg.get("metadata", {})
 
-                # Tool / connector invocation events
-                if ct == "code" and role == "assistant":
-                    call_text = content.get("text", "")
-                    if call_text:
-                        yield {"type": "tool", "call": call_text}
-                    continue
+                    # Tool / connector invocation events
+                    if ct == "code" and role == "assistant":
+                        call_text = content.get("text", "")
+                        if call_text:
+                            yield {"type": "tool", "call": call_text}
+                        continue
 
-                # Text streaming — assistant in-progress or finished
-                if role == "assistant" and ct == "text":
-                    parts = content.get("parts") or []
-                    new = parts[0] if parts and isinstance(parts[0], str) else ""
+                    # Text streaming — assistant in-progress or finished
+                    if role == "assistant" and ct == "text":
+                        parts = content.get("parts") or []
+                        new = parts[0] if parts and isinstance(parts[0], str) else ""
 
-                    if status == "finished_successfully":
-                        yield {
-                            "type": "done",
-                            "text": new,
-                            "content_references": meta.get("content_references", []),
-                            "search_result_groups": meta.get(
-                                "search_result_groups", []
-                            ),
-                        }
-                        last_text = new
-                    elif status == "in_progress" and new:
-                        if new.startswith(last_text):
-                            delta = new[len(last_text) :]
-                            if delta:
-                                yield {"type": "progress", "text": delta}
-                        else:
-                            yield {"type": "progress", "text": new}
-                        last_text = new
+                        if status == "finished_successfully":
+                            yield {
+                                "type": "done",
+                                "text": new,
+                                "content_references": meta.get("content_references", []),
+                                "search_result_groups": meta.get(
+                                    "search_result_groups", []
+                                ),
+                            }
+                            done_emitted = True
+                            last_text = new
+                        elif status == "in_progress" and new:
+                            if new.startswith(last_text):
+                                delta = new[len(last_text):]
+                                if delta:
+                                    yield {"type": "progress", "text": delta}
+                            else:
+                                yield {"type": "progress", "text": new}
+                            last_text = new
+            finally:
+                if last_text and not done_emitted:
+                    yield {
+                        "type": "done",
+                        "text": last_text,
+                        "content_references": [],
+                        "search_result_groups": [],
+                        "terminated_abnormally": True,
+                    }

--- a/openai_mcp/sse.py
+++ b/openai_mcp/sse.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from typing import AsyncIterator
 from uuid import uuid4
 
@@ -43,8 +44,18 @@ def _safe_body(resp: object) -> str:
     return _redact_error(text) if text else ""
 
 
-#: Model slug for Deep Research (confirmed working, resolves to web-search-capable backend)
+# /backend-api/f/conversation — the frontend-facing endpoint used by the web app.
+# Required for Deep Research heavy path; regular /conversation also works for normal chat.
+_F_CONV_URL = _BASE + "/backend-api/f/conversation"
+
+#: Model slug for legacy Deep Research (resolves to i-mini-m / web-search backend)
 DR_MODEL = "research"
+
+#: Model slug for heavy Deep Research — gpt-5-5-pro with extended thinking + DR connector
+HEAVY_DR_MODEL = "gpt-5-5-pro"
+
+#: System hint for heavy Deep Research (connector identifier from chatgpt.com frontend)
+HEAVY_DR_HINT = "connector:connector_openai_deep_research"
 
 
 def _build_payload(model: str, messages: list[dict]) -> dict:
@@ -71,10 +82,75 @@ def _build_payload(model: str, messages: list[dict]) -> dict:
 
 
 def _build_dr_payload(query: str) -> dict:
-    """Build payload for Deep Research: model=research + system_hints=['research']."""
+    """Build payload for legacy Deep Research: model=research + system_hints=['research'].
+
+    This resolves to i-mini-m (web-search/SearchGPT backend), NOT the Pro-tier
+    multi-section deep research.  Use _build_heavy_dr_payload() for the full DR.
+    """
     payload = _build_payload(DR_MODEL, [{"role": "user", "content": query}])
     payload["system_hints"] = ["research"]
     return payload
+
+
+def _build_heavy_dr_payload(query: str) -> dict:
+    """Build payload for heavy Deep Research — the true Pro-tier 5–30 min DR path.
+
+    Ground-truth reverse-engineered from chatgpt.com/deep-research browser traffic
+    (2026-04-23).  Key differences from legacy DR:
+
+    * URL target: /backend-api/f/conversation  (frontend endpoint)
+    * model: gpt-5-5-pro
+    * system_hints: ["connector:connector_openai_deep_research"]
+    * thinking_effort: "extended"
+    * message.metadata contains deep_research_version / venus_model_variant / caterpillar fields
+
+    The server_ste_metadata from the SSE stream will show tool_name="ApiToolWrapper"
+    and tool_invoked=true, confirming the DR connector fired.  The resolved_model_slug
+    in the user-message echo is "i-mini-m" (the orchestration layer); the actual heavy
+    reasoning runs as a background tool call inside the connector.
+
+    Rate-limited by the "deep_research" feature quota (248 uses / reset cycle for Pro).
+    """
+    msg_id = str(uuid4())
+    return {
+        "action": "next",
+        "messages": [
+            {
+                "id": msg_id,
+                "author": {"role": "user"},
+                "create_time": time.time(),
+                "content": {"content_type": "text", "parts": [query]},
+                "metadata": {
+                    "caterpillar_selected_sources": [],
+                    "developer_mode_connector_ids": [],
+                    "selected_mcp_sources": [],
+                    "selected_sources": [],
+                    "selected_github_repos": [],
+                    "selected_all_github_repos": False,
+                    "system_hints": [HEAVY_DR_HINT],
+                    "deep_research_version": "standard",
+                    "venus_model_variant": "standard",
+                    "serialization_metadata": {"custom_symbol_offsets": []},
+                    "user_timezone": "UTC",
+                },
+            }
+        ],
+        "parent_message_id": str(uuid4()),
+        "model": HEAVY_DR_MODEL,
+        "client_prepare_state": "success",
+        "timezone_offset_min": -480,
+        "timezone": "UTC",
+        "conversation_mode": {"kind": "primary_assistant"},
+        "enable_message_followups": True,
+        "system_hints": [HEAVY_DR_HINT],
+        "thinking_effort": "extended",
+        "supports_buffering": True,
+        "supported_encodings": ["v1"],
+        "force_parallel_switch": "auto",
+        "paragen_cot_summary_display_override": "allow",
+        "history_and_training_disabled": True,
+        "force_use_sse": True,
+    }
 
 
 class ConversationClient:
@@ -325,6 +401,134 @@ class ConversationClient:
                         last_text = new
                     elif status == "in_progress" and new:
                         # Emit incremental text delta
+                        if new.startswith(last_text):
+                            delta = new[len(last_text) :]
+                            if delta:
+                                yield {"type": "progress", "text": delta}
+                        else:
+                            yield {"type": "progress", "text": new}
+                        last_text = new
+
+    async def deep_research_heavy(self, query: str) -> AsyncIterator[dict]:
+        """Stream true Pro-tier Deep Research events for *query*.
+
+        Uses the ground-truth payload reverse-engineered from chatgpt.com/deep-research
+        (2026-04-23).  Targets /backend-api/f/conversation with:
+
+            model = gpt-5-5-pro
+            system_hints = ["connector:connector_openai_deep_research"]
+            thinking_effort = "extended"
+            message.metadata.deep_research_version = "standard"
+            message.metadata.venus_model_variant = "standard"
+
+        Yields dicts of shape:
+          {"type": "progress", "text": <partial>}   — streaming text deltas
+          {"type": "tool",     "call": <call_text>} — tool/connector invocations
+          {"type": "meta",     "data": <ste_meta>}  — server_ste_metadata events
+          {"type": "done",     "text": <full_text>,
+           "content_references": [...], "search_result_groups": [...]}
+
+        Rate: consumes from the "deep_research" quota (248 uses / reset cycle on Pro).
+        Timeout: 1800 s (DR runs can take 5–30 minutes for complex queries).
+
+        Note: the resolved_model_slug in user-message echo will show "i-mini-m"
+        (the orchestration layer).  The actual heavy reasoning runs inside the
+        connector_openai_deep_research tool call.
+        """
+        headers = dict(self._backend._session.headers)
+        headers["Accept"] = "text/event-stream"
+        headers["Content-Type"] = "application/json"
+
+        sentinel = await SentinelGate(self._backend).get_tokens()
+        headers["Openai-Sentinel-Chat-Requirements-Token"] = sentinel[
+            "chat-requirements"
+        ]
+        if sentinel.get("proof"):
+            headers["Openai-Sentinel-Proof-Token"] = sentinel["proof"]
+        if sentinel.get("turnstile"):
+            headers["Openai-Sentinel-Turnstile-Token"] = sentinel["turnstile"]
+
+        payload = _build_heavy_dr_payload(query)
+
+        async with AsyncSession(impersonate="chrome131", verify=True) as s:
+            resp = await s.post(
+                _F_CONV_URL,
+                headers=headers,
+                json=payload,
+                timeout=1800,
+                stream=True,
+            )
+            if resp.status_code == 401:
+                raise RuntimeError("401 Unauthorized — run `codex login`")
+            if resp.status_code == 403:
+                raise RuntimeError("403 Forbidden — token may have expired")
+            if resp.status_code not in (200, 201):
+                body = ""
+                async for chunk in resp.aiter_content():
+                    body += (
+                        chunk.decode("utf-8", errors="replace")
+                        if isinstance(chunk, bytes)
+                        else chunk
+                    )
+                    if len(body) > 500:
+                        break
+                raise RuntimeError(
+                    f"HTTP {resp.status_code} from {_F_CONV_URL}: {body[:500]}"
+                )
+
+            last_text = ""
+            async for raw_line in resp.aiter_lines():
+                if isinstance(raw_line, bytes):
+                    raw_line = raw_line.decode("utf-8", errors="replace")
+                line = raw_line.strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+                # Server-side telemetry / metadata event
+                if obj.get("type") == "server_ste_metadata":
+                    yield {"type": "meta", "data": obj.get("metadata", {})}
+                    continue
+
+                msg = obj.get("message", {})
+                if not isinstance(msg, dict):
+                    continue
+
+                role = msg.get("author", {}).get("role", "")
+                content = msg.get("content", {})
+                ct = content.get("content_type", "")
+                status = msg.get("status", "")
+                meta = msg.get("metadata", {})
+
+                # Tool / connector invocation events
+                if ct == "code" and role == "assistant":
+                    call_text = content.get("text", "")
+                    if call_text:
+                        yield {"type": "tool", "call": call_text}
+                    continue
+
+                # Text streaming — assistant in-progress or finished
+                if role == "assistant" and ct == "text":
+                    parts = content.get("parts") or []
+                    new = parts[0] if parts and isinstance(parts[0], str) else ""
+
+                    if status == "finished_successfully":
+                        yield {
+                            "type": "done",
+                            "text": new,
+                            "content_references": meta.get("content_references", []),
+                            "search_result_groups": meta.get(
+                                "search_result_groups", []
+                            ),
+                        }
+                        last_text = new
+                    elif status == "in_progress" and new:
                         if new.startswith(last_text):
                             delta = new[len(last_text) :]
                             if delta:

--- a/openai_mcp/sse.py
+++ b/openai_mcp/sse.py
@@ -43,6 +43,10 @@ def _safe_body(resp: object) -> str:
     return _redact_error(text) if text else ""
 
 
+#: Model slug for Deep Research (confirmed working, resolves to web-search-capable backend)
+DR_MODEL = "research"
+
+
 def _build_payload(model: str, messages: list[dict]) -> dict:
     return {
         "action": "next",
@@ -59,9 +63,18 @@ def _build_payload(model: str, messages: list[dict]) -> dict:
         "conversation_mode": {"kind": "primary_assistant"},
         "force_paragen": False,
         "force_rate_limit": False,
+        "force_use_sse": True,
         "timezone_offset_min": -480,
         "history_and_training_disabled": True,
+        "system_hints": [],
     }
+
+
+def _build_dr_payload(query: str) -> dict:
+    """Build payload for Deep Research: model=research + system_hints=['research']."""
+    payload = _build_payload(DR_MODEL, [{"role": "user", "content": query}])
+    payload["system_hints"] = ["research"]
+    return payload
 
 
 class ConversationClient:
@@ -207,3 +220,115 @@ class ConversationClient:
         async for chunk in self.stream(model, messages):
             chunks.append(chunk)
         return "".join(chunks)
+
+    async def deep_research(self, query: str) -> AsyncIterator[dict]:
+        """Stream Deep Research events for *query*.
+
+        Yields dicts of shape:
+          {"type": "progress", "text": <partial_text>}   — intermediate text deltas
+          {"type": "tool",     "call": <search_call>}    — tool invocations (search/browse)
+          {"type": "done",     "text": <full_text>,
+           "content_references": [...], "search_result_groups": [...]}
+
+        Uses model='research' + system_hints=['research'] which triggers the
+        ChatGPT web-search deep-research backend (confirmed working 2026-04-24).
+        Timeout is 1800 s to accommodate multi-minute research runs.
+        """
+        headers = dict(self._backend._session.headers)
+        headers["Accept"] = "text/event-stream"
+        headers["Content-Type"] = "application/json"
+
+        sentinel = await SentinelGate(self._backend).get_tokens()
+        headers["Openai-Sentinel-Chat-Requirements-Token"] = sentinel[
+            "chat-requirements"
+        ]
+        if sentinel.get("proof"):
+            headers["Openai-Sentinel-Proof-Token"] = sentinel["proof"]
+        if sentinel.get("turnstile"):
+            headers["Openai-Sentinel-Turnstile-Token"] = sentinel["turnstile"]
+
+        payload = _build_dr_payload(query)
+
+        async with AsyncSession(impersonate="chrome131", verify=True) as s:
+            resp = await s.post(
+                _CONV_URL,
+                headers=headers,
+                json=payload,
+                timeout=1800,
+                stream=True,
+            )
+            if resp.status_code == 401:
+                raise RuntimeError("401 Unauthorized — run `codex login`")
+            if resp.status_code == 403:
+                raise RuntimeError("403 Forbidden — token may have expired")
+            if resp.status_code not in (200, 201):
+                body = ""
+                async for chunk in resp.aiter_content():
+                    body += (
+                        chunk.decode("utf-8", errors="replace")
+                        if isinstance(chunk, bytes)
+                        else chunk
+                    )
+                    if len(body) > 500:
+                        break
+                raise RuntimeError(
+                    f"HTTP {resp.status_code} from /backend-api/conversation: {body[:500]}"
+                )
+
+            last_text = ""
+            async for raw_line in resp.aiter_lines():
+                if isinstance(raw_line, bytes):
+                    raw_line = raw_line.decode("utf-8", errors="replace")
+                line = raw_line.strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+                msg = obj.get("message", {})
+                if not isinstance(msg, dict):
+                    continue
+
+                role = msg.get("author", {}).get("role", "")
+                content = msg.get("content", {})
+                ct = content.get("content_type", "")
+                status = msg.get("status", "")
+                meta = msg.get("metadata", {})
+
+                # Tool invocation events (search/browse)
+                if ct == "code" and role == "assistant":
+                    call_text = content.get("text", "")
+                    if call_text:
+                        yield {"type": "tool", "call": call_text}
+                    continue
+
+                # Text streaming — assistant in-progress or finished
+                if role == "assistant" and ct == "text":
+                    parts = content.get("parts") or []
+                    new = parts[0] if parts and isinstance(parts[0], str) else ""
+
+                    if status == "finished_successfully":
+                        # Emit final done event with citations
+                        yield {
+                            "type": "done",
+                            "text": new,
+                            "content_references": meta.get("content_references", []),
+                            "search_result_groups": meta.get(
+                                "search_result_groups", []
+                            ),
+                        }
+                        last_text = new
+                    elif status == "in_progress" and new:
+                        # Emit incremental text delta
+                        if new.startswith(last_text):
+                            delta = new[len(last_text) :]
+                            if delta:
+                                yield {"type": "progress", "text": delta}
+                        else:
+                            yield {"type": "progress", "text": new}
+                        last_text = new

--- a/openai_mcp/sse.py
+++ b/openai_mcp/sse.py
@@ -447,6 +447,26 @@ class ConversationClient:
         (the orchestration layer).  The actual heavy reasoning runs inside the
         connector_openai_deep_research tool call.
         """
+        # --- B1: Quota guard ---
+        # Probe /backend-api/conversation/init once to check deep_research quota.
+        # Field path from live response: features.deep_research.remaining
+        _INIT_PATH = "/backend-api/conversation/init"
+        try:
+            init_data = self._backend.get(_INIT_PATH)
+            features = init_data.get("features") if isinstance(init_data, dict) else None
+            dr_feature = (features or {}).get("deep_research") if features else None
+            remaining = (dr_feature or {}).get("remaining") if dr_feature else None
+            if remaining is not None and int(remaining) <= 0:
+                raise RuntimeError(
+                    f"Deep Research quota exhausted. "
+                    f"Check {_BASE}{_INIT_PATH} to verify quota reset."
+                )
+        except RuntimeError:
+            raise
+        except Exception as _exc:
+            _log.warning("quota check failed (%s) — proceeding anyway", _exc)
+        # --- end quota guard ---
+
         headers = dict(self._backend._session.headers)
         headers["Accept"] = "text/event-stream"
         headers["Content-Type"] = "application/json"

--- a/tests/test_deep_research.py
+++ b/tests/test_deep_research.py
@@ -1,0 +1,109 @@
+"""Integration tests for Deep Research via native SSE.
+
+Live tests are skipped by default (SKIP_LIVE=1 env var) because a real DR
+run takes 30-120 seconds.  Set SKIP_LIVE=0 (or unset it) to run live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+
+_AUTH_EXISTS = (Path.home() / ".codex" / "auth.json").exists()
+_SKIP_LIVE = os.environ.get("SKIP_LIVE", "1") == "1"
+
+
+@pytest.mark.skipif(not _AUTH_EXISTS, reason="requires ~/.codex/auth.json")
+@pytest.mark.skipif(_SKIP_LIVE, reason="SKIP_LIVE=1 — set SKIP_LIVE=0 to run live")
+def test_deep_research_yields_done_event():
+    """DR stream must emit at least one 'done' event with non-empty text."""
+    from openai_mcp.backend import BackendClient
+    from openai_mcp.sse import ConversationClient
+
+    conv = ConversationClient(BackendClient())
+    events: list[dict] = []
+
+    async def collect():
+        async for event in conv.deep_research("What is the capital of France? (brief)"):
+            events.append(event)
+
+    asyncio.run(collect())
+
+    event_types = {e["type"] for e in events}
+    assert "done" in event_types, f"no 'done' event; got types: {event_types}"
+
+    done_events = [e for e in events if e["type"] == "done"]
+    assert done_events[-1]["text"], "final 'done' event has empty text"
+
+
+@pytest.mark.skipif(not _AUTH_EXISTS, reason="requires ~/.codex/auth.json")
+@pytest.mark.skipif(_SKIP_LIVE, reason="SKIP_LIVE=1 — set SKIP_LIVE=0 to run live")
+def test_deep_research_emits_tool_events():
+    """DR stream should emit at least one 'tool' event (search call)."""
+    from openai_mcp.backend import BackendClient
+    from openai_mcp.sse import ConversationClient
+
+    conv = ConversationClient(BackendClient())
+    events: list[dict] = []
+
+    async def collect():
+        async for event in conv.deep_research(
+            "Search the web: what are the latest AI model releases in 2025?"
+        ):
+            events.append(event)
+
+    asyncio.run(collect())
+
+    tool_events = [e for e in events if e["type"] == "tool"]
+    assert tool_events, (
+        f"no 'tool' events; all event types: {[e['type'] for e in events]}"
+    )
+    assert "search" in tool_events[0]["call"].lower(), (
+        f"first tool call doesn't look like a search: {tool_events[0]['call']!r}"
+    )
+
+
+@pytest.mark.skipif(not _AUTH_EXISTS, reason="requires ~/.codex/auth.json")
+@pytest.mark.skipif(_SKIP_LIVE, reason="SKIP_LIVE=1 — set SKIP_LIVE=0 to run live")
+def test_deep_research_has_content_references():
+    """Completed DR response should include web source references."""
+    from openai_mcp.backend import BackendClient
+    from openai_mcp.sse import ConversationClient
+
+    conv = ConversationClient(BackendClient())
+    events: list[dict] = []
+
+    async def collect():
+        async for event in conv.deep_research(
+            "What is the most recent version of Python? Search the web."
+        ):
+            events.append(event)
+
+    asyncio.run(collect())
+
+    done_events = [e for e in events if e["type"] == "done"]
+    assert done_events, "no 'done' event"
+    refs = done_events[-1].get("content_references", [])
+    groups = done_events[-1].get("search_result_groups", [])
+    assert refs or groups, (
+        "no content_references or search_result_groups in done event — "
+        "web search may not have fired"
+    )
+
+
+def test_build_dr_payload_shape():
+    """Unit test: _build_dr_payload produces correct model + system_hints."""
+    from openai_mcp.sse import _build_dr_payload, DR_MODEL
+
+    payload = _build_dr_payload("test query")
+    assert payload["model"] == DR_MODEL == "research"
+    assert payload["system_hints"] == ["research"]
+    assert payload["conversation_mode"] == {"kind": "primary_assistant"}
+    assert payload["force_use_sse"] is True
+    assert payload["history_and_training_disabled"] is True
+    assert len(payload["messages"]) == 1
+    assert payload["messages"][0]["content"]["parts"][0] == "test query"

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -15,11 +15,13 @@ import pytest
 _SKIP_LIVE = os.environ.get("SKIP_LIVE", "1") == "1"
 _SKIP_HEAVY_DR = os.environ.get("SKIP_HEAVY_DR", "1") == "1"
 
-
-@pytest.mark.skipif(
+_NEEDS_AUTH = pytest.mark.skipif(
     not (Path.home() / ".codex" / "auth.json").exists(),
     reason="requires ~/.codex/auth.json",
 )
+
+
+@_NEEDS_AUTH
 @pytest.mark.skipif(_SKIP_LIVE, reason="SKIP_LIVE=1 (default); set SKIP_LIVE=0 to run")
 def test_sse_pong():
     from openai_mcp.backend import BackendClient
@@ -35,10 +37,7 @@ def test_sse_pong():
     assert "pong" in out.lower(), f"no PONG in response: {out!r}"
 
 
-@pytest.mark.skipif(
-    not (Path.home() / ".codex" / "auth.json").exists(),
-    reason="requires ~/.codex/auth.json",
-)
+@_NEEDS_AUTH
 @pytest.mark.skipif(
     _SKIP_LIVE or _SKIP_HEAVY_DR,
     reason="heavy DR skipped by default; set SKIP_LIVE=0 SKIP_HEAVY_DR=0 to run",
@@ -56,3 +55,73 @@ def test_sse_deep_research_heavy():
         )
     )
     assert out and out.strip(), "empty DR response"
+
+
+def test_heavy_dr_payload_structure():
+    """Verify _build_heavy_dr_payload produces the correct ground-truth payload shape.
+
+    Pure unit test — no network call.
+    """
+    from openai_mcp.sse import (
+        HEAVY_DR_HINT,
+        HEAVY_DR_MODEL,
+        _F_CONV_URL,
+        _build_heavy_dr_payload,
+    )
+
+    payload = _build_heavy_dr_payload("What is the tallest mountain?")
+
+    assert payload["model"] == HEAVY_DR_MODEL
+    assert payload["thinking_effort"] == "extended"
+    assert payload["system_hints"] == [HEAVY_DR_HINT]
+    assert payload["conversation_mode"] == {"kind": "primary_assistant"}
+    assert payload["supported_encodings"] == ["v1"]
+    assert payload["supports_buffering"] is True
+
+    assert len(payload["messages"]) == 1
+    msg = payload["messages"][0]
+    assert msg["author"] == {"role": "user"}
+    assert msg["content"]["parts"] == ["What is the tallest mountain?"]
+
+    meta = msg["metadata"]
+    assert meta["system_hints"] == [HEAVY_DR_HINT]
+    assert meta["deep_research_version"] == "standard"
+    assert meta["venus_model_variant"] == "standard"
+    assert meta["caterpillar_selected_sources"] == []
+
+    assert _F_CONV_URL.endswith("/backend-api/f/conversation")
+
+
+@_NEEDS_AUTH
+@pytest.mark.skipif(
+    _SKIP_LIVE or _SKIP_HEAVY_DR,
+    reason="heavy DR skipped by default; set SKIP_LIVE=0 SKIP_HEAVY_DR=0 to run",
+)
+def test_heavy_dr_live_metadata():
+    """Fire one heavy DR request and verify the connector is invoked.
+
+    Checks server_ste_metadata event with tool_name=ApiToolWrapper and
+    tool_invoked=True, confirming connector_openai_deep_research fired.
+    """
+    from openai_mcp.backend import BackendClient
+    from openai_mcp.sse import ConversationClient
+
+    async def run():
+        conv = ConversationClient(BackendClient())
+        meta_events = []
+        async for event in conv.deep_research_heavy("What is 2+2?"):
+            if event["type"] == "meta":
+                meta_events.append(event["data"])
+            if event["type"] == "done":
+                break
+        return meta_events
+
+    metas = asyncio.run(run())
+    assert metas, "no server_ste_metadata events received"
+    first_meta = metas[0]
+    assert first_meta.get("tool_invoked") is True, (
+        f"tool_invoked not True in metadata: {first_meta}"
+    )
+    assert first_meta.get("tool_name") == "ApiToolWrapper", (
+        f"unexpected tool_name: {first_meta.get('tool_name')}"
+    )

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -64,16 +64,16 @@ def test_heavy_dr_payload_structure():
     """
     from openai_mcp.sse import (
         HEAVY_DR_HINT,
-        HEAVY_DR_MODEL,
         _F_CONV_URL,
         _build_heavy_dr_payload,
     )
 
     payload = _build_heavy_dr_payload("What is the tallest mountain?")
 
-    assert payload["model"] == HEAVY_DR_MODEL
+    # Core fields
+    assert payload["model"] == "gpt-5-5-pro", f"model mismatch: {payload['model']}"
+    assert payload["system_hints"] == ["connector:connector_openai_deep_research"]
     assert payload["thinking_effort"] == "extended"
-    assert payload["system_hints"] == [HEAVY_DR_HINT]
     assert payload["conversation_mode"] == {"kind": "primary_assistant"}
     assert payload["supported_encodings"] == ["v1"]
     assert payload["supports_buffering"] is True
@@ -89,6 +89,7 @@ def test_heavy_dr_payload_structure():
     assert meta["venus_model_variant"] == "standard"
     assert meta["caterpillar_selected_sources"] == []
 
+    # Endpoint constant must point to /f/conversation
     assert _F_CONV_URL.endswith("/backend-api/f/conversation")
 
 


### PR DESCRIPTION
## Summary

Implements the true Pro-tier Deep Research (DR) heavy path for chatgpt.com.

### Ground-truth payload (reverse-engineered from chatgpt.com/deep-research 2026-04-23)

| Field | Value |
|-------|-------|
| URL | `/backend-api/f/conversation` (frontend endpoint, not `/backend-api/conversation`) |
| model | `gpt-5-5-pro` |
| thinking_effort | `extended` |
| system_hints | `["connector:connector_openai_deep_research"]` |
| conversation_mode | `{"kind": "primary_assistant"}` |
| message.metadata | `deep_research_version="standard"`, `venus_model_variant="standard"`, `caterpillar_selected_sources=[]` |

### Key findings from spike

**Feature flags confirmed** (from `/backend-api/accounts/check`):
- `caterpillar` — UI button name for the DR composer trigger
- `gpt5_pro`, `o3_pro`, `o3` — all enabled on Pro account
- **deep_research quota**: 248 uses remaining / reset cycle
- **odyssey quota**: 397 uses remaining / reset cycle (internal name for DR)

**Hypothesis matrix results** (original 10 hypotheses):
| # | model + hints | status | resolved_model_slug |
|---|---|---|---|
| H1 | research + caterpillar | 200 | i-mini-m |
| H2 | research + deep_research | 200 | i-mini-m |
| H3 | research + research_pro | 200 | i-mini-m |
| H4 | gpt-5-5-pro + research | 200 | i-mini-m |
| H5 | o3-pro + research | 200 | i-mini-m |
| H6 | deep_research (model) | 200 | i-mini-m |
| H7 | research + kind=research | ERR 422 | — |
| H8 | research + action=research | ERR 422 | — |
| H9 | research + force_paragen | ERR 500 | — |
| H10 | gpt-5-5-thinking + research | 200 | i-mini-m |

**Key insight**: `resolved_model_slug = "i-mini-m"` is the *orchestration layer* slug, not the execution model. The actual heavy DR runs inside `ApiToolWrapper` (connector tool call). Only valid `conversation_mode.kind` value is `"primary_assistant"`.

**Winner payload** (from chatgpt.com/deep-research browser capture):
- URL: `/backend-api/f/conversation`
- model: `gpt-5-5-pro`, thinking_effort: `extended`
- system_hints: `["connector:connector_openai_deep_research"]`
- Confirmed by: `server_ste_metadata` showing `tool_name=ApiToolWrapper`, `tool_invoked=true`

### What changed

- `openai_mcp/sse.py`: Added `_F_CONV_URL`, `HEAVY_DR_MODEL`, `HEAVY_DR_HINT`, `_build_heavy_dr_payload()`, and `ConversationClient.deep_research_heavy()` method
- `tests/test_sse.py`: Added `test_heavy_dr_payload_structure` (unit, no network) and `test_heavy_dr_live_metadata` (live, gated by `SKIP_HEAVY_DR=1`)

## Test plan

- [x] `SKIP_HEAVY_DR=1 pytest tests/test_sse.py::test_heavy_dr_payload_structure` — passes (unit, no live calls)
- [ ] `pytest tests/test_sse.py::test_heavy_dr_live_metadata` — requires Pro account + consumes 1 DR quota unit
- [ ] Verify `server_ste_metadata` event shows `tool_invoked=true` and `tool_name=ApiToolWrapper`
- [ ] For a real 5-30 min run: use a substantive research query (e.g. "Write a comprehensive report on...") and check for multi-section markdown with citations in the `done` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Direct native integration with ChatGPT.com via server-sent events (SSE) streaming
  * Added tools for account status, memory management, custom instructions, GPTs, conversations, and Codex task tracking
  * Introduced Deep Research capability with source citations and references

* **Changes**
  * Removed dependency on external gateway; now connects directly to ChatGPT backend
  * Simplified authentication to prioritize Codex CLI tokens
  * Image generation support removed
  * Updated default chat model selection based on account entitlements

* **Documentation**
  * Added third-party attribution documentation
  * Updated architecture overview

<!-- end of auto-generated comment: release notes by coderabbit.ai -->