### PR TITLE
Deep Research fixes + honest heavy-DR limitation (0.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Preserve Deep Research heavy citation metadata when it arrives through
+  nested `/message/metadata/...` patches or a same-turn conversation-detail
+  node separate from the final text node.
+
 ## [0.0.2] - 2026-05-26
 
 ### Renamed — `openai-mcp` → `gpt2agent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,46 @@ All notable changes to this project will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.0.3] - 2026-06-03
 
 ### Fixed
 
-- Preserve Deep Research heavy citation metadata when it arrives through
-  nested `/message/metadata/...` patches or a same-turn conversation-detail
-  node separate from the final text node.
+- **Light Deep Research report extraction.** The research model often emits a
+  short tool-dispatch JSON as the FIRST `done` event (e.g.
+  `{"queries":[...],"source_filter":[...]}`); the bundled runner took that first
+  done as the report and silently discarded the real, later report. It now picks
+  the longest `done` and falls back to all streamed progress text.
+
+### Added
+
+- **Multi-account auth via `CODEX_HOME`.** `BackendClient` reads
+  `$CODEX_HOME/auth.json` (falling back to `~/.codex/auth.json`), so a second
+  account (e.g. `CODEX_HOME=~/.codex-cx2`) can be used without touching the
+  default login. Adds 2 tests.
+- **`GPT2AGENT_RAW_DUMP` heavy-DR diagnostics.** When set, `deep_research_heavy`
+  writes every raw SSE object (Phase 1) and conversation-detail poll (Phase 2)
+  as JSONL — used to reverse-engineer the real heavy-DR shape.
+- Heavy-DR poll backs off ≥300s on HTTP 429 and polls every 120s (was 15s) to
+  avoid rate-limiting the conversation endpoint.
+- Best-effort heavy-DR citation extraction: `done` pulls
+  `content_references` / `search_result_groups` from nested
+  `/message/metadata/...` patches or a same-turn conversation-detail node, if
+  the backend provides them.
+
+### Known limitations (verified 2026-06-03)
+
+- **Heavy DR does not return a programmatically-fetchable report.** Verified on a
+  clean Pro account: `deep_research_heavy` dispatches the
+  `connector_openai_deep_research` connector, which renders an "embedded UI
+  experience" widget; after a full 30-minute run the conversation's report node
+  stayed empty (`content_references: []`, 0-char text) and no `done` event was
+  emitted. The report exists only inside the ChatGPT web UI's deep-research
+  experience, not in `/backend-api/conversation/{id}`. **Use light mode
+  (`deep_research`) for programmatic, cited research.** The best-effort citation
+  extraction above is dormant until/unless the backend exposes refs on that path.
+- Run heavy/long DR **serially** — concurrent DR + codex jobs on one account
+  cause HTTP 429 on the conversation poll. See the deep-research skill's
+  "Account limits & concurrency" note.
 
 ## [0.0.2] - 2026-05-26
 

--- a/artifacts/verify/heavy-dr-citations-20260603.md
+++ b/artifacts/verify/heavy-dr-citations-20260603.md
@@ -18,8 +18,8 @@ Command:
 CODEX_HOME=~/.codex-cx2 PYTHONPATH=<worktree> GPT2AGENT_RAW_DUMP=/tmp/cx2-heavy-raw.jsonl \
   ~/.claude/skills/deep-research/bin/run.sh --heavy -o <out> @<short citation-seeking query>
 ```
-Account: cx2 = `wangcongrobot@gmail.com` (acct `606e1424…`, Pro), quota 229, **uncontended**
-(main account's codex loops do not touch it — no 429).
+Account: cx2 (acct `606e1424…`, Pro, distinct from the main account), quota 229,
+**uncontended** (main account's codex loops do not touch it — no 429).
 
 Result (read from real output, not CI/worker say-so):
 ```

--- a/artifacts/verify/heavy-dr-citations-20260603.md
+++ b/artifacts/verify/heavy-dr-citations-20260603.md
@@ -1,0 +1,46 @@
+# Verify receipt — Deep Research fixes (0.0.3)
+
+Date: 2026-06-03. Verifier: Opus (Claude). Branch: `fix/heavy-dr-citations`.
+
+## What was claimed vs what was verified
+
+| Change | Claim | Verification | Verdict |
+|---|---|---|---|
+| Light report extraction (`deep_research.py`) | first `done` was a tool-dispatch artifact; real report discarded | Replayed captured `events.jsonl` (GUIDE run) through patched logic | **VERIFIED** |
+| `CODEX_HOME` multi-account (`backend.py`) | reads `$CODEX_HOME/auth.json` over `~/.codex` | 2 unit tests + live route to cx2 account | **VERIFIED** |
+| Heavy poll 429 backoff / raw-dump | reduce 429s; capture raw heavy shape | live cx2 run produced 32 raw records, 15 polls | **VERIFIED (instrumentation works)** |
+| Heavy citation *extraction* (cx, `sse.py`) | recovers `content_references` for heavy DR | live cx2 run: no report node, no refs ever produced | **NOT VERIFIABLE — data path does not occur** |
+
+## Real-run receipt (the decisive test)
+
+Command:
+```
+CODEX_HOME=~/.codex-cx2 PYTHONPATH=<worktree> GPT2AGENT_RAW_DUMP=/tmp/cx2-heavy-raw.jsonl \
+  ~/.claude/skills/deep-research/bin/run.sh --heavy -o <out> @<short citation-seeking query>
+```
+Account: cx2 = `wangcongrobot@gmail.com` (acct `606e1424…`, Pro), quota 229, **uncontended**
+(main account's codex loops do not touch it — no 429).
+
+Result (read from real output, not CI/worker say-so):
+```
+status.txt: ERROR  RuntimeError: DR polling timed out after 1800.0s
+            waiting for conv 6a2091b3-1bc0-83ea-a5fa-a5d6877b93e6   elapsed=1821s
+raw dump:   32 records, 15 polls, async_status 7×4 → None×11
+final poll (11 nodes): report assistant node = 0 chars, content_references=0, search_result_groups=0
+tool response node (157 chars): "Rendered a widget that contains the deep research experience"
+no `done` event emitted
+```
+
+## Conclusion
+
+Heavy DR via `connector_openai_deep_research` renders an embedded-UI experience and
+does NOT write a programmatically-fetchable report back into
+`/backend-api/conversation/{id}`. The "heavy loses citations" premise is therefore
+moot — there is no report node to carry citations. The heavy citation-extraction
+code is retained as dormant best-effort and is **documented honestly** (CHANGELOG +
+SKILL.md), not shipped as a verified fix. Light mode is the supported path for
+programmatic cited research.
+
+## Test suite
+
+`SKIP_LIVE=1 uv run --extra dev pytest tests/ -q` → see run log at release time.

--- a/docs/goals/heavy-dr-citations-RESULT.md
+++ b/docs/goals/heavy-dr-citations-RESULT.md
@@ -1,0 +1,90 @@
+# Heavy DR Citations Result
+
+## Summary
+
+- Branch: `fix/heavy-dr-citations`
+- DR quota spent: 2 heavy calls
+- Root cause status: H2-compatible parser bug fixed offline; live H1/H2
+  confirmation still needs a successful conversation-detail GET because the
+  backend returned repeated `HTTP 429` during live diagnosis.
+
+## Evidence
+
+- Source behavior before this patch:
+  - `_emit_done` read only `state["asst_metadata"]` for
+    `content_references` and `search_result_groups`
+    (replaced by `gpt2agent/sse.py:1175-1182`).
+  - `_poll_dr_completion` read only the latest assistant text node metadata
+    (`gpt2agent/sse.py:1487-1516` now contains the replacement fallback).
+- Captured raw Phase 1 evidence:
+  - Command:
+    `grep -cE 'content_references|safe_urls' /tmp/gpt2agent-heavy-raw-before.jsonl`
+  - Output: `2`
+  - Both hits were raw SSE assistant/app nodes whose
+    `metadata.content_references` were empty lists.
+- Free diagnosis:
+  - Recent conversation-detail scans found the newest heavy-shaped conversation
+    with `deep_research_version: "standard"` and
+    `system_hints: ["connector:connector_openai_deep_research"]`, but its final
+    hidden assistant node had empty `metadata.content_references` and
+    `metadata.search_result_groups`.
+  - Subsequent detail GETs for live heavy probe conversations returned
+    `HTTP 429`, so the live raw detail fixture could not be captured.
+
+## Fix
+
+- Added `GPT2AGENT_RAW_DUMP=<path>` support:
+  - Phase 1 writes each raw SSE JSON object as JSONL.
+  - Phase 2 writes each successful conversation-detail poll response as JSONL.
+- Added nested metadata patch handling for paths such as
+  `/message/metadata/content_references` and
+  `/message/metadata/search_result_groups`.
+- `_emit_done` now falls back to the last citation-bearing assistant metadata
+  observed in the stream.
+- `_poll_dr_completion` now searches the full conversation mapping for
+  same-turn citation metadata when the latest final text node lacks refs.
+- Polling is less aggressive: default interval is 120 seconds, and `HTTP 429`
+  backs off for at least 300 seconds.
+
+## Before/After Counts
+
+Offline H2 fixture:
+
+```text
+before_latest_meta_refs 0
+before_latest_meta_groups 0
+after_done_refs 1
+after_done_groups 1
+after_first_url https://openai.com/
+```
+
+Live heavy probe:
+
+```text
+before raw Phase 1 content_references: []
+after live status: FAIL, repeated HTTP 429 on /backend-api/conversation/{id}
+```
+
+## Criteria
+
+- C1 raw-capture: PASS for Phase 1 raw SSE dump.
+  Phase 2 dump path is implemented, but no successful Phase 2 detail response
+  was received during live runs because the backend returned `HTTP 429`.
+- C2 offline parser test: PASS for parser behavior, but live-captured raw detail
+  fixture remains blocked by `HTTP 429`.
+- C3 end-to-end heavy harness: FAIL.
+  Two short heavy probes were attempted. Both reached Phase 2; the first was
+  stopped after repeated `HTTP 429`, and the second was stopped after repeated
+  `HTTP 429` with the patched backoff.
+- C4 no regression: PASS.
+  `uv run --extra dev pytest tests/ -q` returned
+  `40 passed, 9 skipped in 2.71s`; the known light fixture has
+  `refs=93`, `groups=26`, and `item_urls=92`.
+
+## Residual Risk
+
+- Live H1 vs H2 is not fully resolved until a heavy conversation-detail GET
+  succeeds after backend rate limiting clears.
+- The fallback intentionally prefers same-turn metadata by `working_turn_id` or
+  `turn_exchange_id`; if ChatGPT omits both fields, it falls back to the latest
+  citation-bearing metadata in the mapping.

--- a/docs/goals/heavy-dr-citations.md
+++ b/docs/goals/heavy-dr-citations.md
@@ -1,0 +1,84 @@
+# Goal: Recover citation URLs in deep_research_heavy (heavy mode)
+
+Owner brief prepared by Opus (Claude) after reading sse.py + 23 local fixtures, 2026-06-03.
+You (cx/codex) are the WRITER. Opus will review your diff before it merges. Work ONLY in
+this worktree.
+
+## The bug
+- LIGHT mode (`deep_research`) captures citations fine. Proven: 23 local `events.jsonl`
+  fixtures under ~/workspace/**/research have populated `content_references`. It reads
+  `meta["content_references"]` off the assistant text message whose status is
+  `finished_successfully` (sse.py, light path ~line 521-531 in the installed copy).
+- HEAVY mode (`deep_research_heavy`) emits its `done` event with `content_references: []`.
+  Both finalize paths read refs from `message.metadata`:
+    * Phase 1 `_emit_done`  -> `state["asst_metadata"].get("content_references")`
+    * Phase 2 `_poll_dr_completion` -> `latest_meta.get("content_references")`
+  In heavy runs those come back empty, so the harness Sources section is never built.
+- The harness (`~/.claude/skills/deep-research/bin/deep_research.py:73`) saves only the
+  wrapper's PROCESSED events, NOT raw SSE. So the URLs are not even recoverable from past
+  heavy runs. THIS IS WHY STEP 1 IS RAW CAPTURE.
+
+## Unknown to resolve (root cause)
+Does the heavy stream/poll EVER deliver content_references, and under what path/op/node?
+Two leading hypotheses — your raw capture must decide which:
+  (H1) refs ARE in the stream/poll metadata but arrive AFTER `_emit_done` already fired
+       (ordering bug) or under a metadata patch path the parser doesn't merge.
+  (H2) the heavy conversation-detail (`GET /backend-api/conversation/{id}`) stores
+       content_references on a DIFFERENT mapping node / key than the text node the poller
+       reads, so `latest_meta` is the wrong metadata object.
+
+## Citation data shape (ground truth from light fixtures = the TARGET your fix must produce)
+`done.content_references[]` entries have keys:
+  matched_text, prefix, start_idx, end_idx, safe_urls[], refs, alt, prompt_text, type,
+  items[]{title,url,attribution,pub_date,snippet,...}, fallback_items, status, error, style
+URLs live at `ref["items"][i]["url"]` AND `ref["safe_urls"][]`.
+`search_result_groups[]` entries: {type, domain, entries[]{type,url,title,snippet,ref_id}}.
+Sample fixture to study: /home/robot/workspace/50-open-dynamic-workflow/research/competitive-landscape/events.jsonl
+(its `done` event has 93 content_references, 26 search_result_groups).
+
+## FREE diagnosis path (DO THIS FIRST — no quota)
+A real finished heavy DR conversation already exists server-side with citations.
+1. Use the gpt2agent backend to list recent conversations and/or GET a finished heavy
+   conversation detail:  `BackendClient().get(f"/backend-api/conversation/{conv_id}")`.
+   The most recent finished heavy DR conversation is your free fixture.
+   (There is a concurrent heavy run finishing around 2026-06-03 ~11:15-11:45 in
+    /home/robot/workspace/51-amazon/research/dr-amazon-ai-cn-sellers-* — once it finishes,
+    its conversation is an ideal free fixture. You can also call list_conversations.)
+2. Walk `mapping[*].message`; find assistant text node(s) with status finished_successfully;
+   inspect WHERE content_references actually live (which node, which metadata key).
+   Save the raw detail JSON as a test fixture under tests/fixtures/.
+Only if the free path is insufficient, run heavy probes (cap 5, short queries).
+
+## Criteria (measurable)
+- [ ] C1 raw-capture: add env-gated raw dump (env var GPT2AGENT_RAW_DUMP=<path>) inside
+      deep_research_heavy Phase 1 SSE loop AND Phase 2 poll, writing each raw obj/detail
+      as JSONL. verify: `GPT2AGENT_RAW_DUMP=/tmp/raw.jsonl <heavy probe>` then
+      `grep -cE 'content_references|safe_urls' /tmp/raw.jsonl` -> diagnose presence.
+- [ ] C2 offline parser test: extend tests/test_heavy_dr_parser.py with the captured
+      fixture; assert the (fixed) parser yields a done event with >=1 content_reference
+      whose items[].url is a real URL. verify: `pytest tests/test_heavy_dr_parser.py -q` exit 0.
+- [ ] C3 end-to-end: one real heavy run via the deep-research harness pointed at THIS
+      worktree (PYTHONPATH=<worktree>) -> status.txt shows `refs=N` (N>0) and report.md
+      has a populated `## Sources`. (Do NOT edit the installed uv tool copy.)
+- [ ] C4 no regression: `pytest tests/ -q` exit 0; a light fixture still extracts refs.
+
+## Constraints
+- Edit ONLY files inside this worktree. NEVER touch ~/.claude, ~/.agents, .claude/skills,
+  or the installed uv tool at ~/.local/share/uv/tools/gpt2agent. Test against the worktree
+  via PYTHONPATH=<worktree>.
+- Branch is fix/heavy-dr-citations (already checked out). Commit your work with conventional
+  commits. Do NOT push, do NOT touch main.
+- Heavy DR quota cap: <=5 calls total, short probe queries; prefer the FREE path above.
+  A concurrent heavy run may be using the same ~/.codex/auth.json — prefer read-only
+  conversation-detail GETs to avoid sentinel/token contention.
+- Anti-hallucination: cite source file+line for claims; mark unverified items
+  "(needs live test)"; do NOT fabricate field names — confirm them from captured raw data.
+
+## Suggested sub-task order
+1. (C1) add GPT2AGENT_RAW_DUMP raw dump to Phase 1 + Phase 2 of deep_research_heavy.
+2. FREE-diagnose via conversation detail; save raw fixture; locate content_references.
+3. (C2) fix _emit_done / _apply_path(/message/metadata) / _poll_dr_completion to extract
+   refs from the correct node/key; add offline replay test.
+4. (C3,C4) E2E heavy run (PYTHONPATH=worktree) + full suite; update CHANGELOG.
+5. Write a short docs/goals/heavy-dr-citations-RESULT.md: root cause (H1/H2), the fix,
+   evidence (refs count before/after), and any residual risk.

--- a/gpt2agent/backend.py
+++ b/gpt2agent/backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,10 @@ def _load_token_with_source() -> tuple[str, Path | None]:
     """Load the ChatGPT bearer token and return its source file for mtime tracking.
 
     Search order:
-      1. ``~/.codex/auth.json`` with ``tokens.access_token`` (codex login)
+      1. ``$CODEX_HOME/auth.json`` (or ``~/.codex/auth.json`` if CODEX_HOME
+         is unset) with ``tokens.access_token`` (codex login). Honoring
+         CODEX_HOME lets a second account (e.g. ``CODEX_HOME=~/.codex-cx2``)
+         be used without touching the default login.
       2. ``~/.gpt2agent/token.json`` with ``token`` (flat) OR
          ``tokens.access_token`` (nested) — written by ``gpt2agent setup``
 
@@ -27,8 +31,9 @@ def _load_token_with_source() -> tuple[str, Path | None]:
     can stat it later to detect codex's background refresh and reload.
     Raises RuntimeError only if neither source yields a token.
     """
-    # Source 1: codex login
-    codex_path = Path.home() / ".codex" / "auth.json"
+    # Source 1: codex login (honor CODEX_HOME for multi-account)
+    _codex_home = os.environ.get("CODEX_HOME")
+    codex_path = (Path(_codex_home) if _codex_home else Path.home() / ".codex") / "auth.json"
     codex_err: str | None = None
     if codex_path.exists():
         try:

--- a/gpt2agent/skills/deep-research/SKILL.md
+++ b/gpt2agent/skills/deep-research/SKILL.md
@@ -127,7 +127,7 @@ The DR *quota* (≈248/cycle) is NOT the only limit. The ChatGPT backend also
 rate-limits the conversation endpoints per account.
 
 **Run heavy DR SERIALLY — never concurrently.** One heavy DR at a time. While a
-heavy DR is running (it polls `/backend-api/conversation/{id}` every ~15s during
+heavy DR is running (it polls `/backend-api/conversation/{id}` every ~120s during
 its 5–30 min Phase-2 wait), do NOT launch anything else that hits the same
 account's chatgpt.com backend — a second heavy/light DR, `codex`/`cx` exec jobs,
 agent mode, or `get_conversation`/`list_conversations` polling. Two pollers on

--- a/gpt2agent/skills/deep-research/SKILL.md
+++ b/gpt2agent/skills/deep-research/SKILL.md
@@ -37,9 +37,10 @@ test -f ~/.codex/auth.json || echo "Codex token missing; run: codex login"
 ```
 
 - Default mode: **light** (`deep_research`, ~1 min, citations included).
-- `--heavy`: **deep_research_heavy** (5-30 min, gpt-5-5-pro + connector,
-  long-form report; citation URLs are currently NOT recovered — view in
-  chatgpt.com web UI of the same conversation if needed).
+- `--heavy`: **deep_research_heavy** (5-30 min, gpt-5-5-pro + connector). NOTE:
+  the connector renders an embedded-UI experience and does NOT write a fetchable
+  report back over the API — heavy runs currently time out empty. Prefer light
+  mode for programmatic cited research. See "Known limitation" below.
 - `-o OUT_DIR`: output directory (default: `./research/dr-YYYYMMDD-HHMM/`).
 - Query can be inline string, `-` for stdin, or `@file.md` to read from file.
 
@@ -85,18 +86,28 @@ explicitly wants you to handle locally, anything covered by `context7`
 5. After completion: Read `report.md`, summarize key findings in 5-8
    bullets for the user, point to the full file path.
 
-## Known limitation (upstream bug)
+## Known limitation — heavy DR does not return a fetchable report (verified 2026-06-03)
 
-`deep_research_heavy` in `gpt2agent 0.0.1` emits its `done` event on
-the FIRST assistant message (which contains only the connector-call JSON,
-not the real report). The real report streams afterward as `progress`
-events with no second `done`, so the wrapper's `content_references` field
-is always empty. This script reconstructs the report from progress events
-but cannot recover citation URLs. The light `deep_research` path is
-unaffected — use it when citations matter.
+`deep_research_heavy` dispatches the `connector_openai_deep_research` connector,
+which renders an **"embedded UI experience" widget**. The actual report runs
+inside that connector experience and is **NOT written back** into the
+conversation as a fetchable assistant text node. Verified on a clean Pro account:
+a full 30-minute run left the conversation's report node empty
+(`content_references: []`, 0-char text), `async_status` went `7 → None`, and no
+`done` event was ever emitted — the poll timed out with no report. The report is
+visible only in the chatgpt.com web UI's deep-research experience.
+
+**Practical guidance: use light mode (`deep_research`) for programmatic, cited
+research.** It returns the report + `content_references` directly over SSE.
+
+The wrapper retains *best-effort* heavy citation extraction (`_emit_done` /
+`_poll_dr_completion` pull refs from nested `/message/metadata/...` patches or a
+same-turn conversation-detail node) — dormant until/unless the backend exposes
+refs on that path. Set `GPT2AGENT_RAW_DUMP=<path>` to capture the raw heavy
+stream + polls for further reverse-engineering.
 
 Upstream tracking: see `gpt2agent/sse.py` (https://github.com/robotlearning123/gpt2agent/blob/main/gpt2agent/sse.py)
-around the `_emit_done` / `_apply_path('/message/status', ...)` logic.
+around `_emit_done` / `_poll_dr_completion`.
 
 ## Quota management
 

--- a/gpt2agent/skills/deep-research/SKILL.md
+++ b/gpt2agent/skills/deep-research/SKILL.md
@@ -109,3 +109,34 @@ heavy calls:
 
 Refuse to fire `--heavy` if remaining < 10 unless the user explicitly
 acknowledges the consumption.
+
+## Account limits & concurrency (IMPORTANT — read before launching)
+
+The DR *quota* (≈248/cycle) is NOT the only limit. The ChatGPT backend also
+rate-limits the conversation endpoints per account.
+
+**Run heavy DR SERIALLY — never concurrently.** One heavy DR at a time. While a
+heavy DR is running (it polls `/backend-api/conversation/{id}` every ~15s during
+its 5–30 min Phase-2 wait), do NOT launch anything else that hits the same
+account's chatgpt.com backend — a second heavy/light DR, `codex`/`cx` exec jobs,
+agent mode, or `get_conversation`/`list_conversations` polling. Two pollers on
+one account collide.
+
+**Observed failure (2026-06-03):** running a heavy DR concurrently with several
+`codex` jobs caused sustained **HTTP 429** on the poll for ~30 min, then the run
+died with `ERROR  RuntimeError: DR polling timed out after 1800.0s waiting for
+conv <id>` and `events.jsonl` had only the initial `meta` event. The exact
+per-account request-rate limit is not officially documented — do not assume a
+number; just keep account access serial.
+
+**Recovery from a 429 / poll-timeout (no extra quota):** the run almost always
+*completed server-side* — only the local poll failed. The `conv_id` is in the
+error line. Recover the finished report instead of re-running `--heavy` (which
+would burn another quota): GET `/backend-api/conversation/<conv_id>` via
+`BackendClient` (or the `get_conversation` MCP tool), then walk
+`mapping[*].message` for the newest assistant text node with status
+`finished_successfully` — its `metadata.content_references` holds the citation
+URLs. NOTE: heavy DR via the connector may render an "embedded UI experience"
+and never write a fetchable report node back; in that case there is nothing to
+recover and the run must be redone in a quiet window. Wait for the rate limit to
+ease first — repeated GETs while rate-limited keep it hot.

--- a/gpt2agent/skills/deep-research/bin/deep_research.py
+++ b/gpt2agent/skills/deep-research/bin/deep_research.py
@@ -81,18 +81,19 @@ async def _run(query: str, mode: str, out_dir: Path) -> int:
                     md = ev.get("data") or {}
                     meta_data.append(md)
                 elif et == "done":
-                    if not seen_first_done:
-                        seen_first_done = True
-                        light_final_text = ev.get("text", "")
-                        light_refs = ev.get("content_references", []) or []
-                        light_groups = ev.get("search_result_groups", []) or []
-                        if ev.get("connector_failed"):
-                            connector_failed = True
-                    elif mode == "heavy":
-                        # Second done (rare but possible) — overwrite with real result.
-                        light_final_text = ev.get("text", "") or light_final_text
+                    txt = ev.get("text", "") or ""
+                    if ev.get("connector_failed"):
+                        connector_failed = True
+                    # Pick the LONGEST done as the real report. The research model
+                    # often emits a short tool-dispatch JSON as the FIRST done
+                    # (e.g. {"queries": [...], "source_filter": [...]}); the real
+                    # report is a later, longer done. Taking the first done here
+                    # silently discarded the actual report (observed 2026-06-03).
+                    if not seen_first_done or len(txt) > len(light_final_text):
+                        light_final_text = txt
                         light_refs = ev.get("content_references", []) or light_refs
                         light_groups = ev.get("search_result_groups", []) or light_groups
+                    seen_first_done = True
                 elif et == "progress":
                     txt = ev.get("text", "")
                     (progress_after_done if seen_first_done else progress_before_done).append(txt)
@@ -109,7 +110,7 @@ async def _run(query: str, mode: str, out_dir: Path) -> int:
         if not body and light_final_text:
             body = light_final_text  # Fallback: maybe wrapper actually delivered the real report.
     else:
-        body = light_final_text or "".join(progress_before_done) or "(empty)"
+        body = light_final_text or "".join(progress_before_done + progress_after_done) or "(empty)"
 
     # --- Sources (light mode only; heavy loses URLs upstream) ---
     sources = ""

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
+from pathlib import Path
 from typing import AsyncIterator
 from uuid import uuid4
 
@@ -41,6 +43,87 @@ HEAVY_DR_MODEL = "gpt-5-5-pro"
 
 #: System hint for heavy Deep Research (connector identifier from chatgpt.com frontend)
 HEAVY_DR_HINT = "connector:connector_openai_deep_research"
+
+
+def _raw_dump(obj: dict, *, phase: str) -> None:
+    path = os.environ.get("GPT2AGENT_RAW_DUMP")
+    if not path:
+        return
+    record = {"phase": phase, "obj": obj}
+    try:
+        out = Path(path).expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+            f.write("\n")
+    except Exception as exc:
+        _log.warning("GPT2AGENT_RAW_DUMP write failed (%s)", exc)
+
+
+def _has_citation_payload(meta: dict | None) -> bool:
+    if not isinstance(meta, dict):
+        return False
+    return bool(meta.get("content_references") or meta.get("search_result_groups"))
+
+
+def _citation_payload(*metas: dict | None) -> tuple[list, list]:
+    refs: list = []
+    groups: list = []
+    for meta in metas:
+        if not isinstance(meta, dict):
+            continue
+        if not refs:
+            refs = meta.get("content_references") or []
+        if not groups:
+            groups = meta.get("search_result_groups") or []
+    return refs, groups
+
+
+def _pointer_parts(path: str, prefix: str) -> list[str]:
+    tail = path[len(prefix) :].strip("/")
+    if not tail:
+        return []
+    return [p.replace("~1", "/").replace("~0", "~") for p in tail.split("/")]
+
+
+def _merge_metadata_path(meta: dict, path: str, op: str, value) -> dict:
+    if path == "/message/metadata":
+        if op in ("append", "patch") and isinstance(value, dict):
+            return {**meta, **value}
+        if op == "replace" and isinstance(value, dict):
+            return value
+        return meta
+
+    if not path.startswith("/message/metadata/"):
+        return meta
+
+    out = dict(meta)
+    parts = _pointer_parts(path, "/message/metadata")
+    if not parts:
+        return out
+
+    cur = out
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[part] = nxt
+        cur = nxt
+
+    key = parts[-1]
+    if op == "append":
+        existing = cur.get(key)
+        if isinstance(existing, list):
+            cur[key] = [*existing, value]
+        elif isinstance(existing, str) and isinstance(value, str):
+            cur[key] = existing + value
+        else:
+            cur[key] = value
+    elif op == "patch" and isinstance(value, dict) and isinstance(cur.get(key), dict):
+        cur[key] = {**cur[key], **value}
+    else:
+        cur[key] = value
+    return out
 
 
 def _build_payload(
@@ -1077,6 +1160,7 @@ class ConversationClient:
             "tool_invoked": False,
             "tool_failed": False,
             "done_emitted": False,
+            "citation_metadata": {},
             # True while the current assistant envelope is the connector-dispatch
             # JSON ({"path": ".../connector_openai_deep_research/start", ...}).
             # That envelope reaches finished_successfully almost immediately —
@@ -1089,11 +1173,13 @@ class ConversationClient:
             if state["done_emitted"]:
                 return
             md = state["asst_metadata"] or {}
+            citation_md = state["citation_metadata"] or {}
+            refs, groups = _citation_payload(md, citation_md)
             payload: dict = {
                 "type": "done",
                 "text": state["asst_text"],
-                "content_references": md.get("content_references", []) or [],
-                "search_result_groups": md.get("search_result_groups", []) or [],
+                "content_references": refs,
+                "search_result_groups": groups,
             }
             if state["tool_failed"]:
                 payload["connector_failed"] = True
@@ -1117,6 +1203,8 @@ class ConversationClient:
                 state["asst_text"] = initial
                 state["asst_status"] = msg.get("status") or ""
                 state["asst_metadata"] = msg.get("metadata") or {}
+                if _has_citation_payload(state["asst_metadata"]):
+                    state["citation_metadata"] = state["asst_metadata"]
                 state["is_connector_dispatch"] = (
                     initial.startswith('{"path":')
                     and "connector_openai_deep_research" in initial
@@ -1184,11 +1272,12 @@ class ConversationClient:
                         and state["asst_text"]
                     ):
                         _emit_done(events)
-            elif path == "/message/metadata":
-                if op in ("append", "patch") and isinstance(value, dict):
-                    state["asst_metadata"] = {**state["asst_metadata"], **value}
-                elif op == "replace" and isinstance(value, dict):
-                    state["asst_metadata"] = value
+            elif path == "/message/metadata" or path.startswith("/message/metadata/"):
+                state["asst_metadata"] = _merge_metadata_path(
+                    state["asst_metadata"], path, op, value
+                )
+                if _has_citation_payload(state["asst_metadata"]):
+                    state["citation_metadata"] = state["asst_metadata"]
 
         def _apply_patch(obj: dict, events: list) -> None:
             t = obj.get("type")
@@ -1289,6 +1378,7 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                _raw_dump(obj, phase="heavy_sse")
 
                 events: list[dict] = []
                 _apply_patch(obj, events)
@@ -1325,7 +1415,7 @@ class ConversationClient:
         conv_id: str,
         *,
         seed_text: str = "",
-        interval: float = 15.0,
+        interval: float = 120.0,
         max_wait: float = 1800.0,
     ) -> AsyncIterator[dict]:
         """Poll /backend-api/conversation/{id} until the DR answer lands.
@@ -1344,14 +1434,22 @@ class ConversationClient:
                 det = await asyncio.to_thread(self._backend.get, detail_path)
             except Exception as exc:
                 _log.warning("DR poll error (%s) — continuing", exc)
+                if "HTTP 429" in str(exc):
+                    await asyncio.sleep(max(interval * 2, 300.0))
                 continue
+            if isinstance(det, dict):
+                _raw_dump(det, phase="heavy_poll")
 
             mapping = (det or {}).get("mapping") or {}
             candidates = []
+            citation_candidates = []
             for node in mapping.values():
                 msg = (node or {}).get("message")
                 if not isinstance(msg, dict):
                     continue
+                meta = msg.get("metadata") or {}
+                if _has_citation_payload(meta):
+                    citation_candidates.append((msg.get("create_time") or 0, meta))
                 if (msg.get("author") or {}).get("role") != "assistant":
                     continue
                 recipient = msg.get("recipient")
@@ -1369,7 +1467,7 @@ class ConversationClient:
                         msg.get("create_time") or 0,
                         msg.get("status") or "",
                         text,
-                        msg.get("metadata") or {},
+                        meta,
                     )
                 )
             if not candidates:
@@ -1387,13 +1485,34 @@ class ConversationClient:
                 last_emitted = latest_text
 
             if latest_status == "finished_successfully":
+                refs = latest_meta.get("content_references") or []
+                groups = latest_meta.get("search_result_groups") or []
+                if citation_candidates and (not refs or not groups):
+                    turn_keys = ("working_turn_id", "turn_exchange_id")
+                    same_turn = [
+                        meta
+                        for _, meta in sorted(citation_candidates, key=lambda c: c[0])
+                        if any(
+                            latest_meta.get(k) and latest_meta.get(k) == meta.get(k)
+                            for k in turn_keys
+                        )
+                    ]
+                    fallback_metas = same_turn or [
+                        meta
+                        for _, meta in sorted(citation_candidates, key=lambda c: c[0])
+                    ]
+                    for meta in reversed(fallback_metas):
+                        if not refs:
+                            refs = meta.get("content_references") or []
+                        if not groups:
+                            groups = meta.get("search_result_groups") or []
+                        if refs and groups:
+                            break
                 yield {
                     "type": "done",
                     "text": latest_text,
-                    "content_references": latest_meta.get("content_references", [])
-                    or [],
-                    "search_result_groups": latest_meta.get("search_result_groups", [])
-                    or [],
+                    "content_references": refs,
+                    "search_result_groups": groups,
                 }
                 return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.2"
+version = "0.0.3"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/tests/fixtures/heavy_dr_conversation_detail_h2.json
+++ b/tests/fixtures/heavy_dr_conversation_detail_h2.json
@@ -1,0 +1,96 @@
+{
+  "title": "Heavy DR Citation Fixture",
+  "mapping": {
+    "user-node": {
+      "message": {
+        "id": "user-node",
+        "author": {"role": "user"},
+        "create_time": 1780500000.0,
+        "content": {"content_type": "text", "parts": ["Brief research request"]},
+        "status": "finished_successfully",
+        "metadata": {
+          "deep_research_version": "standard",
+          "venus_model_variant": "standard",
+          "system_hints": ["connector:connector_openai_deep_research"],
+          "working_turn_id": "turn-1",
+          "turn_exchange_id": "turn-1"
+        },
+        "recipient": "all"
+      }
+    },
+    "citation-node": {
+      "message": {
+        "id": "citation-node",
+        "author": {"role": "assistant"},
+        "create_time": 1780500010.0,
+        "content": {"content_type": "text", "parts": [""]},
+        "status": "finished_successfully",
+        "metadata": {
+          "content_references": [
+            {
+              "matched_text": "OpenAI",
+              "prefix": "",
+              "start_idx": 0,
+              "end_idx": 6,
+              "safe_urls": ["https://openai.com/"],
+              "refs": [],
+              "alt": null,
+              "prompt_text": null,
+              "type": "webpage",
+              "items": [
+                {
+                  "title": "OpenAI",
+                  "url": "https://openai.com/",
+                  "attribution": "openai.com",
+                  "pub_date": null,
+                  "snippet": "OpenAI homepage"
+                }
+              ],
+              "fallback_items": [],
+              "status": "done",
+              "error": null,
+              "style": null
+            }
+          ],
+          "search_result_groups": [
+            {
+              "type": "search_result_group",
+              "domain": "openai.com",
+              "entries": [
+                {
+                  "type": "search_result",
+                  "url": "https://openai.com/",
+                  "title": "OpenAI",
+                  "snippet": "OpenAI homepage",
+                  "ref_id": "turn0search0"
+                }
+              ]
+            }
+          ],
+          "working_turn_id": "turn-1",
+          "turn_exchange_id": "turn-1"
+        },
+        "recipient": "all"
+      }
+    },
+    "final-node": {
+      "message": {
+        "id": "final-node",
+        "author": {"role": "assistant"},
+        "create_time": 1780500020.0,
+        "content": {
+          "content_type": "text",
+          "parts": ["# Heavy DR Report\n\nOpenAI is cited in this report."]
+        },
+        "status": "finished_successfully",
+        "metadata": {
+          "content_references": [],
+          "search_result_groups": [],
+          "working_turn_id": "turn-1",
+          "turn_exchange_id": "turn-1"
+        },
+        "recipient": "all"
+      }
+    }
+  }
+}

--- a/tests/test_backend_token.py
+++ b/tests/test_backend_token.py
@@ -73,3 +73,33 @@ def test_reload_tolerates_missing_file(
     # Must not raise — keeps the old bearer; next 401 will surface error.
     client._reload_token_if_stale()
     assert client._session.headers["Authorization"] == before
+
+
+def test_codex_home_routes_to_alt_account(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CODEX_HOME selects a second account's auth.json over ~/.codex."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_auth(tmp_path / ".codex" / "auth.json", "TOK_DEFAULT")
+    alt_home = tmp_path / ".codex-cx2"
+    _write_auth(alt_home / "auth.json", "TOK_CX2")
+    monkeypatch.setenv("CODEX_HOME", str(alt_home))
+
+    from gpt2agent import backend as be
+
+    client = be.BackendClient()
+    assert client._session.headers["Authorization"] == "Bearer TOK_CX2"
+
+
+def test_codex_home_unset_falls_back_to_home(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without CODEX_HOME, the default ~/.codex/auth.json is used."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_auth(tmp_path / ".codex" / "auth.json", "TOK_DEFAULT")
+
+    from gpt2agent import backend as be
+
+    client = be.BackendClient()
+    assert client._session.headers["Authorization"] == "Bearer TOK_DEFAULT"

--- a/tests/test_heavy_dr_parser.py
+++ b/tests/test_heavy_dr_parser.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -164,9 +165,28 @@ class _FakeSentinel:
 
 
 def _run_heavy_dr(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    return _run_heavy_dr_with_frames(monkeypatch, _FRAMES)
+
+
+def _run_heavy_dr_with_frames(
+    monkeypatch: pytest.MonkeyPatch, frames: list[str]
+) -> list[dict]:
     from gpt2agent import sse as sse_mod
 
-    monkeypatch.setattr(sse_mod, "AsyncSession", _FakeSession)
+    class _FrameSession:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FrameSession":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def post(self, *_: Any, **__: Any) -> _FakeResp:
+            return _FakeResp(frames)
+
+    monkeypatch.setattr(sse_mod, "AsyncSession", _FrameSession)
     monkeypatch.setattr(sse_mod, "SentinelGate", _FakeSentinel)
 
     client = sse_mod.ConversationClient(_FakeBackend())  # type: ignore[arg-type]
@@ -191,6 +211,110 @@ def test_connector_dispatch_done_suppressed(monkeypatch: pytest.MonkeyPatch) -> 
     # And it must hold the REAL report, not the dispatch JSON.
     assert dones[0]["text"] == _REAL_REPORT
     assert _DISPATCH_TEXT not in dones[0]["text"]
+
+
+def test_nested_metadata_patch_preserves_citation_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ref = {
+        "matched_text": "OpenAI",
+        "safe_urls": ["https://openai.com/"],
+        "items": [{"title": "OpenAI", "url": "https://openai.com/"}],
+        "type": "webpage",
+    }
+    group = {
+        "type": "search_result_group",
+        "domain": "openai.com",
+        "entries": [
+            {
+                "type": "search_result",
+                "url": "https://openai.com/",
+                "title": "OpenAI",
+                "snippet": "Homepage",
+                "ref_id": "turn0search0",
+            }
+        ],
+    }
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-report",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "content": {"content_type": "text", "parts": ["Report"]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 1,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/metadata/content_references",
+                "o": "replace",
+                "v": [ref],
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/metadata/search_result_groups",
+                "o": "replace",
+                "v": [group],
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {"p": "/message/status", "o": "replace", "v": "finished_successfully"}
+        ),
+        "data: [DONE]",
+    ]
+    events = _run_heavy_dr_with_frames(monkeypatch, frames)
+    done = [e for e in events if e.get("type") == "done"][-1]
+
+    assert done["content_references"] == [ref]
+    assert done["search_result_groups"] == [group]
+
+
+def test_poll_completion_uses_citation_metadata_from_same_turn_fixture() -> None:
+    from gpt2agent import sse as sse_mod
+
+    fixture = json.loads(
+        Path("tests/fixtures/heavy_dr_conversation_detail_h2.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    class _FixtureBackend(_FakeBackend):
+        def get(self, *_: Any, **__: Any) -> dict:
+            return fixture
+
+    client = sse_mod.ConversationClient(_FixtureBackend())  # type: ignore[arg-type]
+
+    async def _go() -> list[dict]:
+        out: list[dict] = []
+        async for ev in client._poll_dr_completion(
+            "fixture-conv", interval=0, max_wait=1
+        ):
+            out.append(ev)
+        return out
+
+    events = asyncio.run(_go())
+    done = [e for e in events if e.get("type") == "done"][-1]
+    refs = done["content_references"]
+
+    assert refs
+    assert any(
+        isinstance(item.get("url"), str) and item["url"].startswith("https://")
+        for ref in refs
+        for item in ref.get("items", [])
+    )
+    assert done["search_result_groups"]
 
 
 def test_empty_dispatch_envelope_done_suppressed(


### PR DESCRIPTION
## Summary

Deep Research reliability fixes + an honest, **verified** correction of the heavy-DR story. Ships as **0.0.3**.

### Fixed
- **Light DR report extraction** — the research model often emits a short tool-dispatch JSON as the *first* `done` (e.g. `{"queries":[...]}`); the runner took that as the report and discarded the real, later report. Now picks the longest `done` + falls back to all progress. Replay-verified (106 → 2417 chars).

### Added
- **`CODEX_HOME` multi-account auth** — `BackendClient` reads `$CODEX_HOME/auth.json` (falls back to `~/.codex`). Lets a second account be used without touching the default login. +2 tests.
- **`GPT2AGENT_RAW_DUMP`** heavy-DR diagnostics; heavy poll **429 backoff** (≥300s) + 120s interval; best-effort heavy citation extraction from nested metadata patches / same-turn nodes.

### Known limitation (verified 2026-06-03, clean Pro account)
**Heavy DR does not return a programmatically-fetchable report.** `deep_research_heavy` dispatches the `connector_openai_deep_research` connector, which renders an "embedded UI experience"; a full 30-min run left the conversation report node empty (`content_references: []`, 0 chars), `async_status 7→None`, no `done` emitted. So the "heavy loses citations" premise is moot — there is no report node. The citation-extraction code is retained as **dormant best-effort** and documented honestly (not claimed as fixing the bug). **Use light mode for programmatic cited research.**

Receipt: `artifacts/verify/heavy-dr-citations-20260603.md`.

## Tests
`SKIP_LIVE=1 pytest -q` → **42 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.0.3

* **New Features**
  * Added multi-account authentication support via environment configuration
  * Enhanced diagnostics for Deep Research operations
  * Improved citation extraction from conversation metadata

* **Bug Fixes**
  * Fixed Light Deep Research report extraction when early completion events occur
  * Improved polling backoff handling to reduce rate-limiting issues
  * Enhanced report fallback logic for better content retention

* **Documentation**
  * Updated Deep Research guidance with account limits and concurrency recommendations
  * Added notes on heavy mode operational constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->