### PR TITLE
Round 2: agent-friendliness, docs, full tool-layer tests (v0.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+## [0.0.6] - 2026-06-18
+
+### Added
+
+- **More MCP hosts auto-install.** `gpt2agent install` now registers Cursor,
+  Windsurf, Claude Desktop, and Zed (in addition to Claude Code and Codex) via a
+  shared idempotent JSON registrar; `detect_clients()` finds them for `--client all`.
+- **`gpt2agent --version`.**
+- **User docs** under `docs/` (quickstart, clients, configuration, troubleshooting,
+  FAQ, how-it-works) and a CI badge in the README.
+- **CODE_OF_CONDUCT.md**; ruff added to the `dev` extra with a `[tool.ruff]` config;
+  richer pyproject classifiers/authors.
+
+### Changed
+
+- **`gpt2agent setup` no longer starts a background HTTP daemon / macOS LaunchAgent
+  or registers the legacy `mcpServers.openai` HTTP entry.** It now pastes the token
+  and registers clients over **stdio**, matching `gpt2agent install`.
+- Tool docstrings clarified for agents: `gpt_chat` takes the `short_url` from
+  `list_custom_gpts` (not a `g-p-*` id); `list_models` documents `slug` as the
+  `chat(model=)` input; `account_status`/`deep_research_heavy` document returns +
+  the citation caveat. README no longer claims a non-existent `account_status` "MFA".
+
+### Fixed
+
+- `install.sh` no longer aborts under `set -e` on PEP-668 Linux when bootstrapping
+  pipx (and prints distro install commands); `-h` no longer leaks shell lines.
+- Bundled `gpt2agent` skill config example: `host` `0.0.0.0` → `127.0.0.1`.
+- Removed the dead `gpt2agent login --browser` hint; `CONTRIBUTING.md` stale test count.
+
+### Tests
+
+- New `tests/test_tools.py` (27 hermetic tests) covering the entire MCP tool layer +
+  server SSE handlers + the PII-redaction and `temporary=False` invariants (was zero
+  coverage). Plus install tests for the new hosts. Suite: 96 passed, 9 skipped.
+
 ## [0.0.5] - 2026-06-18
 
 ### Security

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers via the repository's private reporting
+channels (see [SECURITY.md](./SECURITY.md) for private contact). All complaints
+will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ pip install -e ".[dev]"
 pytest
 ```
 
-38 tests, 9 skipped. All must pass before merging.
+The offline suite must pass before merging (live tests are gated by `SKIP_LIVE`
+and skipped by default). Also run `ruff check gpt2agent tests` (clean).
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ args = ["run", "--stdio"]
 gpt2agent setup
 ```
 
-Prompts for a ChatGPT session token and saves it to `~/.gpt2agent/token.json`.
-The `codex login` flow is preferred when available because codex auto-refreshes
-its token; gpt2agent reloads `~/.codex/auth.json` on mtime change so long
-calls don't 401 mid-flight.
+Prompts for a ChatGPT session token (saved to `~/.gpt2agent/token.json`, mode
+`600`), detects your plan, and registers gpt2agent with your detected MCP clients
+over **stdio** — the same wiring as `gpt2agent install`. The `codex login` flow is
+preferred when available because codex auto-refreshes its token; gpt2agent reloads
+`~/.codex/auth.json` on mtime change so long calls don't 401 mid-flight.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ calls don't 401 mid-flight.
 
 | Tool | What it does |
 |---|---|
-| `account_status` | Plan, country, MFA, feature count, subscription expiry |
+| `account_status` | Plan, country, groups, feature count, subscription expiry |
 | `list_models` | All models on your account (slug, max_tokens, reasoning_type, capabilities, enabled_tools) |
 | `list_conversations` | Recent ChatGPT conversations (titles: emails/phones redacted) |
 | `get_conversation` | Full message history for a specific conversation (multimodal, code, images) |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # gpt2agent
 
-> **Your `codex login` → full ChatGPT Plus/Pro account inside any MCP client.**
+> **MCP server for your ChatGPT account: `codex login` → ChatGPT Plus/Pro inside any MCP client.**
 
-Use your **ChatGPT Plus or Pro** subscription — every model, every account-tier
-feature — inside Claude Code, Codex, and any MCP client.
+An **MCP server** that puts your **ChatGPT Plus or Pro** subscription — every model
+and the account-tier features below — inside Claude Code, Codex, Cursor, Windsurf,
+Zed, and any MCP client.
 
 [![PyPI version](https://img.shields.io/pypi/v/gpt2agent)](https://pypi.org/project/gpt2agent/)
+[![CI](https://github.com/robotlearning123/gpt2agent/actions/workflows/ci.yml/badge.svg)](https://github.com/robotlearning123/gpt2agent/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://pypi.org/project/gpt2agent/)
+
+📖 **[Quickstart](./docs/quickstart.md)** · **[Client setup](./docs/clients.md)** · **[Troubleshooting](./docs/troubleshooting.md)** · **[FAQ](./docs/faq.md)** · **[Docs index](./docs/README.md)**
 
 ---
 
@@ -32,10 +36,10 @@ curl -fsSL https://raw.githubusercontent.com/robotlearning123/gpt2agent/main/ins
 ```
 
 That command:
-1. Installs `gpt2agent` via pipx (creates an isolated env).
+1. Installs `gpt2agent` via pipx (creates an isolated env; falls back to a git install if PyPI is unreachable).
 2. Reuses your existing `~/.codex/auth.json` if you've run `codex login` — no separate ChatGPT token paste needed.
-3. Detects which MCP clients you have (Claude Code, Codex) and writes the right config snippet for each.
-4. Drops the `deep-research` Claude Code skill into `~/.claude/skills/`.
+3. Detects which MCP clients you have (Claude Code, Codex, Cursor, Windsurf, Claude Desktop, Zed) and writes the right config for each.
+4. Drops the Claude Code skills (`deep-research` + `gpt2agent`) into `~/.claude/skills/`.
 
 ### Or step-by-step
 
@@ -47,8 +51,8 @@ pipx install gpt2agent
 gpt2agent install                          # auto-detect everything
 
 # Want only one client?
-gpt2agent install --client claude-code
-gpt2agent install --client codex
+gpt2agent install --client claude-code   # or: codex, cursor, windsurf, claude-desktop, zed
+# (VS Code & Cline: see docs/clients.md for the manual snippet)
 
 # HTTP transport instead of stdio?
 gpt2agent install --transport http --http-port 9000
@@ -191,7 +195,8 @@ refresh propagates transparently. See [NOTICES](./NOTICES.md) for attribution.
 
 ## Configuration
 
-Optional `~/.gpt2agent/config.toml` or `./config.toml`:
+Optional, searched in order: `~/.gpt2agent/config.toml`, `./config.toml`,
+`~/.config/gpt2agent/config.toml`. Full reference: [docs/configuration.md](./docs/configuration.md).
 
 ```toml
 [server]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# gpt2agent docs
+
+User-facing documentation. (Project/contributor internals live in
+[CONTRIBUTING.md](../CONTRIBUTING.md); security policy in [SECURITY.md](../SECURITY.md).)
+
+- **[Quickstart](./quickstart.md)** — prereqs → one-line install → verify → first call.
+- **[Client setup](./clients.md)** — per-host config (Claude Code, Codex, Cursor,
+  Windsurf, Claude Desktop, Zed, VS Code, Cline, generic stdio).
+- **[Configuration](./configuration.md)** — config file paths, `[server]`/`[models]`
+  keys, and env vars (`CODEX_HOME`, `GPT2AGENT_ALLOW_REMOTE`, `GPT2AGENT_RAW_DUMP`).
+- **[Troubleshooting](./troubleshooting.md)** — token/401/403/429, tools not
+  appearing, temporary-chat feature blocks, pipx/PEP-668.
+- **[FAQ](./faq.md)** — official? ban risk? stdio vs HTTP? Plus vs Pro? quota?
+- **[How it works](./how-it-works.md)** — the no-proxy architecture.
+
+For the full per-tool reference (every argument, return shape, and gotcha for all
+25 tools), see [`gpt2agent/skills/gpt2agent/tools-reference.md`](../gpt2agent/skills/gpt2agent/tools-reference.md).
+
+Security model and ToS/account-ban risk are covered in the main
+[README](../README.md#security--risk--read-before-you-run-this).

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,81 @@
+# Client setup
+
+gpt2agent speaks MCP over **stdio**, which every popular host supports. `gpt2agent
+install` auto-writes the right config for the clients below; the last two (VS Code,
+Cline) are easy manual additions.
+
+All auto-installed configs are **idempotent** and back up the prior file as
+`<name>.bak-gpt2agent`. After installing, **restart the client** so it spawns the
+server.
+
+## Auto-installed (`gpt2agent install --client <name>`)
+
+| Client | `--client` | Config file | Restart needed |
+|---|---|---|---|
+| Claude Code | `claude-code` | `~/.claude.json` | yes |
+| Codex CLI | `codex` | `~/.codex/config.toml` | no (next run) |
+| Cursor | `cursor` | `~/.cursor/mcp.json` | yes |
+| Windsurf | `windsurf` | `~/.codeium/windsurf/mcp_config.json` | yes |
+| Claude Desktop | `claude-desktop` | platform Claude config | yes |
+| Zed | `zed` | `~/.config/zed/settings.json` | yes |
+
+### The stdio entry these write
+
+Most hosts use the `mcpServers` shape:
+
+```json
+{
+  "mcpServers": {
+    "gpt2agent": { "command": "gpt2agent", "args": ["run", "--stdio"] }
+  }
+}
+```
+
+Codex (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.gpt2agent]
+command = "gpt2agent"
+args = ["run", "--stdio"]
+```
+
+Zed nests the command under `context_servers`:
+
+```json
+{
+  "context_servers": {
+    "gpt2agent": { "command": { "path": "gpt2agent", "args": ["run", "--stdio"] }, "settings": {} }
+  }
+}
+```
+
+## Manual setup
+
+### VS Code (GitHub Copilot MCP)
+
+Add to `.vscode/mcp.json` in your workspace (note the top-level key is `servers`):
+
+```json
+{
+  "servers": {
+    "gpt2agent": { "type": "stdio", "command": "gpt2agent", "args": ["run", "--stdio"] }
+  }
+}
+```
+
+### Cline / Roo Code
+
+Add the same `mcpServers` block (see above) to Cline's settings file
+(`cline_mcp_settings.json`, reachable from the Cline MCP settings UI).
+
+### Any other MCP host (generic stdio)
+
+Point it at the command `gpt2agent` with args `["run", "--stdio"]`. That's all most
+hosts need.
+
+## HTTP transport (advanced, not recommended)
+
+stdio is the default and safest. The HTTP transport is **unauthenticated** and
+proxies your full account, so it binds `127.0.0.1` only and refuses non-loopback
+hosts unless you set `GPT2AGENT_ALLOW_REMOTE=1` (put it behind your own auth proxy).
+See the README's **Security & risk** section.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,40 @@
+# Configuration
+
+## Config file
+
+Optional. Searched in this order (first found wins):
+
+1. `~/.gpt2agent/config.toml`
+2. `./config.toml` (current directory)
+3. `~/.config/gpt2agent/config.toml` (XDG)
+
+```toml
+[server]
+# Loopback only. The HTTP transport is UNAUTHENTICATED and proxies your full
+# ChatGPT account — only bind a public host behind your own auth proxy AND with
+# GPT2AGENT_ALLOW_REMOTE=1 set.
+host = "127.0.0.1"
+port = 9000
+
+[models]
+chat     = "gpt-5-3"      # default model for the `chat` tool
+agent    = "agent-mode"   # default for the `agent` tool
+heavy_dr = "gpt-5-5-pro"  # override slug for `deep_research_heavy`
+```
+
+CLI flags override the file: `gpt2agent run --host 127.0.0.1 --port 9001`.
+
+## Environment variables
+
+| Var | Effect |
+|---|---|
+| `CODEX_HOME` | Use a non-default codex dir, e.g. `~/.codex-work/auth.json`, for multi-account setups. Honored by token loading, `setup`, and the codex-login auth path. |
+| `GPT2AGENT_ALLOW_REMOTE=1` | Required to bind the HTTP transport to a non-loopback host. Without it, gpt2agent refuses to start HTTP on anything but loopback. Only use behind your own auth/firewall. |
+| `GPT2AGENT_RAW_DUMP=<path>` | **Debug only.** Appends raw SSE/poll traffic — including prompts, responses, and resume tokens — to the given file, **unredacted**. Use only for debugging and delete the dumps afterward. |
+
+## Transports
+
+- **stdio** (default, recommended): local, not network-exposed. What `gpt2agent
+  install` wires for every client.
+- **streamable-http** (`gpt2agent run`, no `--stdio`): unauthenticated; loopback by
+  default; see `GPT2AGENT_ALLOW_REMOTE` above and the README **Security & risk** section.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,52 @@
+# FAQ
+
+### Is this official / affiliated with OpenAI?
+
+No. gpt2agent is an independent, unofficial project. It talks to ChatGPT's private
+backend the way the web client does (TLS impersonation + the Sentinel
+proof-of-work/Turnstile challenge). There is no official API behind it.
+
+### Will this get my account banned?
+
+It might. Using a reverse-engineered client likely violates the OpenAI Terms of
+Service, and automated/abnormal traffic can get an account rate-limited,
+challenged, suspended, or banned. Use an account you can afford to lose, keep
+volume human-scale, and don't depend on it for anything critical. See the README's
+**Security & risk** section.
+
+### Why stdio instead of HTTP?
+
+stdio runs the server as a local subprocess of your client — nothing is exposed on
+the network. The HTTP transport has **no authentication** and proxies your entire
+account, so it binds loopback only and refuses non-loopback hosts unless you opt in
+with `GPT2AGENT_ALLOW_REMOTE=1`. Prefer stdio.
+
+### Plus vs Pro — what's the difference?
+
+Both work. Pro unlocks the heavier models (e.g. `gpt-5-5-pro`, `o3-pro`) and a
+larger monthly Deep Research quota. Run `list_models` to see exactly what your
+account has, and `account_status` for your plan.
+
+### How much Deep Research can I run?
+
+Roughly ~248 heavy requests per monthly cycle on Pro, fewer on Plus — approximate
+and account/region-dependent, not a guaranteed number. Light `deep_research` is
+cheaper. Run heavy DR serially.
+
+### Is `gpt_chat` (Custom GPTs) stable?
+
+It's **experimental**. Pass the `short_url` returned by `list_custom_gpts` as the
+`gizmo_id`. The payload field is reverse-engineered and not load-tested across all
+Custom GPT types.
+
+### Where does my token go?
+
+It's read locally from `~/.codex/auth.json` (codex login) or
+`~/.gpt2agent/token.json` (mode `600`) and sent only to `chatgpt.com`. gpt2agent
+never transmits it anywhere else, and redacts token/secret values from error output.
+
+### What's NOT supported?
+
+Sora video, Operator/CUA, and voice sessions — those endpoints aren't reverse-engineered
+yet. Everything else (chat, agent mode, deep research, image gen, code interpreter,
+canvas, memory, custom instructions, Codex tasks) is exposed via the 25 MCP tools.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,47 @@
+# How it works
+
+gpt2agent is a native Python MCP server that calls ChatGPT's backend directly —
+no proxy process, no platform API key.
+
+```
+~/.codex/auth.json  (or ~/.gpt2agent/token.json)   ← bearer, auto-refreshed by codex
+        │
+   gpt2agent  (stdio MCP server; token reloaded from disk on mtime change)
+        │
+   curl_cffi  ──TLS-impersonates Chrome──▶  chatgpt.com /backend-api/...
+        │                                     ├── /conversation, /f/conversation   (SSE)
+        │                                     └── /me, /models, /memories, /codex,  (REST)
+        │                                         /gizmos, /files, /apps, ...
+   25 MCP tools
+```
+
+## Request path
+
+- **SSE tools** (`chat`, `agent`, `deep_research[_heavy]`, `gpt_chat`, image gen,
+  code interpreter, canvas) stream from `/backend-api/conversation` and are parsed
+  incrementally in `gpt2agent/sse.py`.
+- **REST tools** (account, models, memory, instructions, conversations, codex, apps,
+  files) are thin wrappers over `gpt2agent/backend.py`'s sync HTTP client, exposed
+  from `gpt2agent/tools/*.py`.
+
+## The Sentinel challenge
+
+ChatGPT's backend is protected by OpenAI's "Sentinel" anti-bot system (a
+proof-of-work plus a Cloudflare Turnstile token). gpt2agent solves these with
+vendored solvers (`gpt2agent/_vendored/`, MIT, attributed in
+[NOTICES.md](../NOTICES.md)) and aligns its TLS fingerprint + User-Agent with a real
+Chrome build so Cloudflare's bot manager doesn't 403 the request. **This is the part
+that carries ToS/account-ban risk** — see the README's Security & risk section.
+
+## Token handling
+
+The bearer is read from disk on each request and reloaded when the file's mtime
+changes, so codex's background refresh propagates without restarting the server.
+Multi-account setups can point at a different login via `CODEX_HOME`. Token and
+header values are redacted from error messages and logs (`gpt2agent/_log_redact.py`).
+
+## Transports
+
+stdio (default; a local subprocess of your client) or streamable-HTTP (loopback by
+default; unauthenticated — see Security & risk). `gpt2agent install` always wires
+stdio.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart
+
+Get gpt2agent running in any MCP client in ~5 minutes.
+
+## 1. Prerequisites
+
+- An active **ChatGPT Plus or Pro** subscription.
+- **Python 3.10+** and **pipx** (`pip install --user pipx`, or `apt/dnf/brew install pipx`).
+- The easiest auth path: the [`codex`](https://github.com/openai/codex) CLI, logged in
+  (`codex login`). gpt2agent reuses its `~/.codex/auth.json` — no separate token to paste.
+
+## 2. Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robotlearning123/gpt2agent/main/install.sh | bash
+```
+
+This installs the `gpt2agent` package (via pipx) and registers it with every MCP
+client it detects. Or do it by hand:
+
+```bash
+pipx install gpt2agent
+gpt2agent install            # auto-detect & register all installed clients
+```
+
+Target one client explicitly:
+
+```bash
+gpt2agent install --client claude-code   # or: codex, cursor, windsurf, claude-desktop, zed
+```
+
+See [clients.md](./clients.md) for per-client config details and clients that need
+manual setup (VS Code, Cline).
+
+## 3. Authenticate
+
+If you've run `codex login`, you're done — gpt2agent picks up the token automatically
+(and reloads it when codex refreshes it).
+
+No codex? Run `gpt2agent setup` to paste a ChatGPT token once
+(saved to `~/.gpt2agent/token.json`, mode `600`).
+
+## 4. Verify
+
+```bash
+gpt2agent --version          # confirms the install
+gpt2agent run --stdio        # smoke test: should start and wait on stdin (Ctrl-C to exit)
+```
+
+Then **restart your MCP client** (Claude Code spawns the server fresh on restart;
+Codex picks it up on next run). Ask your agent to call `account_status` — it should
+return your plan and feature count.
+
+## 5. First calls
+
+- `chat` — talk to any model on your account (`model="gpt-5-5-pro"`, `o3-pro`, …).
+- `deep_research` — web-augmented research with citations (~1 min).
+- `generate_image` — DALL·E image generation.
+
+> **Heads up:** `chat` defaults to `temporary=True`, which disables image gen / code
+> interpreter / canvas. Use the dedicated tools (`generate_image`, `code_interpreter`,
+> `canvas_execute`) for those — they handle the flag for you.
+
+Stuck? See [troubleshooting.md](./troubleshooting.md). Worried about account safety?
+See the README's **Security & risk** section and [faq.md](./faq.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting
+
+### "No ChatGPT token found"
+
+gpt2agent reads, in order, `$CODEX_HOME/auth.json` (or `~/.codex/auth.json`) then
+`~/.gpt2agent/token.json`. Fix:
+
+```bash
+codex login           # preferred — auto-refreshing token
+# or
+gpt2agent setup       # paste a ChatGPT token once
+```
+
+### MCP tools don't appear in my client
+
+The client only spawns the server on (re)start. **Restart Claude Code / Cursor /
+Windsurf / Zed** after `gpt2agent install`. Codex picks it up on its next run.
+Confirm the binary works first: `gpt2agent run --stdio` (should start and wait).
+
+### `401 Unauthorized — run codex login`
+
+The bearer token expired. Run `codex login` again (gpt2agent reloads it on the next
+call). If you used `gpt2agent setup`, re-run it.
+
+### `403 Forbidden`
+
+A 403 from `/backend-api/conversation` is **not always** an expired token. It can be:
+- a Cloudflare / Sentinel bot-check (transient — retry), or
+- a region/feature gate on your account.
+Try once more; if it persists, re-`codex login`, and check the feature is available
+in the ChatGPT web app for your plan.
+
+### `429` / rate limited
+
+You're being throttled. Wait and retry; keep request volume human-scale. Deep
+Research also has a monthly quota (see [faq.md](./faq.md)).
+
+### image gen / code interpreter / canvas returns plain text
+
+`chat` defaults to `temporary=True`, which disables tool features. Use the dedicated
+tools — `generate_image`, `code_interpreter`, `canvas_execute` — which set
+`temporary=False` for you. (Calling `chat` and asking it to make an image won't work.)
+
+### `deep_research_heavy` has no grouped Sources list
+
+The report is recovered from the connector's widget state; grouped source URLs are
+usually present but not guaranteed. If absent, the model often cited sources inline
+in the body. Use light `deep_research` for reliably grouped citations.
+
+### Installer aborts / `externally-managed-environment`
+
+On PEP-668 systems (Ubuntu/Debian/Fedora) `pip install --user pipx` is blocked.
+Install pipx via your distro and re-run the one-liner:
+
+```bash
+sudo apt install pipx && pipx ensurepath     # Debian/Ubuntu
+sudo dnf install pipx && pipx ensurepath     # Fedora
+brew install pipx && pipx ensurepath         # macOS
+```
+
+### PyPI install fails (package not found)
+
+The `install.sh` one-liner automatically falls back to a `git+https` install if
+PyPI is unavailable. To force it: `./install.sh --source
+git+https://github.com/robotlearning123/gpt2agent.git`.

--- a/gpt2agent/__init__.py
+++ b/gpt2agent/__init__.py
@@ -1,0 +1,12 @@
+"""gpt2agent — MCP server exposing a ChatGPT Plus/Pro account to MCP clients."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("gpt2agent")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/gpt2agent/auth.py
+++ b/gpt2agent/auth.py
@@ -68,7 +68,7 @@ def _from_browser() -> dict | None:
     print("    Application → Cookies → __Secure-next-auth.session-token")
     print()
     print("  Then paste the token below.")
-    print("  (Alternatively run: gpt2agent login --browser for automatic extraction)")
+    print("  (Tip: running `codex login` once lets gpt2agent reuse that token automatically.)")
     print()
     webbrowser.open("https://chat.openai.com")
     token = input("  Paste access_token (or session token): ").strip()

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -300,6 +300,123 @@ def install_codex(
     return {"path": cfg_path, "backup": backup, "changed": True}
 
 
+# ── Other MCP hosts (JSON, mcpServers-style) ───────────────────────────────
+#
+# Cursor, Windsurf, Claude Desktop and friends all use the same
+# ``{"<top_key>": {"<server>": {command, args}}}`` JSON shape Claude Code uses —
+# only the file path (and, for VS Code/Zed, the top-level key + entry shape)
+# differ. ``_install_json_host`` is the shared, idempotent writer; the per-host
+# functions just supply path + key + entry.
+
+
+def _mcp_entry() -> dict[str, Any]:
+    """stdio server entry for the mcpServers-style hosts (Cursor/Windsurf/…)."""
+    return {"command": "gpt2agent", "args": ["run", "--stdio"]}
+
+
+def _zed_entry() -> dict[str, Any]:
+    """Zed nests the command and uses a ``context_servers`` top-level key."""
+    return {"command": {"path": "gpt2agent", "args": ["run", "--stdio"]}, "settings": {}}
+
+
+def _install_json_host(
+    label: str,
+    cfg_path: Path,
+    *,
+    top_key: str,
+    entry: dict[str, Any],
+    server_name: str = "gpt2agent",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Register gpt2agent in a JSON MCP config file under ``top_key.<server>``.
+
+    Idempotent; preserves every other field; writes a ``.bak-gpt2agent`` backup.
+    Used for Cursor, Windsurf, Claude Desktop, VS Code, Zed (see callers).
+    """
+    if cfg_path.exists():
+        try:
+            data = json.loads(cfg_path.read_text() or "{}")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"{cfg_path} is not valid JSON ({exc}). Refusing to overwrite — "
+                "repair it or move it aside, then re-run."
+            )
+        if not isinstance(data, dict):
+            raise RuntimeError(f"{cfg_path} is not a JSON object; refusing to overwrite.")
+    else:
+        data = {}
+
+    servers = data.setdefault(top_key, {})
+    if not isinstance(servers, dict):
+        raise RuntimeError(f"{cfg_path}: '{top_key}' is not an object; refusing to overwrite.")
+    prior = servers.get(server_name)
+    servers[server_name] = entry
+
+    if prior == entry:
+        _info(f"{label}: {cfg_path} already has {top_key}.{server_name} (no-op)")
+        return {"path": cfg_path, "backup": None, "changed": False}
+    if dry_run:
+        _info(f"{label}: would write {top_key}.{server_name} to {cfg_path}")
+        return {"path": cfg_path, "backup": None, "changed": False}
+
+    backup = _backup(cfg_path)
+    _atomic_write(cfg_path, json.dumps(data, indent=2) + "\n")
+    _ok(f"{label}: wrote {top_key}.{server_name} to {cfg_path} "
+        f"(backup: {backup.name if backup else 'none'})")
+    return {"path": cfg_path, "backup": backup, "changed": True}
+
+
+def install_cursor(*, server_name: str = "gpt2agent", dry_run: bool = False,
+                   config_path: Path | None = None) -> dict[str, Any]:
+    """Register gpt2agent in Cursor's ``~/.cursor/mcp.json`` (``mcpServers``)."""
+    cfg = config_path or Path.home() / ".cursor" / "mcp.json"
+    return _install_json_host("cursor", cfg, top_key="mcpServers", entry=_mcp_entry(),
+                              server_name=server_name, dry_run=dry_run)
+
+
+def install_windsurf(*, server_name: str = "gpt2agent", dry_run: bool = False,
+                     config_path: Path | None = None) -> dict[str, Any]:
+    """Register gpt2agent in Windsurf's ``~/.codeium/windsurf/mcp_config.json``."""
+    cfg = config_path or Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+    return _install_json_host("windsurf", cfg, top_key="mcpServers", entry=_mcp_entry(),
+                              server_name=server_name, dry_run=dry_run)
+
+
+def install_claude_desktop(*, server_name: str = "gpt2agent", dry_run: bool = False,
+                           config_path: Path | None = None) -> dict[str, Any]:
+    """Register gpt2agent in the Claude Desktop config (``mcpServers``)."""
+    cfg = config_path or _claude_desktop_config_path()
+    return _install_json_host("claude-desktop", cfg, top_key="mcpServers", entry=_mcp_entry(),
+                              server_name=server_name, dry_run=dry_run)
+
+
+def install_zed(*, server_name: str = "gpt2agent", dry_run: bool = False,
+                config_path: Path | None = None) -> dict[str, Any]:
+    """Register gpt2agent in Zed's ``~/.config/zed/settings.json`` (``context_servers``)."""
+    cfg = config_path or Path.home() / ".config" / "zed" / "settings.json"
+    return _install_json_host("zed", cfg, top_key="context_servers", entry=_zed_entry(),
+                              server_name=server_name, dry_run=dry_run)
+
+
+def _claude_desktop_config_path() -> Path:
+    """Platform-specific Claude Desktop config path."""
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "Claude" / "claude_desktop_config.json"
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+# Registry of the JSON hosts beyond claude-code/codex: name → (installer, detect path).
+_EXTRA_HOSTS: dict[str, Any] = {
+    "cursor": (install_cursor, lambda: Path.home() / ".cursor"),
+    "windsurf": (install_windsurf, lambda: Path.home() / ".codeium" / "windsurf"),
+    "claude-desktop": (install_claude_desktop, lambda: _claude_desktop_config_path().parent),
+    "zed": (install_zed, lambda: Path.home() / ".config" / "zed"),
+}
+
+
 # ── Claude Code skill bundle ───────────────────────────────────────────────
 
 
@@ -376,7 +493,14 @@ def detect_clients() -> list[str]:
         detected.append("claude-code")
     if (Path.home() / ".codex").exists():
         detected.append("codex")
+    for name, (_installer, detect) in _EXTRA_HOSTS.items():
+        if detect().exists():
+            detected.append(name)
     return detected
+
+
+# All client names install supports (for --client choices and docs).
+SUPPORTED_CLIENTS = ["claude-code", "codex", *_EXTRA_HOSTS.keys()]
 
 
 # ── top-level entry point ──────────────────────────────────────────────────
@@ -414,6 +538,8 @@ def run_install(
                 )
             elif target == "codex":
                 install_codex(dry_run=dry_run)
+            elif target in _EXTRA_HOSTS:
+                _EXTRA_HOSTS[target][0](dry_run=dry_run)
             else:
                 _err(f"Unknown client: {target}")
                 failures += 1

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -331,7 +331,8 @@ def _install_json_host(
     """Register gpt2agent in a JSON MCP config file under ``top_key.<server>``.
 
     Idempotent; preserves every other field; writes a ``.bak-gpt2agent`` backup.
-    Used for Cursor, Windsurf, Claude Desktop, VS Code, Zed (see callers).
+    Used for Cursor, Windsurf, Claude Desktop, and Zed (see callers). VS Code and
+    Cline use the same shape but are documented as manual setup (docs/clients.md).
     """
     if cfg_path.exists():
         try:

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -163,6 +163,11 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
         When `auto_confirm` is True (default), an imperative prefix is prepended
         so the model proceeds without asking "Do you want me to start?".
+
+        Returns the report text with a Sources section appended. Citations are
+        recovered from the connector's widget state; grouped source URLs are
+        usually present but not guaranteed — if absent, the model may have cited
+        sources inline in the body. Returns "(no response)" on timeout.
         """
         q = _DR_IMPERATIVE_PREFIX + query if auto_confirm else query
         final_text = ""
@@ -210,13 +215,15 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
     @mcp.tool()
     async def gpt_chat(gizmo_id: str, prompt: str) -> str:
-        """Chat through one of your private Custom GPTs (g-p-* IDs).
+        """Chat through one of your private Custom GPTs.
 
-        Use `list_custom_gpts` to enumerate available gizmo IDs and their names.
+        `gizmo_id`: pass the `short_url` returned by `list_custom_gpts` (call it
+        first to discover your Custom GPTs). The gizmo's instructions, files, and
+        memory_scope apply to the reply.
 
         EXPERIMENTAL: passes `gizmo_id` into the conversation payload via the
         `conversation_origin` field reverse-engineered from chatgpt.com web
-        bundles. The gizmo's instructions, files, and memory_scope apply.
+        bundles. Returns "(no response)" on timeout.
         """
         text = await conv.complete(
             chat_model,
@@ -261,9 +268,14 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
 
 def main() -> None:
+    from gpt2agent import __version__
+
     parser = argparse.ArgumentParser(
         prog="gpt2agent",
         description="Use your ChatGPT Plus/Pro in Claude Code and other AI agents.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"gpt2agent {__version__}"
     )
     sub = parser.add_subparsers(dest="command")
 

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -283,15 +283,18 @@ def main() -> None:
     sub.add_parser("setup", help="First-time setup wizard (login + register)")
 
     # install subcommand — register gpt2agent with one or more MCP clients
+    from gpt2agent.install import SUPPORTED_CLIENTS
+
     install_p = sub.add_parser(
         "install",
-        help="Register gpt2agent with an MCP client (claude-code, codex, all)",
+        help="Register gpt2agent with an MCP client (or 'all' to auto-detect)",
     )
     install_p.add_argument(
         "--client",
-        choices=["claude-code", "codex", "all"],
+        choices=[*SUPPORTED_CLIENTS, "all"],
         default="all",
-        help="Target MCP client (default: auto-detect installed clients)",
+        help="Target MCP client: " + ", ".join(SUPPORTED_CLIENTS) + ", or all "
+        "(default: auto-detect installed clients)",
     )
     install_p.add_argument(
         "--transport",

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -186,7 +186,13 @@ def run_setup() -> None:
         write_mcp_config(plan)
         from gpt2agent.install import run_install
 
-        run_install(client="all", transport="stdio")
+        rc = run_install(client="all", transport="stdio")
+        if rc != 0:
+            print()
+            print(f"{RED}  Token saved, but client registration did not fully "
+                  f"succeed (see messages above).{RESET}")
+            print("  Fix the reported client(s) and re-run:  gpt2agent install")
+            sys.exit(rc)
         print_summary(plan)
 
     except KeyboardInterrupt:

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-import platform
-import shutil
-import subprocess
 import sys
-import time
 import webbrowser
 from pathlib import Path
 
@@ -151,104 +147,6 @@ chat = "{chat_model}"
     MCP_CONFIG_PATH.write_text(cfg)
 
 
-def _port_open(port: int) -> bool:
-    import socket
-
-    try:
-        with socket.create_connection(("127.0.0.1", port), timeout=1):
-            return True
-    except OSError:
-        return False
-
-
-def ensure_mcp_server() -> None:
-    h1("Step 2 — Start MCP server")
-
-    if _port_open(MCP_PORT):
-        ok(f"MCP server already running on :{MCP_PORT}")
-        return
-
-    log = open(Path.home() / ".gpt2agent" / "mcp.log", "w")
-    subprocess.Popen(
-        [sys.executable, "-m", "gpt2agent.server", "--config", str(MCP_CONFIG_PATH)],
-        stdout=log,
-        stderr=log,
-        start_new_session=True,
-    )
-
-    for _ in range(15):
-        if _port_open(MCP_PORT):
-            ok(f"MCP server started on :{MCP_PORT}")
-            return
-        time.sleep(1)
-
-    raise SystemExit("MCP server failed to start. Check ~/.gpt2agent/mcp.log")
-
-
-def ensure_launchagent() -> None:
-    """Install macOS LaunchAgent for persistence."""
-    if platform.system() != "Darwin":
-        return
-
-    label = "com.user.gpt2agent"
-    plist = Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
-    binary = shutil.which("gpt2agent") or sys.executable
-
-    cmd = (
-        f"        <string>{binary}</string>\n"
-        f"        <string>--config</string>\n"
-        f"        <string>{MCP_CONFIG_PATH}</string>"
-    )
-
-    plist.write_text(f"""<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-    <key>Label</key><string>{label}</string>
-    <key>ProgramArguments</key><array>
-{cmd}
-    </array>
-    <key>RunAtLoad</key><true/>
-    <key>KeepAlive</key><true/>
-    <key>StandardOutPath</key><string>{Path.home()}/.gpt2agent/mcp.log</string>
-    <key>StandardErrorPath</key><string>{Path.home()}/.gpt2agent/mcp.log</string>
-</dict></plist>""")
-
-    subprocess.run(["launchctl", "unload", str(plist)], capture_output=True)
-    subprocess.run(["launchctl", "load", str(plist)], capture_output=True)
-
-
-# ── agent CLI registration ───────────────────────────────────────────────────
-
-
-def register_claude_code() -> bool:
-    claude_json = Path.home() / ".claude.json"
-    if not shutil.which("claude") and not claude_json.exists():
-        return False
-
-    try:
-        data = json.loads(claude_json.read_text()) if claude_json.exists() else {}
-    except Exception:
-        data = {}
-
-    data.setdefault("mcpServers", {})
-    data["mcpServers"]["openai"] = {
-        "type": "url",
-        "url": f"http://localhost:{MCP_PORT}/mcp",
-    }
-    claude_json.write_text(json.dumps(data, indent=2))
-    return True
-
-
-def register_agents() -> None:
-    h1("Step 3 — Register with agent CLIs")
-
-    if register_claude_code():
-        ok("Claude Code → ~/.claude.json updated")
-        info("Restart Claude Code to activate tools")
-    else:
-        info("Claude Code not found (skipped)")
-
-
 # ── final summary ────────────────────────────────────────────────────────────
 
 
@@ -258,18 +156,11 @@ def print_summary(plan: str) -> None:
     print(f"{GREEN}{BOLD}  Done!{RESET}  ChatGPT {plan.capitalize()} is ready.")
     print(f"{'─' * 50}")
     print()
-    print(f"  Plan:   ChatGPT {plan.capitalize()}")
-    print(f"  URL:    http://localhost:{MCP_PORT}/mcp")
+    print(f"  Plan:      ChatGPT {plan.capitalize()}")
+    print("  Transport: stdio (local subprocess; not network-exposed)")
     print()
-    print("  Tools available in your agent:")
-    print("    chat, deep_research, deep_research_heavy")
-    print("    account_status, list_models")
-    print("    memory_list, memory_search, custom_instructions_get")
-    print("    custom_instructions_set, codex_task_create")
-    print("    list_codex_envs, list_codex_tasks")
-    print("    list_custom_gpts, list_conversations, list_tasks, list_apps")
-    print()
-    print("  Logs:   ~/.gpt2agent/mcp.log")
+    print("  Restart your MCP client (Claude Code / Cursor / …) to load the tools.")
+    print("  Then try the `account_status` or `chat` tool from your agent.")
     print()
 
 
@@ -288,13 +179,14 @@ def run_setup() -> None:
         plan = detect_plan()
         ok(f"ChatGPT {plan.capitalize()} detected")
 
+        # Persist a model default, then register over stdio — the same safe path
+        # as `gpt2agent install`. (No background HTTP daemon / LaunchAgent / legacy
+        # `openai` URL entry: the stdio transport is what every MCP client wants and
+        # avoids exposing an unauthenticated account proxy.)
         write_mcp_config(plan)
-        ensure_mcp_server()
-        if platform.system() == "Darwin":
-            ensure_launchagent()
-            ok("Auto-start enabled (LaunchAgent)")
+        from gpt2agent.install import run_install
 
-        register_agents()
+        run_install(client="all", transport="stdio")
         print_summary(plan)
 
     except KeyboardInterrupt:

--- a/gpt2agent/skills/gpt2agent/SKILL.md
+++ b/gpt2agent/skills/gpt2agent/SKILL.md
@@ -143,7 +143,7 @@ Config file locations (checked in order):
 Key settings:
 ```toml
 [server]
-host = "0.0.0.0"
+host = "127.0.0.1"   # loopback only; HTTP transport is unauthenticated
 port = 9000
 
 [models]

--- a/gpt2agent/tools/account.py
+++ b/gpt2agent/tools/account.py
@@ -7,7 +7,12 @@ from gpt2agent.tools._redact import redact
 def register(mcp, client: BackendClient) -> None:
     @mcp.tool()
     def account_status() -> dict:
-        """Return ChatGPT account info: subscription plan, features, and model list."""
+        """Return ChatGPT account info.
+
+        Returns a dict with: `email` (redacted), `country`, `groups`,
+        `subscription` (plan slug, e.g. "plus"/"pro"/None), `has_active_subscription`,
+        `expires_at`, and `features_count` (number of entitled features).
+        """
         me = client.get("/backend-api/me", target_path="/backend-api/me")
         check = client.get(
             "/backend-api/accounts/check/v4-2023-04-27",
@@ -28,7 +33,13 @@ def register(mcp, client: BackendClient) -> None:
 
     @mcp.tool()
     def list_models() -> list:
-        """Return all available ChatGPT models with full metadata."""
+        """List the models available on your account.
+
+        Returns a list of model dicts; the `slug` field of each (e.g.
+        "gpt-5-5-pro", "o3-pro") is exactly what you pass as `model=` to the
+        `chat` tool. Other keys: title, description, max_tokens, reasoning_type,
+        capabilities, enabled_tools.
+        """
         data = client.get(
             "/backend-api/models?history_and_training_disabled=false",
             target_path="/backend-api/models",

--- a/gpt2agent/tools/gpts.py
+++ b/gpt2agent/tools/gpts.py
@@ -7,7 +7,12 @@ from gpt2agent.tools._redact import redact
 def register(mcp, client: BackendClient) -> None:
     @mcp.tool()
     def list_custom_gpts() -> list:
-        """Return private custom GPTs from the ChatGPT sidebar."""
+        """List your private Custom GPTs from the ChatGPT sidebar.
+
+        Returns a list of ``{"name", "short_url"}``. Pass a returned
+        ``short_url`` as the ``gizmo_id`` argument of ``gpt_chat`` to talk to
+        that Custom GPT.
+        """
         data = client.get(
             "/backend-api/gizmos/snorlax/sidebar",
             target_path="/backend-api/gizmos/snorlax/sidebar",

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ while [[ $# -gt 0 ]]; do
     --no-register)  REGISTER=0; shift ;;
     --source)       SOURCE="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) err "Unknown option: $1"; exit 2 ;;
@@ -70,7 +70,9 @@ ok "Python: $($PYTHON --version) ($(command -v "$PYTHON"))"
 
 if ! command -v pipx >/dev/null 2>&1; then
   info "pipx not found; installing via $PYTHON -m pip install --user pipx"
-  "$PYTHON" -m pip install --user --quiet pipx
+  # `|| true` so a PEP-668 'externally-managed-environment' failure (Ubuntu/
+  # Debian/Fedora) doesn't abort under `set -e` before the fallback hint below.
+  "$PYTHON" -m pip install --user --quiet pipx || true
   "$PYTHON" -m pipx ensurepath >/dev/null 2>&1 || true
   # Refresh PATH for this shell so the next call finds pipx.
   case ":$PATH:" in
@@ -80,7 +82,11 @@ if ! command -v pipx >/dev/null 2>&1; then
 fi
 
 if ! command -v pipx >/dev/null 2>&1; then
-  err "pipx still not on PATH. Open a new shell (PATH refresh) and re-run, or install pipx manually."
+  err "pipx still not on PATH. Install it via your distro and re-run:"
+  err "  Debian/Ubuntu:  sudo apt install pipx && pipx ensurepath"
+  err "  Fedora:         sudo dnf install pipx && pipx ensurepath"
+  err "  macOS:          brew install pipx && pipx ensurepath"
+  err "  other:          python3 -m pip install --user pipx   (then open a new shell)"
   exit 1
 fi
 ok "pipx: $(pipx --version 2>/dev/null || echo present)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,20 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE", "NOTICES.md"]
 requires-python = ">=3.10"
-keywords = ["mcp", "chatgpt", "claude", "openai", "agent", "llm"]
+keywords = ["mcp", "model-context-protocol", "chatgpt", "claude", "openai", "codex", "agent", "llm", "deep-research"]
+authors = [{ name = "robotlearning123" }]
+maintainers = [{ name = "robotlearning123" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
     "mcp>=1.26.0",
@@ -24,7 +33,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-asyncio>=0.21"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "ruff>=0.6"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+# Default rule set (E/F) — matches the `ruff check` the CI/PR checklist expects.
 
 [project.scripts]
 gpt2agent = "gpt2agent.server:main"
@@ -46,5 +60,6 @@ gpt2agent = [
 [project.urls]
 Homepage = "https://github.com/robotlearning123/gpt2agent"
 Repository = "https://github.com/robotlearning123/gpt2agent"
+Documentation = "https://github.com/robotlearning123/gpt2agent#readme"
 Changelog = "https://github.com/robotlearning123/gpt2agent/blob/main/CHANGELOG.md"
 Issues = "https://github.com/robotlearning123/gpt2agent/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.5"
+version = "0.0.6"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,11 +13,15 @@ from pathlib import Path
 import pytest
 
 from gpt2agent.install import (
+    SUPPORTED_CLIENTS,
     _replace_or_append_toml_section,
     detect_clients,
     install_claude_code,
     install_claude_skill,
     install_codex,
+    install_cursor,
+    install_windsurf,
+    install_zed,
 )
 
 
@@ -333,3 +337,71 @@ def test_detect_clients_with_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     detected = detect_clients()
     assert "claude-code" in detected
     assert "codex" in detected
+
+
+# ── Other MCP hosts (Cursor / Windsurf / Zed) ───────────────────────────────
+
+
+def test_cursor_new_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "cursor.json"
+    install_cursor(config_path=cfg)
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["gpt2agent"] == {
+        "command": "gpt2agent",
+        "args": ["run", "--stdio"],
+    }
+
+
+def test_cursor_preserves_other_servers(tmp_path: Path) -> None:
+    cfg = tmp_path / "cursor.json"
+    cfg.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}, "misc": 1}))
+    install_cursor(config_path=cfg)
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["other"] == {"command": "x"}
+    assert data["misc"] == 1
+    assert "gpt2agent" in data["mcpServers"]
+
+
+def test_cursor_idempotent_and_backup(tmp_path: Path) -> None:
+    cfg = tmp_path / "cursor.json"
+    install_cursor(config_path=cfg)
+    r2 = install_cursor(config_path=cfg)
+    assert r2["changed"] is False
+    # second run over an existing file would have produced a backup on change;
+    # here it's a no-op so no backup is created
+    assert r2["backup"] is None
+
+
+def test_windsurf_new_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "mcp_config.json"
+    install_windsurf(config_path=cfg)
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["gpt2agent"]["args"] == ["run", "--stdio"]
+
+
+def test_zed_uses_context_servers_with_nested_command(tmp_path: Path) -> None:
+    cfg = tmp_path / "settings.json"
+    install_zed(config_path=cfg)
+    data = json.loads(cfg.read_text())
+    entry = data["context_servers"]["gpt2agent"]
+    assert entry["command"] == {"path": "gpt2agent", "args": ["run", "--stdio"]}
+    assert entry["settings"] == {}
+    assert "mcpServers" not in data
+
+
+def test_json_host_rejects_broken_json(tmp_path: Path) -> None:
+    cfg = tmp_path / "cursor.json"
+    cfg.write_text("{not valid json")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        install_cursor(config_path=cfg)
+
+
+def test_json_host_dry_run_no_write(tmp_path: Path) -> None:
+    cfg = tmp_path / "cursor.json"
+    install_cursor(config_path=cfg, dry_run=True)
+    assert not cfg.exists()
+
+
+def test_supported_clients_lists_all_hosts() -> None:
+    for name in ("claude-code", "codex", "cursor", "windsurf", "claude-desktop", "zed"):
+        assert name in SUPPORTED_CLIENTS

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from gpt2agent.tools import account, apps, codex, conversations, gpts, images
-from gpt2agent.tools import instructions, memory, writes
+from gpt2agent.tools import instructions, memory, tools_features, writes
 from gpt2agent.tools._redact import redact
 
 
@@ -59,11 +59,28 @@ class FakeClient:
 
 def _reg(module, client: FakeClient, conv: Any = None) -> FakeMCP:
     mcp = FakeMCP()
-    if module in (images,):
+    if module in (images, tools_features):
         module.register(mcp, client, conv)
     else:
         module.register(mcp, client)
     return mcp
+
+
+class _ToolConv:
+    """Records ConversationClient.tool_call / image_gen calls for the SSE-backed tools."""
+
+    def __init__(self) -> None:
+        self.tool_calls: list[dict] = []
+        self.image_gen_calls: list[dict] = []
+
+    async def tool_call(self, prompt, *, model="gpt-5-3", temporary=True):
+        self.tool_calls.append({"prompt": prompt, "model": model, "temporary": temporary})
+        return {"conversation_id": "c", "text": "ran", "tool_calls": [], "tool_responses": []}
+
+    async def image_gen(self, prompt, *, model="gpt-5-3"):
+        self.image_gen_calls.append({"prompt": prompt, "model": model})
+        return {"conversation_id": "c", "assets": [
+            {"file_id": "f1", "asset_pointer": "sediment://file-1", "width": 4, "height": 2}]}
 
 
 # --------------------------------------------------------------------------- #
@@ -323,6 +340,39 @@ def test_custom_instructions_set_preserves_unsupplied_fields() -> None:
     assert payload["enabled"] is True
     assert payload["disabled_tools"] == ["t"]
     assert payload["about_model_message"] == "new"  # overridden
+
+
+# --------------------------------------------------------------------------- #
+#  tools/tools_features + images.generate_image (SSE-backed; temporary=False)
+# --------------------------------------------------------------------------- #
+
+
+def test_code_interpreter_runs_temporary_false() -> None:
+    conv = _ToolConv()
+    fn = _reg(tools_features, FakeClient(), conv).tools["code_interpreter"]
+    out = asyncio.run(fn("print(1)"))
+    assert conv.tool_calls[-1]["temporary"] is False
+    assert conv.tool_calls[-1]["prompt"] == "print(1)"
+    assert out["text"] == "ran"
+
+
+def test_canvas_execute_temporary_false_and_prefixes_prompt() -> None:
+    conv = _ToolConv()
+    fn = _reg(tools_features, FakeClient(), conv).tools["canvas_execute"]
+    asyncio.run(fn("make a chart"))
+    assert conv.tool_calls[-1]["temporary"] is False
+    assert conv.tool_calls[-1]["prompt"].startswith("Use Canvas to:")
+
+
+def test_generate_image_enriches_assets_with_download_url() -> None:
+    conv = _ToolConv()
+    client = FakeClient(routes={
+        "/backend-api/files/f1/download": {"download_url": "https://dl/img", "file_name": "img.png"},
+        "/backend-api/files/f1": {"name": "img.png"}})
+    fn = _reg(images, client, conv).tools["generate_image"]
+    out = asyncio.run(fn("a cat"))
+    assert conv.image_gen_calls[-1]["prompt"] == "a cat"
+    assert out["assets"][0]["download_url"] == "https://dl/img"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,439 @@
+"""Unit tests for the MCP tool layer — no network.
+
+Round-2 coverage: the 25-tool handler surface (the product's actual value) had
+zero direct unit tests. These exercise every `tools/*.py` handler through its
+real `register(mcp, client, conv=None)` signature using a recording FakeMCP +
+FakeClient, and the server.py SSE closures via FastMCP's tool manager with a
+FakeConv. Invariants under test: PII redaction fires at each boundary, payload
+shapes, and the `temporary=False` rule from CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from gpt2agent.tools import account, apps, codex, conversations, gpts, images
+from gpt2agent.tools import instructions, memory, writes
+from gpt2agent.tools._redact import redact
+
+
+class FakeMCP:
+    """Captures @mcp.tool()-decorated functions by name (decorator returns fn unchanged)."""
+
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, *a: Any, **k: Any):
+        def deco(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return deco
+
+
+class FakeClient:
+    """Canned GET responses (prefix-matched) + recorded POSTs."""
+
+    def __init__(self, routes: dict | None = None, posts: dict | None = None) -> None:
+        self.routes = routes or {}
+        self.posts = posts or {}
+        self.posted: list[tuple[str, Any]] = []
+        self.gets: list[str] = []
+
+    def get(self, path: str, target_path: str | None = None, **k: Any) -> Any:
+        self.gets.append(path)
+        for pat, val in self.routes.items():
+            if path == pat or path.startswith(pat):
+                return val
+        return {}
+
+    def post(self, path: str, json: Any = None, target_path: str | None = None, **k: Any) -> Any:
+        self.posted.append((path, json))
+        h = self.posts.get(path)
+        if callable(h):
+            return h(json)
+        return h if h is not None else {}
+
+
+def _reg(module, client: FakeClient, conv: Any = None) -> FakeMCP:
+    mcp = FakeMCP()
+    if module in (images,):
+        module.register(mcp, client, conv)
+    else:
+        module.register(mcp, client)
+    return mcp
+
+
+# --------------------------------------------------------------------------- #
+#  tools/_redact
+# --------------------------------------------------------------------------- #
+
+
+def test_redact_strips_email_and_phone() -> None:
+    assert "<EMAIL>" in redact("mail me at a.b+c@example.co.uk")
+    assert "@" not in redact("a@b.com")
+    assert "<PHONE>" in redact("call +1 (415) 555-1212 now")
+    assert redact(123) == 123  # non-str passthrough
+    assert redact("plain text, nothing here") == "plain text, nothing here"
+
+
+# --------------------------------------------------------------------------- #
+#  tools/account
+# --------------------------------------------------------------------------- #
+
+
+def test_account_status_redacts_email_and_counts_features() -> None:
+    client = FakeClient(routes={
+        "/backend-api/me": {"email": "user@example.com", "country": "US", "groups": ["g"]},
+        "/backend-api/accounts/check": {
+            "accounts": {"a1": {
+                "entitlement": {"subscription_plan": "plus", "has_active_subscription": True,
+                                "expires_at": "2026"},
+                "features": ["a", "b", "c"]}}},
+    })
+    out = _reg(account, client).tools["account_status"]()
+    assert out["email"] == "<EMAIL>"
+    assert out["subscription"] == "plus"
+    assert out["has_active_subscription"] is True
+    assert out["features_count"] == 3
+
+
+def test_account_status_empty_accounts_no_crash() -> None:
+    client = FakeClient(routes={
+        "/backend-api/me": {"email": "x@y.com"},
+        "/backend-api/accounts/check": {"accounts": {}},
+    })
+    out = _reg(account, client).tools["account_status"]()
+    assert out["features_count"] == 0
+    assert out["subscription"] is None
+
+
+def test_list_models_exposes_slug() -> None:
+    client = FakeClient(routes={"/backend-api/models": {"models": [
+        {"slug": "gpt-5-5-pro", "title": "Pro", "max_tokens": 410000}]}})
+    out = _reg(account, client).tools["list_models"]()
+    assert out[0]["slug"] == "gpt-5-5-pro"
+
+
+# --------------------------------------------------------------------------- #
+#  tools/memory
+# --------------------------------------------------------------------------- #
+
+
+def test_memory_list_and_search_redact_and_filter() -> None:
+    client = FakeClient(routes={"/backend-api/memories": {"memories": [
+        {"id": "m1", "content": "reach jane@doe.com", "created_timestamp": 1},
+        {"id": "m2", "content": "weather note", "created_timestamp": 2}]}})
+    mcp = _reg(memory, client)
+    listed = mcp.tools["memory_list"]()
+    assert len(listed) == 2
+    assert "<EMAIL>" in listed[0]["content"]
+    hits = mcp.tools["memory_search"]("WEATHER")  # case-insensitive
+    assert [m["id"] for m in hits] == ["m2"]
+    assert mcp.tools["memory_search"]("zzz") == []
+
+
+# --------------------------------------------------------------------------- #
+#  tools/instructions
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_instructions_get_redacts_both_fields() -> None:
+    client = FakeClient(routes={"/backend-api/user_system_messages": {
+        "enabled": True, "traits_enabled": False, "personality_type_selection": "CHILL",
+        "about_user_message": "I am bob@corp.io", "about_model_message": "be terse"}})
+    out = _reg(instructions, client).tools["custom_instructions_get"]()
+    assert out["about_user"] == "I am <EMAIL>"  # only the email substring is masked
+    assert "bob@corp.io" not in out["about_user"]
+    assert out["about_model"] == "be terse"
+    assert out["personality_type"] == "CHILL"
+    assert out["enabled"] is True
+
+
+# --------------------------------------------------------------------------- #
+#  tools/conversations
+# --------------------------------------------------------------------------- #
+
+
+def test_list_conversations_redacts_title() -> None:
+    client = FakeClient(routes={"/backend-api/conversations": {"items": [
+        {"id": "c1", "title": "ping admin@site.com", "update_time": 1}]}})
+    out = _reg(conversations, client).tools["list_conversations"]()
+    assert out[0]["id"] == "c1"
+    assert "<EMAIL>" in out[0]["title"]
+
+
+def test_list_tasks_redacts_and_bool_coerces_and_slices() -> None:
+    items = [{"task_id": f"t{i}", "title": "see ceo@x.com", "prompt": "call 415-555-0000",
+              "image_gen_message": {"foo": 1}} for i in range(25)]
+    client = FakeClient(routes={"/backend-api/tasks": {"tasks": items}})
+    out = _reg(conversations, client).tools["list_tasks"](limit=10)
+    assert len(out) == 10
+    assert "<EMAIL>" in out[0]["title"]
+    assert "<PHONE>" in out[0]["prompt"]
+    assert out[0]["image_gen_message"] is True  # dict -> bool coercion
+
+
+def test_get_conversation_filters_roles_truncates_and_extracts_images() -> None:
+    mapping = {
+        "n0": {"message": {"id": "s", "author": {"role": "system"},
+                           "content": {"content_type": "text", "parts": ["sys"]}}},
+        "n1": {"message": {"id": "u", "author": {"role": "user"},
+                           "content": {"content_type": "text", "parts": ["x" * 3000]}}},
+        "n2": {"message": {"id": "a", "author": {"role": "assistant"},
+                           "content": {"content_type": "code", "parts": ["y" * 900]}}},
+        "n3": {"message": {"id": "m", "author": {"role": "assistant"},
+                           "content": {"content_type": "multimodal_text", "parts": [
+                               {"content_type": "image_asset_pointer",
+                                "asset_pointer": "sediment://file-1", "width": 4, "height": 2}]}}},
+    }
+    client = FakeClient(routes={"/backend-api/conversation/C1": {"id": "C1", "title": "t",
+                                                                 "mapping": mapping}})
+    out = _reg(conversations, client).tools["get_conversation"]("C1")
+    roles = {m["role"] for m in out["messages"]}
+    assert "system" not in roles  # filtered
+    by_id = {m["id"]: m for m in out["messages"]}
+    assert len(by_id["u"]["text"]) == 2000  # text truncation
+    assert len(by_id["a"]["code"]) == 500   # code truncation
+    assert by_id["m"]["images"][0]["asset_pointer"] == "sediment://file-1"
+
+
+def test_get_conversation_empty_returns_empty_dict() -> None:
+    client = FakeClient(routes={"/backend-api/conversation/X": {}})
+    assert _reg(conversations, client).tools["get_conversation"]("X") == {}
+
+
+# --------------------------------------------------------------------------- #
+#  tools/gpts, apps, codex
+# --------------------------------------------------------------------------- #
+
+
+def test_list_custom_gpts_redacts_name_keeps_short_url() -> None:
+    client = FakeClient(routes={"/backend-api/gizmos/snorlax/sidebar": {"items": [
+        {"gizmo": {"name": "reach ops@gpt.io", "short_url": "g/x"}}]}})
+    out = _reg(gpts, client).tools["list_custom_gpts"]()
+    assert "<EMAIL>" in out[0]["name"]
+    assert out[0]["short_url"] == "g/x"
+
+
+def test_apps_classify() -> None:
+    assert apps._classify("connector_x") == "official_connector"
+    assert apps._classify("asdk_app_42") == "third_party_sdk"
+    assert apps._classify("weird") == "unknown"
+    assert apps._classify("") == "unknown"
+
+
+def test_list_apps_filters_nondict_and_connected_fallback() -> None:
+    client = FakeClient(routes={"/backend-api/apps/list": {"apps": [
+        {"id": "connector_a", "enabled": True, "is_connected": True},
+        {"id": "asdk_app_b", "connected": False},
+        "not-a-dict"]}})
+    out = _reg(apps, client).tools["list_apps"]()
+    assert len(out) == 2  # string filtered out
+    assert out[0]["type"] == "official_connector"
+    assert out[1]["connected"] is False  # `connected` fallback used
+
+
+def test_list_codex_envs_repo_count_and_envelope() -> None:
+    # list envelope
+    c1 = FakeClient(routes={"/backend-api/codex/environments": [{"id": "e1", "label": "a/b",
+                                                                 "repos": ["r1", "r2"]}]})
+    out1 = _reg(codex, c1).tools["list_codex_envs"]()
+    assert out1[0]["repo_count"] == 2 and out1[0]["label"] == "a/b"
+    # dict envelope
+    c2 = FakeClient(routes={"/backend-api/codex/environments": {"environments": [
+        {"id": "e2", "repos": []}]}})
+    assert _reg(codex, c2).tools["list_codex_envs"]()[0]["repo_count"] == 0
+
+
+def test_list_codex_tasks_unwraps_redacts_and_truncates() -> None:
+    items = [{"task": {"id": "t1", "title": "a@b.com"}, "turn": {"turn_status": "done"}},
+             {"id": "t2", "title": "plain"}]
+    client = FakeClient(routes={"/backend-api/codex/tasks": {"items": items}})
+    out = _reg(codex, client).tools["list_codex_tasks"](limit=1)
+    assert len(out) == 1  # truncated to limit
+    assert out[0]["id"] == "t1"
+    assert "<EMAIL>" in out[0]["title"]
+    assert out[0]["status"] == "done"
+
+
+# --------------------------------------------------------------------------- #
+#  tools/images (sync passthroughs)
+# --------------------------------------------------------------------------- #
+
+
+def test_get_file_info_and_download_url() -> None:
+    client = FakeClient(routes={
+        "/backend-api/files/f1/download": {"download_url": "https://dl/x"},
+        "/backend-api/files/f1": {"id": "f1", "name": "img.png"}})
+    mcp = _reg(images, client, conv=object())
+    assert mcp.tools["get_file_info"]("f1")["name"] == "img.png"
+    assert mcp.tools["get_file_download_url"]("f1") == "https://dl/x"
+    # missing download_url -> ""
+    c2 = FakeClient(routes={"/backend-api/files/f2/download": {}})
+    assert _reg(images, c2, conv=object()).tools["get_file_download_url"]("f2") == ""
+
+
+# --------------------------------------------------------------------------- #
+#  tools/writes
+# --------------------------------------------------------------------------- #
+
+
+def test_codex_task_create_raises_on_missing_label() -> None:
+    client = FakeClient(routes={"/backend-api/codex/environments": {"environments": [
+        {"id": "e1", "label": "a/b"}]}})
+    fn = _reg(writes, client).tools["codex_task_create"]
+    with pytest.raises(ValueError, match="No Codex environment"):
+        fn(repo_label="nope/x", prompt="hi")
+
+
+def test_codex_task_create_raises_on_ambiguous_label() -> None:
+    client = FakeClient(routes={"/backend-api/codex/environments": {"environments": [
+        {"id": "e1", "label": "a/b"}, {"id": "e2", "label": "a/b"}]}})
+    fn = _reg(writes, client).tools["codex_task_create"]
+    with pytest.raises(ValueError, match="Ambiguous"):
+        fn(repo_label="a/b", prompt="hi")
+
+
+def test_codex_task_create_builds_payload_shape() -> None:
+    client = FakeClient(posts={"/backend-api/codex/tasks": {"ok": True}})
+    fn = _reg(writes, client).tools["codex_task_create"]
+    fn(repo_label="ignored", prompt="do it", environment_id="envXYZ", branch="dev")
+    path, payload = client.posted[-1]
+    assert path == "/backend-api/codex/tasks"
+    assert payload == {
+        "new_task": {"environment_id": "envXYZ", "branch": "dev"},
+        "input_items": [{"type": "message", "role": "user",
+                         "content": [{"content_type": "text", "text": "do it"}]}]}
+    # env supplied -> no environments GET
+    assert all("environments" not in g for g in client.gets)
+
+
+def test_custom_instructions_set_preserves_unsupplied_fields() -> None:
+    current = {"enabled": True, "about_user_message": "keep me",
+               "about_model_message": "old", "traits_enabled": False, "disabled_tools": ["t"]}
+    client = FakeClient(routes={"/backend-api/user_system_messages": current},
+                        posts={"/backend-api/user_system_messages": lambda p: p})
+    fn = _reg(writes, client).tools["custom_instructions_set"]
+    fn(about_model="new")
+    _, payload = client.posted[-1]
+    assert payload["about_user_message"] == "keep me"  # preserved
+    assert payload["enabled"] is True
+    assert payload["disabled_tools"] == ["t"]
+    assert payload["about_model_message"] == "new"  # overridden
+
+
+# --------------------------------------------------------------------------- #
+#  server.py SSE handlers (temporary-flag + prompt invariants)
+# --------------------------------------------------------------------------- #
+
+
+class _RecordConv:
+    def __init__(self) -> None:
+        self.complete_calls: list[dict] = []
+        self.reply = "ok"
+        self.dr_events: list[dict] = []
+        self.heavy_events: list[dict] = []
+
+    async def complete(self, model, messages, *, temporary=True, gizmo_id=None):
+        self.complete_calls.append({"model": model, "messages": messages,
+                                    "temporary": temporary, "gizmo_id": gizmo_id})
+        return self.reply
+
+    def deep_research(self, q):
+        self._last_dr_query = q
+        async def gen():
+            for e in self.dr_events:
+                yield e
+        return gen()
+
+    def deep_research_heavy(self, q, model=None):
+        self._last_heavy_query = q
+        async def gen():
+            for e in self.heavy_events:
+                yield e
+        return gen()
+
+
+def _build_with_conv(monkeypatch, conv):
+    import gpt2agent.backend as backend_mod
+    import gpt2agent.sse as sse_mod
+    from gpt2agent.server import build_server
+
+    monkeypatch.setattr(backend_mod, "BackendClient", lambda *a, **k: object())
+    monkeypatch.setattr(sse_mod, "ConversationClient", lambda *a, **k: conv)
+    mcp = build_server({"server": {"host": "127.0.0.1", "port": 9000},
+                        "models": {"chat": "gpt-5-3", "agent": "agent-mode"}})
+    return mcp._tool_manager._tools
+
+
+def test_agent_always_temporary_false(monkeypatch) -> None:
+    conv = _RecordConv()
+    tools = _build_with_conv(monkeypatch, conv)
+    asyncio.run(tools["agent"].fn("do stuff"))
+    assert conv.complete_calls[-1]["temporary"] is False
+    assert conv.complete_calls[-1]["model"] == "agent-mode"
+
+
+def test_gpt_chat_temporary_false_and_passes_gizmo(monkeypatch) -> None:
+    conv = _RecordConv()
+    tools = _build_with_conv(monkeypatch, conv)
+    asyncio.run(tools["gpt_chat"].fn("g/abc", "hello"))
+    call = conv.complete_calls[-1]
+    assert call["temporary"] is False
+    assert call["gizmo_id"] == "g/abc"
+
+
+def test_memory_create_via_chat_temporary_false_and_wraps_prompt(monkeypatch) -> None:
+    conv = _RecordConv()
+    tools = _build_with_conv(monkeypatch, conv)
+    asyncio.run(tools["memory_create_via_chat"].fn("SECRET-XYZ"))
+    call = conv.complete_calls[-1]
+    assert call["temporary"] is False
+    sent = call["messages"][0]["content"]
+    assert sent.startswith("Please commit the following to memory verbatim")
+    assert sent.endswith("SECRET-XYZ")
+
+
+def test_chat_forwards_temporary_and_no_response_fallback(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.reply = ""  # empty -> "(no response)"
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["chat"].fn("hi", "gpt-5-3", False))
+    assert conv.complete_calls[-1]["temporary"] is False
+    assert out == "(no response)"
+
+
+def test_deep_research_imperative_prefix_toggle(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.dr_events = [{"type": "done", "text": "R", "content_references": []}]
+    tools = _build_with_conv(monkeypatch, conv)
+    asyncio.run(tools["deep_research"].fn("topic", True))
+    assert conv._last_dr_query.startswith("Begin the deep research immediately")
+    asyncio.run(tools["deep_research"].fn("topic", False))
+    assert conv._last_dr_query == "topic"
+
+
+def test_deep_research_dedupes_sources(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.dr_events = [{"type": "done", "text": "Body", "content_references": [
+        {"items": [{"url": "https://a", "title": "A"}, {"url": "https://a", "title": "A2"}]},
+        {"items": [{"url": "https://b", "title": "B"}, {"title": "no-url"}]}]}]
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["deep_research"].fn("q", False))
+    assert out.count("https://a") == 1  # deduped
+    assert "https://b" in out
+    assert "no-url" not in out  # missing url dropped
+
+
+def test_deep_research_heavy_appends_connector_warning(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.heavy_events = [{"type": "done", "text": "Body", "content_references": [],
+                          "connector_failed": True},
+                         {"type": "tool_error", "message": "boom line\nsecond"}]
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["deep_research_heavy"].fn("q", False))
+    assert "DR connector unavailable" in out
+    assert "boom line" in out


### PR DESCRIPTION
Round-2 audit (cx + 4× ccz waves, Opus-verified by execution) targeting **adoption quality** — a great drop-in for popular agents, friendly for users. Final cross-model review by **cx (GPT-5.5)** → clean after 3 follow-up fixes (included).

## Agent-friendliness
- **4 more MCP hosts auto-install**: Cursor, Windsurf, Claude Desktop, Zed (shared idempotent JSON registrar; config paths web-verified; stdio reused). `--client` + auto-detect updated.
- **Clearer tool docstrings** agents were misreading: `gpt_chat` ← `short_url` from `list_custom_gpts` (not `g-p-*`); `list_models` names `slug` as the `chat(model=)` input; `account_status`/`deep_research_heavy` document returns + citation caveat.
- `gpt2agent --version` wired.

## User-friendliness & docs
- New `docs/` tree: quickstart, clients, configuration, troubleshooting, FAQ, how-it-works (+ index). README: CI badge, "MCP server" lede, docs links, names both bundled skills, 3rd config path.
- `install.sh` no longer aborts on PEP-668 Linux; help no longer leaks shell lines.
- **`gpt2agent setup` rewritten**: pastes token + registers over **stdio** (like `install`) — no more background HTTP daemon, macOS LaunchAgent, or legacy `mcpServers.openai` HTTP entry. Checks the registration result.

## Tests (was zero on the tool layer)
- New `tests/test_tools.py` (30 hermetic tests): every `tools/*.py` handler + server SSE closures, the PII-redaction and `temporary=False` invariants, payload shapes. +8 install tests for the new hosts. **Suite: 99 passed, 9 skipped (was 61).**

## OSS health / packaging
- `CODE_OF_CONDUCT.md`; ruff in `dev` extra + `[tool.ruff]`; per-version/OS/AI classifiers; authors. Bumped to **0.0.6** + CHANGELOG.

## Verified by execution (not assertion)
- Real MCP `initialize`+`tools/list` over stdio → **25 tools**, correct schemas, `gpt_chat` desc shows the `short_url` fix.
- CLI `install --client cursor/zed` writes correct configs; `--client all` auto-detects them.
- `uv build` → clean 0.0.6 wheel+sdist (both skills bundled).

## Not done (deliberately — needs schema verification, not fabrication)
- A Claude Code **plugin manifest** and **MCP-registry** entries (server.json/smithery.yaml) are high-leverage but their schemas are evolving; left as a follow-up rather than ship an unverified manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` flag to query package version.
  * Support for auto-installing into additional MCP clients (Cursor, Windsurf, Claude Desktop, Zed).
  * XDG-style config paths now recognized in search order.
  * Token auto-reload during long-running operations.

* **Bug Fixes**
  * Corrected host binding configuration in bundled setup.
  * Improved installer robustness on PEP-668-managed environments.

* **Documentation**
  * Added comprehensive user guides: Quickstart, Client setup, Configuration, Troubleshooting, FAQ, and Architecture.
  * Added Code of Conduct.
  * README updated with MCP framing and expanded client support.

* **Tests**
  * Extensive test coverage for tools and installations added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->