### PR TITLE
Claude Code plugin + MCP registry descriptor (schemas verified)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "gpt2agent",
+  "owner": {
+    "name": "robotlearning123",
+    "url": "https://github.com/robotlearning123"
+  },
+  "metadata": {
+    "description": "gpt2agent — your ChatGPT Plus/Pro account as MCP tools for Claude Code."
+  },
+  "plugins": [
+    {
+      "name": "gpt2agent",
+      "source": ".",
+      "description": "ChatGPT Plus/Pro account as 25 MCP tools + the deep-research and gpt2agent skills. Requires `pipx install gpt2agent`.",
+      "author": { "name": "robotlearning123" },
+      "license": "MIT",
+      "keywords": ["mcp", "chatgpt", "openai", "deep-research"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "gpt2agent",
+  "displayName": "gpt2agent",
+  "version": "0.0.6",
+  "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
+  "author": {
+    "name": "robotlearning123",
+    "url": "https://github.com/robotlearning123"
+  },
+  "homepage": "https://github.com/robotlearning123/gpt2agent#readme",
+  "repository": "https://github.com/robotlearning123/gpt2agent",
+  "license": "MIT",
+  "keywords": ["mcp", "chatgpt", "openai", "deep-research", "agent", "llm"],
+  "skills": "./gpt2agent/skills/",
+  "mcpServers": {
+    "gpt2agent": {
+      "command": "gpt2agent",
+      "args": ["run", "--stdio"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ versioning: [SemVer](https://semver.org/).
 
 ## [0.0.6] - 2026-06-18
 
+### Packaging / distribution
+
+- **Claude Code plugin**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`
+  bundle the MCP server + both skills as one `/plugin install gpt2agent@gpt2agent`
+  (after `/plugin marketplace add robotlearning123/gpt2agent`). Validated with
+  `claude plugin validate --strict`. Schemas verified against the official Claude
+  Code plugin docs.
+- **MCP registry descriptor**: `server.json` (schema `2025-12-11`) declares the PyPI
+  package `gpt2agent` as a stdio server for the official MCP registry. Verified
+  against the modelcontextprotocol/registry reference.
+
 ### Added
 
 - **More MCP hosts auto-install.** `gpt2agent install` now registers Cursor,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ versioning: [SemVer](https://semver.org/).
   (after `/plugin marketplace add robotlearning123/gpt2agent`). Validated with
   `claude plugin validate --strict`. Schemas verified against the official Claude
   Code plugin docs.
-- **MCP registry descriptor**: `server.json` (schema `2025-12-11`) declares the PyPI
-  package `gpt2agent` as a stdio server for the official MCP registry. Verified
-  against the modelcontextprotocol/registry reference.
+- **MCP registry descriptor**: `server.json` declares the PyPI package `gpt2agent`
+  as a stdio server (with `run --stdio` packageArguments) for the official MCP
+  registry. Validates against the live `2025-12-11/server.schema.json`. The README
+  carries the `mcp-name` ownership marker. (Registry is in preview; publishing is an
+  owner step via `mcp-publisher`.)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ gpt2agent install --client claude-code   # or: codex, cursor, windsurf, claude-d
 gpt2agent install --transport http --http-port 9000
 ```
 
+### Or as a Claude Code plugin
+
+```text
+/plugin marketplace add robotlearning123/gpt2agent
+/plugin install gpt2agent@gpt2agent
+```
+
+This bundles the MCP server registration + both skills in one step. You still need
+the `gpt2agent` CLI on PATH (`pipx install gpt2agent`) — the plugin wires the server
+(`gpt2agent run --stdio`) and skills, not the Python package itself.
+
 ### Per-client config
 
 The `install` subcommand writes the right thing for each:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gpt2agent
 
+<!-- mcp-name: io.github.robotlearning123/gpt2agent -->
+
 > **MCP server for your ChatGPT account: `codex login` → ChatGPT Plus/Pro inside any MCP client.**
 
 An **MCP server** that puts your **ChatGPT Plus or Pro** subscription — every model

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -49,6 +49,26 @@ Zed nests the command under `context_servers`:
 }
 ```
 
+## Claude Code plugin
+
+Instead of `gpt2agent install --client claude-code`, you can install via the plugin
+marketplace (bundles the MCP server registration + both skills):
+
+```text
+/plugin marketplace add robotlearning123/gpt2agent
+/plugin install gpt2agent@gpt2agent
+```
+
+You still need the `gpt2agent` CLI on PATH (`pipx install gpt2agent`) — the plugin
+wires `gpt2agent run --stdio` and the skills, not the Python package.
+
+## MCP registries
+
+`server.json` (repo root) is the [official MCP registry](https://registry.modelcontextprotocol.io)
+descriptor (PyPI package `gpt2agent`, stdio). Glama / mcp.so / PulseMCP auto-index
+from GitHub (topics + README). Publishing to the official registry is an owner step
+(`mcp-publisher` with GitHub auth).
+
 ## Manual setup
 
 ### VS Code (GitHub Copilot MCP)

--- a/server.json
+++ b/server.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robotlearning123/gpt2agent",
-  "description": "MCP server exposing a ChatGPT Plus/Pro account (chat, deep research, image gen, code interpreter, agent mode) as 25 tools, reusing your codex login.",
+  "title": "gpt2agent",
+  "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
   "version": "0.0.6",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
@@ -13,7 +14,11 @@
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
       "version": "0.0.6",
-      "transport": { "type": "stdio" }
+      "transport": { "type": "stdio" },
+      "packageArguments": [
+        { "type": "positional", "value": "run" },
+        { "type": "positional", "value": "--stdio" }
+      ]
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.robotlearning123/gpt2agent",
+  "description": "MCP server exposing a ChatGPT Plus/Pro account (chat, deep research, image gen, code interpreter, agent mode) as 25 tools, reusing your codex login.",
+  "version": "0.0.6",
+  "repository": {
+    "url": "https://github.com/robotlearning123/gpt2agent",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "gpt2agent",
+      "version": "0.0.6",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}


### PR DESCRIPTION
Makes gpt2agent installable as a **Claude Code plugin** and listable on the **official MCP registry**. All schemas verified against official docs and validated by tooling — not recalled. cx (GPT-5.5) reviewed and did an isolated plugin-install probe.

## Added
- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` → `/plugin marketplace add robotlearning123/gpt2agent` then `/plugin install gpt2agent@gpt2agent`. Bundles the MCP server (inline `gpt2agent run --stdio`) + both skills (`skills: ./gpt2agent/skills/`). **Passes `claude plugin validate --strict`.**
- `server.json` → official MCP registry descriptor; **validates against the live `2025-12-11/server.schema.json`** (jsonschema). Declares the PyPI package with `run --stdio` packageArguments + stdio transport.
- `mcp-name` marker in README (PyPI ownership verification for the registry).
- README + docs/clients.md: plugin install path + registry note.

## Verified by execution
- cx isolated install (temp HOME): `source: "."` resolves to repo root, **both skills load**, MCP server registers as `gpt2agent run --stdio`.
- `claude plugin validate --strict` ✔ · `jsonschema` validate of server.json ✔ · `uv build` excludes these root files from the wheel · ruff clean · 99 passed.

## cx review → fixed
- server.json description 148→87 chars (100-char schema cap); added `packageArguments` so registry clients launch the stdio server, not the bare HTTP-defaulting binary.

## Deferred (on the merits, not fabricated)
- **Smithery**: its hosted model runs servers in a cloud container, but gpt2agent needs the user's **local** `~/.codex/auth.json` — a hosted instance can't function. Glama/mcp.so/PulseMCP auto-index from GitHub (topics/README already optimized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)