### PR TITLE
fix(skills): correct stale heavy-DR + gpt_chat docs (skill verification findings)

### DIFF
--- a/gpt2agent/skills/deep-research/SKILL.md
+++ b/gpt2agent/skills/deep-research/SKILL.md
@@ -155,11 +155,12 @@ number; just keep account access serial.
 **Recovery from a 429 / poll-timeout (no extra quota):** the run almost always
 *completed server-side* — only the local poll failed. The `conv_id` is in the
 error line. Recover the finished report instead of re-running `--heavy` (which
-would burn another quota): GET `/backend-api/conversation/<conv_id>` via
-`BackendClient` (or the `get_conversation` MCP tool), then walk
-`mapping[*].message` for the newest assistant text node with status
-`finished_successfully` — its `metadata.content_references` holds the citation
-URLs. NOTE: heavy DR via the connector may render an "embedded UI experience"
-and never write a fetchable report node back; in that case there is nothing to
-recover and the run must be redone in a quiet window. Wait for the rate limit to
-ease first — repeated GETs while rate-limited keep it hot.
+would burn another quota): GET the conversation **with the hidden-widget flags**
+`/backend-api/conversation/<conv_id>?include_visually_hidden_messages=true&include_widget_state=true`
+via `BackendClient`, then read the connector's hidden widget state — the report
+lives in `widget_state.report_message.content.parts[0]` (text) with
+`report_message.metadata.content_references` (citation URLs). This is exactly what
+`sse._dr_report_from_widget_state` does; heavy DR via the connector does **not**
+write the report as an assistant text node, so walking `mapping` for assistant
+text alone will miss it. Wait for the rate limit to ease first — repeated GETs
+while rate-limited keep it hot.

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -104,7 +104,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
   - Takes 5-30 minutes. Use `run_in_background` for shell integration.
   - Uses `/backend-api/f/conversation` (frontend endpoint), not the standard `/backend-api/conversation`.
   - Model slug configurable via `[models].heavy_dr` in `config.toml` (default: `gpt-5-5-pro`).
-  - **Known limitation**: Citation URLs may not be recovered due to an upstream wrapper bug. The `done` event fires on the first assistant message (connector-call JSON), not the final report. View citations in the chatgpt.com web UI of the same conversation.
+  - **Report + citations recovered from the connector widget state** (fixed in 0.0.4): the connector never writes the report as an assistant text node, so the poll fetches the conversation with `include_widget_state=true` and recovers `widget_state.report_message` (text + `content_references`). Grouped source URLs are usually present but not guaranteed; if absent, the model may have cited sources inline in the body.
   - If the DR connector is unavailable, a warning is appended explaining how to enable it in chatgpt.com Settings > Connectors.
 
 ---
@@ -113,16 +113,16 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 
 - **Purpose**: Chat through a private Custom GPT, applying its instructions, files, and memory scope.
 - **Parameters**:
-  - `gizmo_id` (str, required) -- the Custom GPT identifier (format: `g-p-*`). Use `list_custom_gpts` to enumerate available IDs.
+  - `gizmo_id` (str, required) -- pass the `short_url` returned by `list_custom_gpts` (format: `g-*`). Call `list_custom_gpts` first to enumerate them.
   - `prompt` (str, required) -- the user message.
 - **Returns**: `str` -- the Custom GPT's response text.
 - **When to use**: When you need a specialized GPT's persona, knowledge base, or tool access.
 - **Example**:
   ```python
   # First, find available GPTs
-  gpts = list_custom_gpts()
-  # Then use one
-  gpt_chat("g-p-abc123def456", "Analyze this dataset for seasonal trends.")
+  gpts = list_custom_gpts()                  # each has {name, short_url}
+  # Then use one's short_url as the gizmo_id
+  gpt_chat(gpts[0]["short_url"], "Analyze this dataset for seasonal trends.")
   ```
 - **Notes**:
   - **EXPERIMENTAL**: passes `gizmo_id` via the `conversation_origin` field, reverse-engineered from chatgpt.com web bundles.
@@ -663,7 +663,7 @@ results = memory_search("keyword from new fact")
 
 5. **Heavy DR quota**: ~248 calls/month on Pro plan. Check before dispatching. The quota resets around the 21st of each month.
 
-6. **Heavy DR citation bug**: Citation URLs may not be recovered due to an upstream wrapper bug. View citations in the chatgpt.com web UI.
+6. **Heavy DR citations**: Recovered from the connector's hidden widget state (`widget_state.report_message`) since 0.0.4. Grouped source URLs are usually present but not guaranteed; if absent, the model may have cited sources inline in the report body.
 
 7. **Codex label resolution**: `codex_task_create` resolves `environment_id` from `repo_label` by fetching all environments. Raises `ValueError` on no match or ambiguous match.
 


### PR DESCRIPTION
Parallel cx/ccz verification of the **shipped skills** (they install to `~/.claude/skills/` and ship in the wheel) found 3 stale doc claims — code was already correct, only docs lagged. All fixed:

- **deep-research/SKILL.md** 429/poll-timeout *recovery* paragraph told users heavy-DR reports are unrecoverable and to walk assistant text — v0.0.6 recovers from `widget_state`. Updated. (cx)
- **tools-reference.md** `deep_research_heavy` "Known limitation" + Gotcha #6: removed the stale "citation bug → view in web UI" claim. (ccz S3)
- **tools-reference.md** `gpt_chat`: `g-p-*` → pass `short_url` from `list_custom_gpts` (matches code + the doc's own list_custom_gpts section). (ccz S3)

Verified clean by the other lanes: deep-research bin scripts (shellcheck + py_compile + --help), gpt2agent SKILL.md (frontmatter valid, allowed-tools == 25 live tools, no `0.0.0.0`/dead-login/stale content), deep_research.py logic (read_query, empty-query reject, longest-done, source dedup) — all PASS by execution. Doc-only change; suite still 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recovery procedures for heavy research runs encountering rate limits or timeouts.
  * Clarified citation and report recovery methods for deep research queries.
  * Refined guidance on gizmo_id parameter usage and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->