### PR TITLE
release: 0.0.7 — verification-found fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-06-18
+
+Patch release: fixes surfaced by a large-scale cx/cx2/ccz parallel verification of 0.0.6.
+
+### Security
+
+- **Broader secret redaction.** `redact_error` now masks base64 bearer tokens
+  (`Bearer …+ab/cd==`, previously the tail leaked) and more token query-param names
+  (`accessToken`, `session_token`, …). A `{16,}` length floor avoids mangling ordinary
+  prose after the word "Bearer".
+
+### Fixed
+
+- **`.claude-plugin/marketplace.json`** plugin `source` `"."` → `"./"` to satisfy the
+  canonical claude-code-marketplace JSON schema (the lenient CLI had accepted `"."`).
+- **Skill docs corrected to match shipped behavior** (the skills install to
+  `~/.claude/skills/` and ship in the wheel): the deep-research SKILL.md 429/poll-timeout
+  recovery section, and `tools-reference.md`'s `deep_research_heavy` "Known limitation" +
+  Gotcha #6 now describe the connector widget-state recovery (not a "citation bug");
+  `gpt_chat` documents passing the `short_url` from `list_custom_gpts` (not a `g-p-*` id).
+
+### Tests
+
+- +3 redaction regression tests (base64 bearer, camelCase query token, prose preservation).
+  Suite: 102 passed, 9 skipped.
+
 ## [0.0.6] - 2026-06-18
 
 ### Packaging / distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.6"
+version = "0.0.7"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },


### PR DESCRIPTION
Patch release bundling the post-0.0.6 fixes surfaced by the large-scale cx/cx2/ccz verification.

- **Security**: `redact_error` now masks base64 bearer tokens (`Bearer …+ab/cd==`) and more token query-param names; `{16,}` floor avoids mangling prose.
- **Fixed**: `marketplace.json` source `"."`→`"./"` (canonical schema); skill docs corrected to match the shipped heavy-DR widget-state recovery + `gpt_chat` `short_url`.
- **Tests**: +3 redaction regression tests. 102 passed, 9 skipped.

Version bumped to 0.0.7 across pyproject / plugin.json / server.json; CHANGELOG promoted. server.json validates vs the live MCP-registry schema; `claude plugin validate --strict` passes.

On merge: tag `v0.0.7` → release workflow publishes to PyPI (trusted publisher configured) + cuts the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)