### PR TITLE
fix(audit): harden 0.0.8 release readiness

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-06-27
+
+Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.7.
+
+### Security
+
+- **Secret-bearing config and token writes are tighter.** Installer backups preserve
+  source file modes, atomic temp files are created at `0600`, and setup/auth token
+  saves tighten existing `~/.gpt2agent/token.json` files that were previously wider.
+- **More user-returned secrets are redacted.** Tool output redaction now masks common
+  JWT, bearer, API-key, and GitHub-token shapes in conversation, memory, task, and
+  instruction surfaces. SSE in-band error frames are now raised with redacted text.
+
+### Fixed
+
+- `backend.get()` now handles empty/non-JSON 2xx responses like `post()`, returning
+  `None` for empty bodies and raising a clean redacted error for HTML/gateway pages.
+- Heavy Deep Research captures top-level `conversation_id` frames before polling,
+  supports array-index metadata patches for citations, and can finish when a real
+  report replaces a connector-dispatch placeholder in the same message.
+- `chat` no longer waits through the agent-mode async poll window on a real empty
+  response; only `agent` opts into async polling.
+- Stream parsers tolerate `{"message": null}` patch frames and surface common
+  in-band SSE error frames instead of silently ignoring them.
+- `gpt2agent setup` now recognizes every saved token shape accepted by the runtime
+  backend (`access_token`, `token`, or nested `tokens.access_token`).
+- Codex TOML install replacement preserves following `[[array-of-table]]` sections.
+- `get_conversation` follows the active `current_node` branch instead of raw mapping
+  order, and `list_apps` preserves explicit `is_connected: false`.
+- Explicit missing `--config` paths now fail loudly instead of falling back to defaults.
+
+### Tests
+
+- Added focused regressions for the audit fixes and parser edge cases. Offline suite:
+  126 passed, 9 skipped. `ruff check gpt2agent tests` is clean.
+
 ## [0.0.7] - 2026-06-18
 
 Patch release: fixes surfaced by a large-scale cx/cx2/ccz parallel verification of 0.0.6.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.
   in-band SSE error frames instead of silently ignoring them.
 - `gpt2agent setup` now recognizes every saved token shape accepted by the runtime
   backend (`access_token`, `token`, or nested `tokens.access_token`).
+- `auth.get_token()` now prefers Codex auth before saved `~/.gpt2agent/token.json`,
+  matching the backend/setup/docs and avoiding stale-token or wrong-account drift.
 - Codex TOML install replacement preserves following `[[array-of-table]]` sections.
 - `get_conversation` follows the active `current_node` branch instead of raw mapping
   order, and `list_apps` preserves explicit `is_connected: false`.
@@ -40,7 +42,7 @@ Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.
 ### Tests
 
 - Added focused regressions for the audit fixes and parser edge cases. Offline suite:
-  126 passed, 9 skipped. `ruff check gpt2agent tests` is clean.
+  127 passed, 9 skipped. `ruff check gpt2agent tests` is clean.
 
 ## [0.0.7] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.
   saves tighten existing `~/.gpt2agent/token.json` files that were previously wider.
 - **More user-returned secrets are redacted.** Tool output redaction now masks common
   JWT, bearer, API-key, and GitHub-token shapes in conversation, memory, task, and
-  instruction surfaces. SSE in-band error frames are now raised with redacted text.
+  instruction surfaces, including fine-grained `github_pat_` tokens. SSE in-band
+  error frames are now raised with redacted text.
 
 ### Fixed
 
@@ -25,7 +26,8 @@ Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.
   `None` for empty bodies and raising a clean redacted error for HTML/gateway pages.
 - Heavy Deep Research captures top-level `conversation_id` frames before polling,
   supports array-index metadata patches for citations, and can finish when a real
-  report replaces a connector-dispatch placeholder in the same message.
+  report replaces a connector-dispatch placeholder in the same message. Dispatch
+  JSON delivered through content patches is no longer emitted as progress.
 - `chat` no longer waits through the agent-mode async poll window on a real empty
   response; only `agent` opts into async polling.
 - Stream parsers tolerate `{"message": null}` patch frames and surface common
@@ -36,13 +38,16 @@ Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.
   matching the backend/setup/docs and avoiding stale-token or wrong-account drift.
 - Codex TOML install replacement preserves following `[[array-of-table]]` sections.
 - `get_conversation` follows the active `current_node` branch instead of raw mapping
-  order, and `list_apps` preserves explicit `is_connected: false`.
+  order, keeps the newest turns when `max_messages` is capped, and `list_apps`
+  preserves explicit `is_connected: false`.
+- Codex TOML section editing now treats `[section] # comment` and
+  `[[array]] # comment` as section boundaries, preserving following sections.
 - Explicit missing `--config` paths now fail loudly instead of falling back to defaults.
 
 ### Tests
 
 - Added focused regressions for the audit fixes and parser edge cases. Offline suite:
-  127 passed, 9 skipped. `ruff check gpt2agent tests` is clean.
+  129 passed, 9 skipped. `ruff check gpt2agent tests` is clean.
 
 ## [0.0.7] - 2026-06-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server exposing full ChatGPT Plus/Pro account features to any MCP client.
 ## Build & Test
 
 ```bash
-pytest                    # 102 passed, 9 skipped (live tests gated by SKIP_LIVE)
+pytest                    # 126 passed, 9 skipped (live tests gated by SKIP_LIVE)
 python -m gpt2agent run   # start MCP server (stdio)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server exposing full ChatGPT Plus/Pro account features to any MCP client.
 ## Build & Test
 
 ```bash
-pytest                    # 60 passed, 9 skipped (live tests gated by SKIP_LIVE)
+pytest                    # 102 passed, 9 skipped (live tests gated by SKIP_LIVE)
 python -m gpt2agent run   # start MCP server (stdio)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server exposing full ChatGPT Plus/Pro account features to any MCP client.
 ## Build & Test
 
 ```bash
-pytest                    # 127 passed, 9 skipped (live tests gated by SKIP_LIVE)
+pytest                    # 129 passed, 9 skipped (live tests gated by SKIP_LIVE)
 python -m gpt2agent run   # start MCP server (stdio)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server exposing full ChatGPT Plus/Pro account features to any MCP client.
 ## Build & Test
 
 ```bash
-pytest                    # 126 passed, 9 skipped (live tests gated by SKIP_LIVE)
+pytest                    # 127 passed, 9 skipped (live tests gated by SKIP_LIVE)
 python -m gpt2agent run   # start MCP server (stdio)
 ```
 

--- a/artifacts/verify/audit-remediation-2026-06-26.md
+++ b/artifacts/verify/audit-remediation-2026-06-26.md
@@ -9,9 +9,16 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
 - **Opus** (me) — full ~4700 LOC read; independent findings, high overlap.
 
 ## Verification (commands run, real output)
-- `pytest tests/` → **120 passed, 9 skipped** (baseline was 102; +17 regression + 1 chat-poll).
-- Regression proof: stashed production fixes, ran new tests on unfixed tree → **14/16 failed**
+- `pytest tests/` → **126 passed, 9 skipped** (baseline was 102; +23 regression + 1 chat-poll).
+- `ruff check gpt2agent tests` → **All checks passed**.
+- `python -m build --outdir /tmp/gpt2agent-dist.CHzfEg` + `twine check` → **sdist and wheel built as 0.0.8; both PASSED**.
+- Isolated wheel smoke in `/tmp/gpt2agent-venv.I3gsIe/venv` → **imports 0.0.8, console script reports 0.0.8, bundled skills present**.
+- `shellcheck -e SC2086 -e SC2155 install.sh` → **clean**.
+- `python -m compileall -q gpt2agent tests` + JSON parse of `server.json` / plugin manifests → **clean**.
+- Prior regression proof: stashed production fixes, ran new tests on unfixed tree → **14/16 failed**
   (the 2 that passed were a parametrization that always worked + a mode test later strengthened).
+- Codex follow-up regression proof: focused new tests for setup token shape, metadata array patches,
+  dispatch replacement, and in-band SSE errors → **5/6 failed before patch; 6/6 passed after patch**.
 - Import sanity: all 12 changed modules import clean.
 - **cx final verdict (independent):** first pass FAIL — caught a permission regression I introduced
   (`os.open(O_CREAT,0o600)` ignores mode on an existing file). Fixed with `os.fchmod`. Re-verify:
@@ -19,7 +26,7 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
   verified pytest tests/test_audit_2026_06_26.py → 17 passed."
 - **Opus verdict:** all changes reviewed; minimal, scoped; tests green.
 
-## Fixes (15) — file:finding
+## Fixes (20) — file:finding
 Security
 - install.py `_backup` — preserve source mode (was umask → secret-bearing config backups world-readable). [cx2 P0]
 - install.py `_atomic_write` — open tmp 0o600 up front (no umask window). [cx2 P1]
@@ -37,15 +44,17 @@ Correctness / robustness
 - install.py — section regex matches `[[array-of-table]]` (else replacing gpt2agent section deletes a following table). [cx2 P1]
 - conversations.py `get_conversation` — follow `current_node` active chain (fallback create_time) instead of raw mapping order. [cx2 P1]
 - auth.py `_from_saved` — accept token / nested tokens.access_token (align with backend). [cx P2]
+- setup.py `_token_from_saved` — accept token / nested tokens.access_token (align setup wizard with backend/auth). [Codex follow-up]
 - apps.py — preserve explicit `is_connected: False`. [cx2 P2]
 - server.py `load_config` — raise on explicit-but-missing `--config`. [cx2 P2]
-- CLAUDE.md — stale test count 60 → 102.
+- sse.py metadata patches — support JSON-pointer array indexes for citation metadata (`/content_references/0`, `/search_result_groups/0`). [Codex follow-up]
+- sse.py in-band SSE errors — raise redacted `RuntimeError` for common `type=error` / `error` frames instead of silently ignoring them. [Codex follow-up]
+- sse.py connector dispatch — a real report that replaces the connector-dispatch placeholder now clears the dispatch flag and can finish normally. [Codex follow-up]
+- CLAUDE.md — stale test count 60 → 126.
 
-## Deferred (noted, not fixed — would need real frame data / over-redaction risk)
-- sse.py metadata JSON-pointer array support (cx P1) — observed traffic uses whole-list replace; speculative.
-- sse.py in-band SSE error-frame surfacing (ccz P1) — needs real error-frame samples; the worst symptom
-  (5-min hang) is removed by the `complete()` poll-gating fix.
-- sse.py sticky `is_connector_dispatch` (ccz P2) — observed traffic resets it via a fresh envelope.
+## Deferred
+- No known open P0/P1/P2 from the 2026-06-26 audit remains deferred in this branch.
+- Live heavy-DR frame-shape drift remains an operational watch item because ChatGPT private backend traffic is not a stable public API.
 
 ## State
-- Committed to local branch `fix/audit-2026-06-26`. NOT pushed (no PR; outward-facing action not authorized).
+- Local branch `fix/audit-2026-06-26`; Codex follow-up changes are present in this worktree. NOT pushed (no PR; outward-facing action not authorized).

--- a/artifacts/verify/audit-remediation-2026-06-26.md
+++ b/artifacts/verify/audit-remediation-2026-06-26.md
@@ -1,0 +1,51 @@
+# Audit remediation — 2026-06-26
+
+Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`).
+
+## Team
+- **cx** (GPT-5.5 #1, codex) — core: sse/backend/auth/sentinel — 8 findings.
+- **cx2** (GPT-5.5 #2, isolated CODEX_HOME) — server/tools/install/setup/_vendored — 8 findings (1 P0).
+- **ccz** (GLM-5.2 via z.ai) — broad pass — surfaced the unique `complete()` 5-min hang the codex pair missed.
+- **Opus** (me) — full ~4700 LOC read; independent findings, high overlap.
+
+## Verification (commands run, real output)
+- `pytest tests/` → **120 passed, 9 skipped** (baseline was 102; +17 regression + 1 chat-poll).
+- Regression proof: stashed production fixes, ran new tests on unfixed tree → **14/16 failed**
+  (the 2 that passed were a parametrization that always worked + a mode test later strengthened).
+- Import sanity: all 12 changed modules import clean.
+- **cx final verdict (independent):** first pass FAIL — caught a permission regression I introduced
+  (`os.open(O_CREAT,0o600)` ignores mode on an existing file). Fixed with `os.fchmod`. Re-verify:
+  **PASS** — "existing 0644 token.json ends 0o600 in both paths; fchmod runs on valid fd; no new P0/P1;
+  verified pytest tests/test_audit_2026_06_26.py → 17 passed."
+- **Opus verdict:** all changes reviewed; minimal, scoped; tests green.
+
+## Fixes (15) — file:finding
+Security
+- install.py `_backup` — preserve source mode (was umask → secret-bearing config backups world-readable). [cx2 P0]
+- install.py `_atomic_write` — open tmp 0o600 up front (no umask window). [cx2 P1]
+- auth.py / setup.py token writes — os.open 0o600 + os.fchmod (tightens existing file). [cx P1, cx2 P1]
+- _log_redact.py — redact bare `"token"` JSON field (ccz verified leak by execution). [ccz P2]
+- tools/_redact.py — redact pasted secrets in tool output (JWT/bearer/API-key), not just PII. [cx2 P1]
+- sentinel.py — redact `json.dumps(resp)` not `str(dict)` (single-quote bypass). [cx P2]
+
+Correctness / robustness
+- sse.py heavy DR — capture top-level `conversation_id` so Phase-2 poll fires (else async report lost). [cx P1, Opus]
+- sse.py `complete()` — gate 300s async poll behind `poll_async` (only agent); normal chat no longer hangs 5 min. [ccz P1]
+- sse.py v-patch — `v.get("message") or {}` guard (null message crashed stream). [cx P1]
+- backend.py `get()` — non-JSON/empty 2xx guard mirroring `post()`. [cx/ccz P1]
+- sentinel.py — guard `r.json()` + dict validation. [cx P1]
+- install.py — section regex matches `[[array-of-table]]` (else replacing gpt2agent section deletes a following table). [cx2 P1]
+- conversations.py `get_conversation` — follow `current_node` active chain (fallback create_time) instead of raw mapping order. [cx2 P1]
+- auth.py `_from_saved` — accept token / nested tokens.access_token (align with backend). [cx P2]
+- apps.py — preserve explicit `is_connected: False`. [cx2 P2]
+- server.py `load_config` — raise on explicit-but-missing `--config`. [cx2 P2]
+- CLAUDE.md — stale test count 60 → 102.
+
+## Deferred (noted, not fixed — would need real frame data / over-redaction risk)
+- sse.py metadata JSON-pointer array support (cx P1) — observed traffic uses whole-list replace; speculative.
+- sse.py in-band SSE error-frame surfacing (ccz P1) — needs real error-frame samples; the worst symptom
+  (5-min hang) is removed by the `complete()` poll-gating fix.
+- sse.py sticky `is_connector_dispatch` (ccz P2) — observed traffic resets it via a fresh envelope.
+
+## State
+- Committed to local branch `fix/audit-2026-06-26`. NOT pushed (no PR; outward-facing action not authorized).

--- a/artifacts/verify/audit-remediation-2026-06-26.md
+++ b/artifacts/verify/audit-remediation-2026-06-26.md
@@ -9,16 +9,19 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
 - **Opus** (me) — full ~4700 LOC read; independent findings, high overlap.
 
 ## Verification (commands run, real output)
-- `pytest tests/` → **126 passed, 9 skipped** (baseline was 102; +23 regression + 1 chat-poll).
+- `pytest tests/` → **127 passed, 9 skipped** (baseline was 102; +24 regression + 1 chat-poll).
 - `ruff check gpt2agent tests` → **All checks passed**.
-- `python -m build --outdir /tmp/gpt2agent-dist.CHzfEg` + `twine check` → **sdist and wheel built as 0.0.8; both PASSED**.
-- Isolated wheel smoke in `/tmp/gpt2agent-venv.I3gsIe/venv` → **imports 0.0.8, console script reports 0.0.8, bundled skills present**.
+- `python -m build --outdir /tmp/gpt2agent-dist.gKbEm1` + `twine check` → **sdist and wheel built as 0.0.8; both PASSED**.
+- Isolated wheel smoke in `/tmp/gpt2agent-venv.yXGAiP/venv` → **imports 0.0.8, console script reports 0.0.8, bundled skills present, installed auth prefers `CODEX_HOME` over stale saved token**.
 - `shellcheck -e SC2086 -e SC2155 install.sh` → **clean**.
 - `python -m compileall -q gpt2agent tests` + JSON parse of `server.json` / plugin manifests → **clean**.
+- Version consistency check (`pyproject.toml`, `server.json`, package entry, plugin manifest) → **all 0.0.8**.
+- `git diff --check` + added-secret scan over the PR diff → **clean**.
 - Prior regression proof: stashed production fixes, ran new tests on unfixed tree → **14/16 failed**
   (the 2 that passed were a parametrization that always worked + a mode test later strengthened).
-- Codex follow-up regression proof: focused new tests for setup token shape, metadata array patches,
-  dispatch replacement, and in-band SSE errors → **5/6 failed before patch; 6/6 passed after patch**.
+- Codex follow-up regression proof: focused new tests for setup token shape, auth priority,
+  metadata array patches, dispatch replacement, and in-band SSE errors → **5/6 of the initial
+  parser/setup tests failed before patch; all 7 focused follow-up tests pass after patch**.
 - Import sanity: all 12 changed modules import clean.
 - **cx final verdict (independent):** first pass FAIL — caught a permission regression I introduced
   (`os.open(O_CREAT,0o600)` ignores mode on an existing file). Fixed with `os.fchmod`. Re-verify:
@@ -26,7 +29,7 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
   verified pytest tests/test_audit_2026_06_26.py → 17 passed."
 - **Opus verdict:** all changes reviewed; minimal, scoped; tests green.
 
-## Fixes (20) — file:finding
+## Fixes (21) — file:finding
 Security
 - install.py `_backup` — preserve source mode (was umask → secret-bearing config backups world-readable). [cx2 P0]
 - install.py `_atomic_write` — open tmp 0o600 up front (no umask window). [cx2 P1]
@@ -44,17 +47,19 @@ Correctness / robustness
 - install.py — section regex matches `[[array-of-table]]` (else replacing gpt2agent section deletes a following table). [cx2 P1]
 - conversations.py `get_conversation` — follow `current_node` active chain (fallback create_time) instead of raw mapping order. [cx2 P1]
 - auth.py `_from_saved` — accept token / nested tokens.access_token (align with backend). [cx P2]
+- auth.py `get_token` — prefer Codex auth before saved `~/.gpt2agent/token.json` so `CODEX_HOME` and auto-refresh behavior match backend/setup/docs. [Codex follow-up]
 - setup.py `_token_from_saved` — accept token / nested tokens.access_token (align setup wizard with backend/auth). [Codex follow-up]
 - apps.py — preserve explicit `is_connected: False`. [cx2 P2]
 - server.py `load_config` — raise on explicit-but-missing `--config`. [cx2 P2]
 - sse.py metadata patches — support JSON-pointer array indexes for citation metadata (`/content_references/0`, `/search_result_groups/0`). [Codex follow-up]
 - sse.py in-band SSE errors — raise redacted `RuntimeError` for common `type=error` / `error` frames instead of silently ignoring them. [Codex follow-up]
 - sse.py connector dispatch — a real report that replaces the connector-dispatch placeholder now clears the dispatch flag and can finish normally. [Codex follow-up]
-- CLAUDE.md — stale test count 60 → 126.
+- CLAUDE.md — stale test count 60 → 127.
 
 ## Deferred
 - No known open P0/P1/P2 from the 2026-06-26 audit remains deferred in this branch.
 - Live heavy-DR frame-shape drift remains an operational watch item because ChatGPT private backend traffic is not a stable public API.
 
 ## State
-- Local branch `fix/audit-2026-06-26`; Codex follow-up changes are present in this worktree. NOT pushed (no PR; outward-facing action not authorized).
+- PR #16 (`fix/audit-2026-06-26` → `main`) is open for this release-readiness branch.
+- Release tag `v0.0.8` is not created yet; tag/publish remains after PR review/merge.

--- a/artifacts/verify/audit-remediation-2026-06-26.md
+++ b/artifacts/verify/audit-remediation-2026-06-26.md
@@ -9,10 +9,10 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
 - **Opus** (me) — full ~4700 LOC read; independent findings, high overlap.
 
 ## Verification (commands run, real output)
-- `pytest tests/` → **127 passed, 9 skipped** (baseline was 102; +24 regression + 1 chat-poll).
+- `pytest tests/` → **129 passed, 9 skipped** (baseline was 102; +26 regression + 1 chat-poll).
 - `ruff check gpt2agent tests` → **All checks passed**.
-- `python -m build --outdir /tmp/gpt2agent-dist.gKbEm1` + `twine check` → **sdist and wheel built as 0.0.8; both PASSED**.
-- Isolated wheel smoke in `/tmp/gpt2agent-venv.yXGAiP/venv` → **imports 0.0.8, console script reports 0.0.8, bundled skills present, installed auth prefers `CODEX_HOME` over stale saved token**.
+- `python -m build --outdir /tmp/gpt2agent-dist.y7cqZ3` + `twine check` → **sdist and wheel built as 0.0.8; both PASSED**.
+- Isolated wheel smoke in `/tmp/gpt2agent-venv.cpqnZi/venv` → **imports 0.0.8, console script reports 0.0.8, bundled skills present, installed auth prefers `CODEX_HOME` over stale saved token, installed redaction masks `github_pat_` tokens**.
 - `shellcheck -e SC2086 -e SC2155 install.sh` → **clean**.
 - `python -m compileall -q gpt2agent tests` + JSON parse of `server.json` / plugin manifests → **clean**.
 - Version consistency check (`pyproject.toml`, `server.json`, package entry, plugin manifest) → **all 0.0.8**.
@@ -22,20 +22,23 @@ Cross-model bug hunt + fix on `gpt2agent` v0.0.7 (branch `fix/audit-2026-06-26`)
 - Codex follow-up regression proof: focused new tests for setup token shape, auth priority,
   metadata array patches, dispatch replacement, and in-band SSE errors → **5/6 of the initial
   parser/setup tests failed before patch; all 7 focused follow-up tests pass after patch**.
-- Import sanity: all 12 changed modules import clean.
+- CodeRabbit review follow-up proof: focused tests for commented TOML headers,
+  fine-grained GitHub PAT redaction, active-branch `max_messages`, and
+  dispatch-patch progress suppression → **4/4 passed after patch**.
+- Import sanity: all 11 changed runtime modules import clean.
 - **cx final verdict (independent):** first pass FAIL — caught a permission regression I introduced
   (`os.open(O_CREAT,0o600)` ignores mode on an existing file). Fixed with `os.fchmod`. Re-verify:
   **PASS** — "existing 0644 token.json ends 0o600 in both paths; fchmod runs on valid fd; no new P0/P1;
   verified pytest tests/test_audit_2026_06_26.py → 17 passed."
 - **Opus verdict:** all changes reviewed; minimal, scoped; tests green.
 
-## Fixes (21) — file:finding
+## Fixes (25) — file:finding
 Security
 - install.py `_backup` — preserve source mode (was umask → secret-bearing config backups world-readable). [cx2 P0]
 - install.py `_atomic_write` — open tmp 0o600 up front (no umask window). [cx2 P1]
 - auth.py / setup.py token writes — os.open 0o600 + os.fchmod (tightens existing file). [cx P1, cx2 P1]
 - _log_redact.py — redact bare `"token"` JSON field (ccz verified leak by execution). [ccz P2]
-- tools/_redact.py — redact pasted secrets in tool output (JWT/bearer/API-key), not just PII. [cx2 P1]
+- tools/_redact.py — redact pasted secrets in tool output (JWT/bearer/API-key/GitHub classic and fine-grained PATs), not just PII. [cx2 P1, CodeRabbit]
 - sentinel.py — redact `json.dumps(resp)` not `str(dict)` (single-quote bypass). [cx P2]
 
 Correctness / robustness
@@ -45,7 +48,9 @@ Correctness / robustness
 - backend.py `get()` — non-JSON/empty 2xx guard mirroring `post()`. [cx/ccz P1]
 - sentinel.py — guard `r.json()` + dict validation. [cx P1]
 - install.py — section regex matches `[[array-of-table]]` (else replacing gpt2agent section deletes a following table). [cx2 P1]
+- install.py — section regex treats `[section] # comment` and `[[array]] # comment` as boundaries so commented headers are preserved. [CodeRabbit]
 - conversations.py `get_conversation` — follow `current_node` active chain (fallback create_time) instead of raw mapping order. [cx2 P1]
+- conversations.py `get_conversation` — apply `max_messages` as a tail cap on ordered nodes, preserving newest visible turns. [CodeRabbit]
 - auth.py `_from_saved` — accept token / nested tokens.access_token (align with backend). [cx P2]
 - auth.py `get_token` — prefer Codex auth before saved `~/.gpt2agent/token.json` so `CODEX_HOME` and auto-refresh behavior match backend/setup/docs. [Codex follow-up]
 - setup.py `_token_from_saved` — accept token / nested tokens.access_token (align setup wizard with backend/auth). [Codex follow-up]
@@ -54,7 +59,8 @@ Correctness / robustness
 - sse.py metadata patches — support JSON-pointer array indexes for citation metadata (`/content_references/0`, `/search_result_groups/0`). [Codex follow-up]
 - sse.py in-band SSE errors — raise redacted `RuntimeError` for common `type=error` / `error` frames instead of silently ignoring them. [Codex follow-up]
 - sse.py connector dispatch — a real report that replaces the connector-dispatch placeholder now clears the dispatch flag and can finish normally. [Codex follow-up]
-- CLAUDE.md — stale test count 60 → 127.
+- sse.py connector dispatch — suppress connector-dispatch content delivered through append/replace patches before emitting progress. [CodeRabbit]
+- CLAUDE.md — stale test count 60 → 129.
 
 ## Deferred
 - No known open P0/P1/P2 from the 2026-06-26 audit remains deferred in this branch.

--- a/gpt2agent/_log_redact.py
+++ b/gpt2agent/_log_redact.py
@@ -21,10 +21,13 @@ _SENSITIVE_KEY_RE = re.compile(
 )
 
 # 2. JSON token fields by name — `"access_token":"…"`, `"accessToken":"…"`,
-#    `"session_token":"…"`, `"id_token":"…"`, `"refresh_token":"…"`. Covers the
-#    nested `"tokens":{"access_token":"…"}` shape too (the pair is matched directly).
+#    `"session_token":"…"`, `"id_token":"…"`, `"refresh_token":"…"`, and the bare
+#    `"token":"…"` (the shape ~/.gpt2agent/token.json and sentinel chat-requirements
+#    responses use). Covers the nested `"tokens":{"access_token":"…"}` shape too
+#    (the pair is matched directly). Constrained to the JSON value form so it
+#    cannot mangle the word "token" in ordinary prose.
 _TOKEN_FIELD_RE = re.compile(
-    r'"((?:access|session|id|refresh|bearer)[_-]?token|accessToken)"\s*:\s*"[^"]*"',
+    r'"((?:access|session|id|refresh|bearer)[_-]?token|accessToken|token)"\s*:\s*"[^"]*"',
     re.IGNORECASE,
 )
 

--- a/gpt2agent/auth.py
+++ b/gpt2agent/auth.py
@@ -146,7 +146,10 @@ def _from_browser_use() -> dict | None:
 
 def get_token(interactive: bool = True) -> str:
     """Return a valid ChatGPT access token, trying sources in priority order."""
-    for fn in [_from_saved, _from_codex, _from_browser_use]:
+    # Prefer Codex for parity with BackendClient/setup/docs: it honors CODEX_HOME
+    # and auto-refreshes, while ~/.gpt2agent/token.json can be stale or from a
+    # different account.
+    for fn in [_from_codex, _from_saved, _from_browser_use]:
         result = fn()
         if result:
             print(f"  ✓ Token found ({result['source']})")

--- a/gpt2agent/auth.py
+++ b/gpt2agent/auth.py
@@ -46,7 +46,14 @@ def _from_saved() -> dict | None:
         return None
     try:
         data = json.loads(p.read_text())
-        token = data.get("access_token")
+        # Accept every shape backend._load_token_with_source() accepts, so a
+        # valid saved token isn't missed (forcing browser setup) just because it
+        # was stored as {"token": …} or nested {"tokens": {"access_token": …}}.
+        token = (
+            data.get("access_token")
+            or data.get("token")
+            or (data.get("tokens") or {}).get("access_token")
+        )
         if token:
             return {"access_token": token, "source": "saved"}
     except Exception:
@@ -152,11 +159,20 @@ def get_token(interactive: bool = True) -> str:
     if not result:
         raise RuntimeError("Token acquisition cancelled.")
 
-    # Save for future use
+    # Save for future use. Create the file 0o600 up front (os.open) so the
+    # bearer token is never briefly world-readable between write and chmod.
     save_dir = Path.home() / ".gpt2agent"
     save_dir.mkdir(exist_ok=True)
     tp = save_dir / "token.json"
-    tp.write_text(json.dumps(result, indent=2))
-    tp.chmod(0o600)
+    fd = os.open(tp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        # O_CREAT's mode is ignored when the file already exists, so tighten it
+        # explicitly (fchmod on the fd, after O_TRUNC) before writing the token —
+        # this fixes a pre-existing 0644 token.json staying world-readable.
+        os.fchmod(fd, 0o600)
+    except (OSError, AttributeError):
+        pass  # non-POSIX (e.g. Windows lacks fchmod)
+    with os.fdopen(fd, "w") as f:
+        json.dump(result, f, indent=2)
     print("  Token saved to ~/.gpt2agent/token.json")
     return result["access_token"]

--- a/gpt2agent/backend.py
+++ b/gpt2agent/backend.py
@@ -165,7 +165,18 @@ class BackendClient:
         if r.status_code != 200:
             raise RuntimeError(f"HTTP {r.status_code} for {path}")
 
-        return r.json()
+        # Mirror post()'s guard: an HTML/empty 2xx (Cloudflare interstitial,
+        # gateway page) must surface a clean redacted RuntimeError, not a raw
+        # JSONDecodeError stack trace into the MCP client.
+        if not r.text.strip():
+            return None
+        try:
+            return r.json()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Expected JSON from {path} but got non-JSON 2xx response: "
+                f"{redact_error(r.text)}"
+            ) from exc
 
     def post(
         self,

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -50,11 +50,33 @@ def _h1(msg: str) -> None:
 
 
 def _backup(path: Path) -> Path | None:
-    """Snapshot ``path`` to ``path.bak-gpt2agent`` so the user can undo."""
+    """Snapshot ``path`` to ``path.bak-gpt2agent`` so the user can undo.
+
+    Preserves the source file's mode. Agent configs (~/.claude.json,
+    ~/.codex/config.toml) hold MCP server commands and can hold secrets; a
+    plain ``write_bytes`` would create the backup with the process umask
+    (often world-readable), exposing a ``0600`` config in its ``.bak`` copy.
+    """
     if not path.exists():
         return None
     bak = path.with_name(path.name + ".bak-gpt2agent")
-    bak.write_bytes(path.read_bytes())
+    data = path.read_bytes()
+    try:
+        mode = path.stat().st_mode & 0o777
+    except OSError:
+        mode = 0o600
+    # Create at 0o600 (never wider than needed) then match the source mode.
+    fd = os.open(str(bak), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        try:
+            os.chmod(bak, mode)
+        except OSError:
+            pass  # non-POSIX filesystem
+    except BaseException:
+        bak.unlink(missing_ok=True)
+        raise
     return bak
 
 
@@ -68,16 +90,23 @@ def _atomic_write(path: Path, content: str) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + f".tmp-{os.getpid()}")
-    tmp.write_text(content)
+    # Open the temp file at 0o600 up front so a secret-bearing config is never
+    # briefly world-readable under a permissive umask between write and chmod.
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        if path.exists():
-            tmp.chmod(path.stat().st_mode)
-        else:
-            tmp.chmod(0o600)
-    except OSError:
-        # Best-effort — Windows / non-POSIX filesystems may reject chmod.
-        pass
-    tmp.replace(path)
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        try:
+            # Preserve an existing file's mode; new files stay 0o600.
+            if path.exists():
+                os.chmod(tmp, path.stat().st_mode)
+        except OSError:
+            # Best-effort — Windows / non-POSIX filesystems may reject chmod.
+            pass
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def _stdio_entry() -> dict[str, Any]:
@@ -176,7 +205,11 @@ def _remove_toml_section(content: str, section_name: str) -> str:
     end-of-file. Other sections are preserved verbatim.
     """
     header = f"[{section_name}]"
-    section_header_re = re.compile(r"^\s*\[[^\[\]]+\]\s*$")
+    # Match both standard table headers `[x]` and array-of-table headers `[[x]]`.
+    # Missing the `[[...]]` form made the body-skip loop swallow a following
+    # array-of-table section as if it were part of the replaced/removed block,
+    # deleting unrelated valid TOML.
+    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*$")
     out: list[str] = []
     skipping = False
     for line in content.splitlines():
@@ -227,7 +260,11 @@ def _replace_or_append_toml_section(
     out: list[str] = []
     i = 0
     found = False
-    section_header_re = re.compile(r"^\s*\[[^\[\]]+\]\s*$")
+    # Match both standard table headers `[x]` and array-of-table headers `[[x]]`.
+    # Missing the `[[...]]` form made the body-skip loop swallow a following
+    # array-of-table section as if it were part of the replaced/removed block,
+    # deleting unrelated valid TOML.
+    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*$")
 
     while i < len(lines):
         line = lines[i]

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -209,7 +209,7 @@ def _remove_toml_section(content: str, section_name: str) -> str:
     # Missing the `[[...]]` form made the body-skip loop swallow a following
     # array-of-table section as if it were part of the replaced/removed block,
     # deleting unrelated valid TOML.
-    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*$")
+    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*(?:#.*)?$")
     out: list[str] = []
     skipping = False
     for line in content.splitlines():
@@ -264,7 +264,7 @@ def _replace_or_append_toml_section(
     # Missing the `[[...]]` form made the body-skip loop swallow a following
     # array-of-table section as if it were part of the replaced/removed block,
     # deleting unrelated valid TOML.
-    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*$")
+    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*(?:#.*)?$")
 
     while i < len(lines):
         line = lines[i]

--- a/gpt2agent/sentinel.py
+++ b/gpt2agent/sentinel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -47,11 +48,25 @@ class SentinelGate:
                 f"{_redact_error(body)}"
             )
 
-        resp = r.json()
+        try:
+            resp = r.json()
+        except Exception as exc:
+            body = r.text if hasattr(r, "text") else str(r.content)
+            raise RuntimeError(
+                f"sentinel/chat-requirements non-JSON 200: {_redact_error(body)}"
+            ) from exc
+        if not isinstance(resp, dict):
+            raise RuntimeError(
+                "sentinel/chat-requirements unexpected response shape: "
+                f"{_redact_error(json.dumps(resp, ensure_ascii=False))}"
+            )
         chat_token = resp.get("token")
         if not chat_token:
+            # Redact json.dumps(...) not str(dict): the latter uses single
+            # quotes and would bypass the JSON-key redaction regexes.
             raise RuntimeError(
-                f"sentinel/chat-requirements no token: {_redact_error(str(resp))}"
+                "sentinel/chat-requirements no token: "
+                f"{_redact_error(json.dumps(resp, ensure_ascii=False))}"
             )
 
         out: dict[str, str] = {"chat-requirements": chat_token}

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -49,6 +49,10 @@ def _http_bind_decision(host: str, allow_remote: bool) -> str:
 
 
 def load_config(path: Path | None = None) -> dict[str, Any]:
+    # An explicitly-requested config that doesn't exist is a user error (likely a
+    # typo) — fail loudly instead of silently falling back to defaults.
+    if path is not None and not path.exists():
+        raise FileNotFoundError(f"config file not found: {path}")
     candidates = [path] if path else _CONFIG_SEARCH
     for p in candidates:
         if p and p.exists():
@@ -116,7 +120,10 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         string, so callers can tell a timeout apart from a real empty answer.
         """
         text = await conv.complete(
-            agent_model, [{"role": "user", "content": prompt}], temporary=False
+            agent_model,
+            [{"role": "user", "content": prompt}],
+            temporary=False,
+            poll_async=True,  # agent mode runs async — poll the conversation
         )
         return text or "(no response)"
 

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -101,8 +101,17 @@ def save_token(token: str) -> None:
     d = Path.home() / ".gpt2agent"
     d.mkdir(exist_ok=True)
     p = d / "token.json"
-    p.write_text(json.dumps({"access_token": token}))
-    p.chmod(0o600)
+    # Open 0o600 up front so the bearer token is never briefly world-readable
+    # between write and chmod under a permissive umask.
+    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        # O_CREAT's mode is ignored if the file already exists; tighten an
+        # existing 0644 token.json explicitly (after O_TRUNC, before writing).
+        os.fchmod(fd, 0o600)
+    except (OSError, AttributeError):
+        pass  # non-POSIX (e.g. Windows lacks fchmod)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"access_token": token}, f)
 
 
 # ── plan detection ──────────────────────────────────────────────────────────

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -56,7 +56,11 @@ def _token_from_saved() -> str | None:
         return None
     try:
         d = json.loads(p.read_text())
-        return d.get("access_token")
+        return (
+            d.get("access_token")
+            or d.get("token")
+            or (d.get("tokens") or {}).get("access_token")
+        )
     except Exception:
         return None
 

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -497,9 +497,12 @@ class ConversationClient:
                             last_text += v
                         continue
                     if isinstance(v, dict):
-                        msg_id = v.get("message", {}).get("id")
+                        # `{"v":{"message":null}}` makes .get("message", {}) return
+                        # None (key present), so chained .get() would AttributeError.
+                        vmsg = v.get("message") or {}
+                        msg_id = vmsg.get("id")
                         is_new = _reset_if_new_msg(msg_id)
-                        parts = v.get("message", {}).get("content", {}).get("parts", [])
+                        parts = (vmsg.get("content") or {}).get("parts") or []
                         if parts and isinstance(parts[0], str):
                             new = parts[0]
                             if is_new:
@@ -557,6 +560,7 @@ class ConversationClient:
         *,
         gizmo_id: str | None = None,
         temporary: bool = True,
+        poll_async: bool = False,
     ) -> str:
         chunks: list[str] = []
         conv_id: str | None = None
@@ -568,8 +572,12 @@ class ConversationClient:
             chunks.append(event)
         text = "".join(chunks)
 
-        # Agent mode: stream ends immediately with async_status, response arrives later
-        if not text and conv_id:
+        # Agent mode: the stream ends immediately with async_status and the real
+        # response arrives later, so we poll the conversation for up to 5 min.
+        # This MUST be opt-in (poll_async): conv_id is captured on nearly every
+        # stream, so an unconditional "not text and conv_id" poll would make an
+        # ordinary chat that returns empty text hang for the full poll window.
+        if poll_async and not text and conv_id:
             text = await self._poll_async_response(conv_id)
 
         return text
@@ -1471,6 +1479,18 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                # Capture conversation_id from ANY frame that carries it at top
+                # level. _apply_patch only sets it from a few typed events
+                # (resume_conversation_token / message_marker /
+                # message_stream_complete); the regular stream() captures it
+                # generically. Without this, an async heavy-DR stream that closes
+                # before one of those markers leaves state["conversation_id"]
+                # None, so the Phase-2 poll gate below never fires and the report
+                # is silently lost.
+                if not state["conversation_id"]:
+                    cid = obj.get("conversation_id")
+                    if cid:
+                        state["conversation_id"] = cid
                 _raw_dump(obj, phase="heavy_sse")
 
                 events: list[dict] = []

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -30,6 +30,23 @@ def _safe_body(resp: object) -> str:
     return _redact_error(text) if text else ""
 
 
+def _raise_for_sse_error(obj: dict) -> None:
+    """Surface in-band SSE error frames instead of silently dropping them."""
+    raw: object = None
+    err = obj.get("error")
+    if isinstance(err, dict):
+        raw = err.get("message") or err.get("detail") or err.get("code") or err
+    elif isinstance(err, str):
+        raw = err
+    elif obj.get("type") in {"error", "conversation_error"}:
+        raw = obj.get("message") or obj.get("detail") or obj.get("code") or obj
+    if raw is None:
+        return
+    if not isinstance(raw, str):
+        raw = json.dumps(raw, ensure_ascii=False)
+    raise RuntimeError(f"ChatGPT SSE error: {_redact_error(raw, max_len=500)}")
+
+
 # /backend-api/f/conversation — the frontend-facing endpoint used by the web app.
 # Required for Deep Research heavy path; regular /conversation also works for normal chat.
 _F_CONV_URL = _BASE + "/backend-api/f/conversation"
@@ -176,6 +193,24 @@ def _pointer_parts(path: str, prefix: str) -> list[str]:
     return [p.replace("~1", "/").replace("~0", "~") for p in tail.split("/")]
 
 
+def _new_container(next_part: str) -> list | dict:
+    return [] if next_part == "-" or next_part.isdigit() else {}
+
+
+def _ensure_list_slot(seq: list, part: str, value_factory):
+    if part == "-":
+        seq.append(value_factory())
+        return seq[-1]
+    if not part.isdigit():
+        return None
+    idx = int(part)
+    while len(seq) <= idx:
+        seq.append(None)
+    if not isinstance(seq[idx], (dict, list)):
+        seq[idx] = value_factory()
+    return seq[idx]
+
+
 def _merge_metadata_path(meta: dict, path: str, op: str, value) -> dict:
     if path == "/message/metadata":
         if op in ("append", "patch") and isinstance(value, dict):
@@ -192,28 +227,48 @@ def _merge_metadata_path(meta: dict, path: str, op: str, value) -> dict:
     if not parts:
         return out
 
-    cur = out
-    for part in parts[:-1]:
-        nxt = cur.get(part)
-        if not isinstance(nxt, dict):
-            nxt = {}
-            cur[part] = nxt
-        cur = nxt
+    cur: dict | list = out
+    for i, part in enumerate(parts[:-1]):
+        next_part = parts[i + 1]
+        if isinstance(cur, dict):
+            nxt = cur.get(part)
+            if not isinstance(nxt, (dict, list)):
+                nxt = _new_container(next_part)
+                cur[part] = nxt
+            cur = nxt
+        elif isinstance(cur, list):
+            nxt = _ensure_list_slot(cur, part, lambda: _new_container(next_part))
+            if nxt is None:
+                return out
+            cur = nxt
 
     key = parts[-1]
-    if op == "append":
-        existing = cur.get(key)
-        if isinstance(existing, list):
-            cur[key] = [*existing, value]
-        elif isinstance(existing, str) and isinstance(value, str):
-            cur[key] = existing + value
+    if isinstance(cur, dict):
+        if op == "append":
+            existing = cur.get(key)
+            if isinstance(existing, list):
+                cur[key] = [*existing, value]
+            elif isinstance(existing, str) and isinstance(value, str):
+                cur[key] = existing + value
+            else:
+                cur[key] = value
+        elif op == "patch" and isinstance(value, dict) and isinstance(cur.get(key), dict):
+            cur[key] = {**cur[key], **value}
         else:
             cur[key] = value
-    elif op == "patch" and isinstance(value, dict) and isinstance(cur.get(key), dict):
-        cur[key] = {**cur[key], **value}
-    else:
-        cur[key] = value
+    elif isinstance(cur, list):
+        if key == "-" or op == "append":
+            cur.append(value)
+        elif key.isdigit():
+            idx = int(key)
+            while len(cur) <= idx:
+                cur.append(None)
+            cur[idx] = value
     return out
+
+
+def _is_connector_dispatch_text(text: str) -> bool:
+    return text.startswith('{"path":') and "connector_openai_deep_research" in text
 
 
 def _build_payload(
@@ -481,6 +536,7 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                _raise_for_sse_error(obj)
 
                 # Capture conversation_id from any event that carries it
                 cid = obj.get("conversation_id")
@@ -701,6 +757,7 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                _raise_for_sse_error(obj)
 
                 cid = obj.get("conversation_id")
                 if cid and not conversation_id:
@@ -877,6 +934,7 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                _raise_for_sse_error(obj)
 
                 cid = obj.get("conversation_id")
                 if cid and not conversation_id:
@@ -1059,6 +1117,7 @@ class ConversationClient:
                             continue
                         if not isinstance(obj, dict):
                             continue
+                        _raise_for_sse_error(obj)
 
                         # Capture conversation_id for multi-turn continuation.
                         cid = obj.get("conversation_id")
@@ -1305,10 +1364,7 @@ class ConversationClient:
                 state["asst_metadata"] = msg.get("metadata") or {}
                 if _has_citation_payload(state["asst_metadata"]):
                     state["citation_metadata"] = state["asst_metadata"]
-                state["is_connector_dispatch"] = (
-                    initial.startswith('{"path":')
-                    and "connector_openai_deep_research" in initial
-                )
+                state["is_connector_dispatch"] = _is_connector_dispatch_text(initial)
                 if initial and not state["is_connector_dispatch"]:
                     events.append({"type": "progress", "text": initial})
                 # Suppress _emit_done on:
@@ -1360,6 +1416,7 @@ class ConversationClient:
                     elif value:
                         events.append({"type": "progress", "text": value})
                     state["asst_text"] = value
+                    state["is_connector_dispatch"] = _is_connector_dispatch_text(value)
             elif path == "/message/status":
                 if op == "replace" and isinstance(value, str):
                     state["asst_status"] = value
@@ -1479,6 +1536,7 @@ class ConversationClient:
                     continue
                 if not isinstance(obj, dict):
                     continue
+                _raise_for_sse_error(obj)
                 # Capture conversation_id from ANY frame that carries it at top
                 # level. _apply_patch only sets it from a few typed events
                 # (resume_conversation_token / message_marker /

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -1405,18 +1405,23 @@ class ConversationClient:
         def _apply_path(path: str, op: str, value, events: list) -> None:
             if path == "/message/content/parts/0":
                 if op == "append" and isinstance(value, str):
-                    state["asst_text"] += value
-                    if value:
+                    next_text = state["asst_text"] + value
+                    was_dispatch = bool(state["is_connector_dispatch"])
+                    next_is_dispatch = was_dispatch or _is_connector_dispatch_text(next_text)
+                    state["asst_text"] = next_text
+                    state["is_connector_dispatch"] = next_is_dispatch
+                    if value and not next_is_dispatch:
                         events.append({"type": "progress", "text": value})
                 elif op == "replace" and isinstance(value, str):
-                    if value.startswith(state["asst_text"]):
+                    new_is_dispatch = _is_connector_dispatch_text(value)
+                    if not new_is_dispatch and value.startswith(state["asst_text"]):
                         delta = value[len(state["asst_text"]) :]
                         if delta:
                             events.append({"type": "progress", "text": delta})
-                    elif value:
+                    elif value and not new_is_dispatch:
                         events.append({"type": "progress", "text": value})
                     state["asst_text"] = value
-                    state["is_connector_dispatch"] = _is_connector_dispatch_text(value)
+                    state["is_connector_dispatch"] = new_is_dispatch
             elif path == "/message/status":
                 if op == "replace" and isinstance(value, str):
                     state["asst_status"] = value

--- a/gpt2agent/tools/_redact.py
+++ b/gpt2agent/tools/_redact.py
@@ -1,9 +1,29 @@
 import re
 
+# PII patterns.
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_PHONE_RE = re.compile(r"\+?\d[\d ()\-]{8,}\d")
+
+# Secret patterns. Users routinely paste API keys / tokens into ChatGPT, so they
+# end up in memories, tasks, and custom instructions — which these tools return
+# verbatim. Redact the common structured-secret shapes here so tool OUTPUT never
+# echoes one back. Kept separate from gpt2agent._log_redact (which scrubs session
+# headers from error bodies) so a change to one scope can't silently weaken the
+# other. Each pattern is long/structured enough not to match ordinary prose.
+_JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}")
+_BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._~+/\-]{16,}=*", re.IGNORECASE)
+_APIKEY_RE = re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9_-]{16,}")
+_GH_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")
+
 
 def redact(s: object) -> object:
     if not isinstance(s, str):
         return s
-    s = re.sub(r"[\w.+-]+@[\w-]+\.[\w.-]+", "<EMAIL>", s)
-    s = re.sub(r"\+?\d[\d ()\-]{8,}\d", "<PHONE>", s)
+    # Secrets first (a JWT/bearer must not survive by being partly eaten later).
+    s = _JWT_RE.sub("<JWT>", s)
+    s = _BEARER_RE.sub("Bearer <REDACTED>", s)
+    s = _APIKEY_RE.sub("<APIKEY>", s)
+    s = _GH_TOKEN_RE.sub("<TOKEN>", s)
+    s = _EMAIL_RE.sub("<EMAIL>", s)
+    s = _PHONE_RE.sub("<PHONE>", s)
     return s

--- a/gpt2agent/tools/_redact.py
+++ b/gpt2agent/tools/_redact.py
@@ -13,7 +13,7 @@ _PHONE_RE = re.compile(r"\+?\d[\d ()\-]{8,}\d")
 _JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}")
 _BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._~+/\-]{16,}=*", re.IGNORECASE)
 _APIKEY_RE = re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9_-]{16,}")
-_GH_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")
+_GH_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})")
 
 
 def redact(s: object) -> object:

--- a/gpt2agent/tools/apps.py
+++ b/gpt2agent/tools/apps.py
@@ -24,7 +24,12 @@ def register(mcp, client: BackendClient) -> None:
                 "id": a.get("id"),
                 "type": _classify(a.get("id") or ""),
                 "enabled": a.get("enabled"),
-                "connected": a.get("is_connected") or a.get("connected"),
+                # Check key presence, not truthiness: `is_connected: False` (a
+                # disconnected app) must report False, not fall through to
+                # `connected` or None.
+                "connected": (
+                    a["is_connected"] if "is_connected" in a else a.get("connected")
+                ),
             }
             for a in (data.get("apps") or [])
             if isinstance(a, dict)

--- a/gpt2agent/tools/conversations.py
+++ b/gpt2agent/tools/conversations.py
@@ -58,6 +58,7 @@ def register(mcp, client: BackendClient) -> None:
                 (n for n in mapping.values() if isinstance(n, dict)),
                 key=lambda n: ((n.get("message") or {}).get("create_time") or 0),
             )
+        ordered_nodes = ordered_nodes[-max_messages:] if max_messages > 0 else []
 
         messages = []
         for node in ordered_nodes:

--- a/gpt2agent/tools/conversations.py
+++ b/gpt2agent/tools/conversations.py
@@ -37,8 +37,30 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(f"/backend-api/conversation/{conversation_id}")
         if not data:
             return {}
+        mapping = data.get("mapping") or {}
+        # Walk the active branch from the leaf (`current_node`) up to the root via
+        # parent pointers, then reverse to chronological order. Raw `mapping`
+        # iteration order interleaves sibling branches of an edited/regenerated
+        # conversation and, combined with the max_messages cap, can drop visible
+        # turns. Fall back to a create_time sort when current_node is missing.
+        ordered_nodes: list = []
+        current = data.get("current_node")
+        if current and current in mapping:
+            seen_ids: set[str] = set()
+            nid = current
+            while nid and nid in mapping and nid not in seen_ids:
+                seen_ids.add(nid)
+                ordered_nodes.append(mapping[nid])
+                nid = (mapping[nid] or {}).get("parent")
+            ordered_nodes.reverse()
+        else:
+            ordered_nodes = sorted(
+                (n for n in mapping.values() if isinstance(n, dict)),
+                key=lambda n: ((n.get("message") or {}).get("create_time") or 0),
+            )
+
         messages = []
-        for node_id, node in (data.get("mapping") or {}).items():
+        for node in ordered_nodes:
             msg = (node or {}).get("message")
             if not isinstance(msg, dict):
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.7"
+version = "0.0.8"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },

--- a/tests/test_audit_2026_06_26.py
+++ b/tests/test_audit_2026_06_26.py
@@ -398,6 +398,23 @@ def test_auth_from_saved_accepts_all_shapes(tmp_path, monkeypatch, blob):
     assert res is not None and res["access_token"] == "T"
 
 
+def test_auth_get_token_prefers_codex_home_over_saved(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    saved = tmp_path / ".gpt2agent" / "token.json"
+    saved.parent.mkdir(parents=True, exist_ok=True)
+    saved.write_text(json.dumps({"access_token": "STALE_SAVED"}))
+
+    codex_home = tmp_path / ".codex-alt"
+    codex_auth = codex_home / "auth.json"
+    codex_auth.parent.mkdir(parents=True, exist_ok=True)
+    codex_auth.write_text(json.dumps({"tokens": {"access_token": "CODEX_HOME_TOKEN"}}))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    from gpt2agent import auth
+
+    assert auth.get_token(interactive=False) == "CODEX_HOME_TOKEN"
+
+
 @pytest.mark.parametrize(
     "blob",
     [

--- a/tests/test_audit_2026_06_26.py
+++ b/tests/test_audit_2026_06_26.py
@@ -371,6 +371,7 @@ def test_tool_redact_secrets():
     assert jwt not in redact(jwt)
     assert "<APIKEY>" in redact("sk-" + "a" * 30)
     assert "Bearer <REDACTED>" in redact("Authorization: Bearer " + "z" * 40)
+    assert "<TOKEN>" in redact("github_pat_" + "A" * 24)
     # PII still works; ordinary prose untouched.
     assert redact("ping me at a@b.com") == "ping me at <EMAIL>"
     assert redact("just some words") == "just some words"
@@ -520,3 +521,6 @@ def test_get_conversation_follows_active_chain():
     texts = [m["text"] for m in out["messages"]]
     assert texts == ["hello", "hi", "more", "done"]
     assert "STALE BRANCH" not in texts
+
+    limited = captured["get_conversation"]("c1", max_messages=2)
+    assert [m["text"] for m in limited["messages"]] == ["more", "done"]

--- a/tests/test_audit_2026_06_26.py
+++ b/tests/test_audit_2026_06_26.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import stat
 
 import pytest
@@ -397,6 +396,24 @@ def test_auth_from_saved_accepts_all_shapes(tmp_path, monkeypatch, blob):
 
     res = auth._from_saved()
     assert res is not None and res["access_token"] == "T"
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        {"access_token": "T"},
+        {"token": "T"},
+        {"tokens": {"access_token": "T"}},
+    ],
+)
+def test_setup_from_saved_accepts_all_shapes(tmp_path, monkeypatch, blob):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = tmp_path / ".gpt2agent" / "token.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(blob))
+    from gpt2agent import setup
+
+    assert setup._token_from_saved() == "T"
 
 
 # ── C8: apps preserves explicit is_connected=False ────────────────────────────

--- a/tests/test_audit_2026_06_26.py
+++ b/tests/test_audit_2026_06_26.py
@@ -1,0 +1,488 @@
+"""Regression tests for the 2026-06-26 cross-model audit (cx + cx2 + ccz + Opus).
+
+Each test pins a specific bug found in the v0.0.7 audit so it can't silently
+regress. Test name → finding id maps to artifacts/verify and the audit synthesis.
+No network: backend/SSE I/O is faked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _mk_codex_auth(tmp_path, token: str = "TOK") -> None:
+    auth = tmp_path / ".codex" / "auth.json"
+    auth.parent.mkdir(parents=True, exist_ok=True)
+    auth.write_text(json.dumps({"tokens": {"access_token": token}}))
+
+
+class _Resp:
+    def __init__(self, status, text, *, json_exc=False, json_val=None):
+        self.status_code = status
+        self.text = text
+        self._json_exc = json_exc
+        self._json_val = json_val
+
+    def json(self):
+        if self._json_exc:
+            raise ValueError("not json")
+        return self._json_val
+
+
+class _Sess:
+    def __init__(self, resp):
+        self._resp = resp
+        self.headers: dict = {}
+
+    def get(self, url, headers=None, timeout=None):
+        return self._resp
+
+
+# ── C2: backend.get() non-JSON 2xx guard (parity with post()) ─────────────────
+
+
+def test_backend_get_non_json_2xx_raises_clean_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _mk_codex_auth(tmp_path)
+    from gpt2agent import backend as be
+
+    client = be.BackendClient()
+    client._session = _Sess(_Resp(200, "<html>cloudflare</html>", json_exc=True))
+    with pytest.raises(RuntimeError, match="non-JSON 2xx"):
+        client.get("/backend-api/me")
+
+
+def test_backend_get_empty_2xx_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _mk_codex_auth(tmp_path)
+    from gpt2agent import backend as be
+
+    client = be.BackendClient()
+    client._session = _Sess(_Resp(200, "   ", json_exc=True))
+    assert client.get("/backend-api/me") is None
+
+
+def test_backend_get_redacts_secret_in_non_json_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _mk_codex_auth(tmp_path)
+    from gpt2agent import backend as be
+
+    client = be.BackendClient()
+    leak = "Bearer eyJ" + "a" * 40 + " gateway boom"
+    client._session = _Sess(_Resp(200, leak, json_exc=True))
+    with pytest.raises(RuntimeError) as ei:
+        client.get("/x")
+    assert "eyJ" + "a" * 40 not in str(ei.value)
+    assert "<REDACTED>" in str(ei.value)
+
+
+# ── C4: heavy DR captures top-level conversation_id so Phase-2 poll fires ──────
+
+
+class _FrameResp:
+    status_code = 200
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def aiter_lines(self):
+        for ln in self._lines:
+            yield ln
+
+
+class _FrameSession:
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def post(self, *a, **k):
+        return _FrameResp(self._lines)
+
+
+class _PollBackend:
+    """Quota probe via post(); Phase-2 conversation poll via get()."""
+
+    class _S:
+        headers = {"User-Agent": "t"}
+
+    _session = _S()
+
+    def __init__(self, report_detail):
+        self._report_detail = report_detail
+
+    def _reload_token_if_stale(self):
+        pass
+
+    def post(self, *a, **k):
+        return {"limits_progress": [{"feature_name": "deep_research", "remaining": 9}]}
+
+    def get(self, *a, **k):
+        return self._report_detail
+
+
+class _StubSentinel:
+    def __init__(self, *a, **k):
+        pass
+
+    async def get_tokens(self):
+        return {"chat-requirements": "x", "proof": "", "turnstile": ""}
+
+
+def test_heavy_dr_polls_after_toplevel_conversation_id(monkeypatch):
+    from gpt2agent import sse as sse_mod
+
+    # Frames: tool invoked + top-level conversation_id (NOT via a marker event),
+    # report streams partially, stream closes WITHOUT finished_successfully.
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-tool",
+                        "author": {"role": "assistant"},
+                        "recipient": "api_tool_chatgpt_deep_research",
+                        "content": {"content_type": "text", "parts": ["call"]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 1,
+                "conversation_id": "conv-xyz",
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-report",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "content": {"content_type": "text", "parts": ["partial"]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 2,
+            }
+        ),
+        "data: [DONE]",
+    ]
+
+    report_detail = {
+        "mapping": {
+            "n1": {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "recipient": "all",
+                    "content": {"content_type": "text", "parts": ["FINAL REPORT"]},
+                    "status": "finished_successfully",
+                    "create_time": 2,
+                    "metadata": {},
+                }
+            }
+        }
+    }
+
+    monkeypatch.setattr(sse_mod, "AsyncSession", lambda *a, **k: _FrameSession(frames))
+    monkeypatch.setattr(sse_mod, "SentinelGate", _StubSentinel)
+
+    async def _no_sleep(*a, **k):
+        return None
+
+    monkeypatch.setattr(sse_mod.asyncio, "sleep", _no_sleep)
+
+    client = sse_mod.ConversationClient(_PollBackend(report_detail))
+
+    async def _go():
+        out = []
+        async for ev in client.deep_research_heavy("q"):
+            out.append(ev)
+        return out
+
+    events = asyncio.run(_go())
+    dones = [e for e in events if e.get("type") == "done"]
+    assert dones, f"expected a done event from polling, got {events}"
+    assert dones[-1]["text"] == "FINAL REPORT"
+
+
+# ── C1: null `message` in a v-patch frame must not crash the stream ────────────
+
+
+def test_stream_tolerates_null_message_frame(monkeypatch):
+    from gpt2agent import sse as sse_mod
+
+    frames = [
+        "data: " + json.dumps({"v": {"message": None}}),  # would AttributeError pre-fix
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "m1",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["hello"]},
+                        "status": "in_progress",
+                    }
+                }
+            }
+        ),
+        "data: [DONE]",
+    ]
+
+    class _Backend:
+        class _S:
+            headers = {"User-Agent": "t"}
+
+        _session = _S()
+
+        def _reload_token_if_stale(self):
+            pass
+
+    monkeypatch.setattr(sse_mod, "AsyncSession", lambda *a, **k: _FrameSession(frames))
+    monkeypatch.setattr(sse_mod, "SentinelGate", _StubSentinel)
+
+    client = sse_mod.ConversationClient(_Backend())
+
+    async def _go():
+        out = []
+        async for ev in client.stream("gpt-5-3", [{"role": "user", "content": "x"}]):
+            if isinstance(ev, str):
+                out.append(ev)
+        return "".join(out)
+
+    assert asyncio.run(_go()) == "hello"
+
+
+# ── C5: install TOML section editor preserves [[array-of-table]] sections ──────
+
+
+def test_install_replace_preserves_array_of_table(monkeypatch):
+    from gpt2agent import install as inst
+
+    content = (
+        "[mcp_servers.gpt2agent]\n"
+        'command = "old"\n'
+        "\n"
+        "[[mcp_servers.other.headers]]\n"
+        'name = "X"\n'
+        "\n"
+        "[model]\n"
+        'name = "gpt"\n'
+    )
+    out = inst._replace_or_append_toml_section(
+        content, "mcp_servers.gpt2agent", ['command = "gpt2agent"']
+    )
+    # The array-of-table block must survive (pre-fix it was swallowed as body).
+    assert "[[mcp_servers.other.headers]]" in out
+    assert 'name = "X"' in out
+    assert "[model]" in out
+    assert 'command = "gpt2agent"' in out
+
+
+# ── S1/S3/S4: secret files written 0o600, never world-readable ────────────────
+
+
+def test_setup_save_token_is_0600(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from gpt2agent import setup as su
+
+    # Pre-create a world-readable token.json so the test also catches the
+    # existing-file case (O_CREAT's mode is ignored when the file exists).
+    d = tmp_path / ".gpt2agent"
+    d.mkdir(parents=True, exist_ok=True)
+    pre = d / "token.json"
+    pre.write_text("{}")
+    pre.chmod(0o644)
+
+    su.save_token("secret-bearer")
+    assert json.loads(pre.read_text())["access_token"] == "secret-bearer"
+    assert stat.S_IMODE(pre.stat().st_mode) == 0o600
+
+
+def test_auth_save_token_tightens_existing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    d = tmp_path / ".gpt2agent"
+    d.mkdir(parents=True, exist_ok=True)
+    pre = d / "token.json"
+    pre.write_text("{}")
+    pre.chmod(0o644)
+
+    from gpt2agent import auth
+
+    # _from_browser returns a token → get_token saves it.
+    monkeypatch.setattr(auth, "_from_browser", lambda: {"access_token": "B", "source": "browser"})
+    # Force the browser path: no codex/saved sources.
+    monkeypatch.setattr(auth, "_from_codex", lambda: None)
+    monkeypatch.setattr(auth, "_from_browser_use", lambda: None)
+    pre.write_text("{}")  # ensure _from_saved sees no usable token
+    monkeypatch.setattr(auth, "_from_saved", lambda: None)
+
+    auth.get_token(interactive=True)
+    assert stat.S_IMODE(pre.stat().st_mode) == 0o600
+
+
+def test_install_backup_not_wider_than_source(tmp_path):
+    from gpt2agent import install as inst
+    from pathlib import Path
+
+    src = Path(tmp_path) / "config.json"
+    src.write_text('{"secret": "x"}')
+    src.chmod(0o600)
+    bak = inst._backup(src)
+    assert bak is not None
+    assert stat.S_IMODE(bak.stat().st_mode) == 0o600
+
+
+# ── S7: _log_redact scrubs a bare "token" JSON field ──────────────────────────
+
+
+def test_log_redact_bare_token_field():
+    from gpt2agent._log_redact import redact_error
+
+    out = redact_error('{"token": "eyJSECRET.jwt.value"}')
+    assert "eyJSECRET" not in out
+    assert "<REDACTED>" in out
+    # Must not mangle the word "token" in prose.
+    assert redact_error("the token expired") == "the token expired"
+
+
+# ── S5: tool-output redaction scrubs pasted secrets, not just PII ─────────────
+
+
+def test_tool_redact_secrets():
+    from gpt2agent.tools._redact import redact
+
+    jwt = "eyJhbGciOi" + "A" * 20 + ".eyJzdWIi" + "B" * 20 + ".sig" + "C" * 20
+    assert "<JWT>" in redact(f"my key is {jwt} ok")
+    assert jwt not in redact(jwt)
+    assert "<APIKEY>" in redact("sk-" + "a" * 30)
+    assert "Bearer <REDACTED>" in redact("Authorization: Bearer " + "z" * 40)
+    # PII still works; ordinary prose untouched.
+    assert redact("ping me at a@b.com") == "ping me at <EMAIL>"
+    assert redact("just some words") == "just some words"
+
+
+# ── C7: auth._from_saved accepts every token shape backend accepts ────────────
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        {"access_token": "T"},
+        {"token": "T"},
+        {"tokens": {"access_token": "T"}},
+    ],
+)
+def test_auth_from_saved_accepts_all_shapes(tmp_path, monkeypatch, blob):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = tmp_path / ".gpt2agent" / "token.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(blob))
+    from gpt2agent import auth
+
+    res = auth._from_saved()
+    assert res is not None and res["access_token"] == "T"
+
+
+# ── C8: apps preserves explicit is_connected=False ────────────────────────────
+
+
+def test_apps_preserves_explicit_false(monkeypatch):
+    from gpt2agent.tools import apps
+
+    captured = {}
+
+    class _MCP:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    class _Client:
+        def get(self, *a, **k):
+            return {"apps": [{"id": "connector_x", "enabled": True, "is_connected": False}]}
+
+    apps.register(_MCP(), _Client())
+    out = captured["list_apps"]()
+    assert out[0]["connected"] is False
+
+
+# ── C9: load_config raises on an explicit-but-missing path ────────────────────
+
+
+def test_load_config_missing_explicit_path_raises(tmp_path):
+    from gpt2agent.server import load_config
+    from pathlib import Path
+
+    with pytest.raises(FileNotFoundError):
+        load_config(Path(tmp_path) / "nope.toml")
+
+
+# ── C6: get_conversation follows the active branch in chronological order ──────
+
+
+def test_get_conversation_follows_active_chain():
+    from gpt2agent.tools import conversations
+
+    captured = {}
+
+    class _MCP:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    def _node(nid, parent, role, text, t):
+        return {
+            "id": nid,
+            "parent": parent,
+            "message": {
+                "id": nid,
+                "author": {"role": role},
+                "content": {"content_type": "text", "parts": [text]},
+                "status": "finished_successfully",
+                "create_time": t,
+            },
+        }
+
+    detail = {
+        "id": "c1",
+        "title": "t",
+        "current_node": "a2",
+        "mapping": {
+            "root": {"id": "root", "parent": None, "message": None},
+            "u1": _node("u1", "root", "user", "hello", 1),
+            "a1": _node("a1", "u1", "assistant", "hi", 2),
+            # An abandoned sibling branch that must NOT appear in the active chain.
+            "a1b": _node("a1b", "u1", "assistant", "STALE BRANCH", 2),
+            "u2": _node("u2", "a1", "user", "more", 3),
+            "a2": _node("a2", "u2", "assistant", "done", 4),
+        },
+    }
+
+    class _Client:
+        def get(self, *a, **k):
+            return detail
+
+    conversations.register(_MCP(), _Client())
+    out = captured["get_conversation"]("c1")
+    texts = [m["text"] for m in out["messages"]]
+    assert texts == ["hello", "hi", "more", "done"]
+    assert "STALE BRANCH" not in texts

--- a/tests/test_heavy_dr_parser.py
+++ b/tests/test_heavy_dr_parser.py
@@ -558,6 +558,69 @@ def test_progress_excludes_dispatch_json(monkeypatch: pytest.MonkeyPatch) -> Non
     assert _REAL_REPORT in progress_text
 
 
+def test_dispatch_patch_progress_suppressed_until_real_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-report",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "content": {"content_type": "text", "parts": [""]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 1,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/content/parts/0",
+                "o": "append",
+                "v": _DISPATCH_TEXT,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/content/parts/0",
+                "o": "append",
+                "v": " hidden-dispatch-tail",
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/content/parts/0",
+                "o": "replace",
+                "v": _REAL_REPORT,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {"p": "/message/status", "o": "replace", "v": "finished_successfully"}
+        ),
+        "data: [DONE]",
+    ]
+
+    events = _run_heavy_dr_with_frames(monkeypatch, frames)
+    progress_text = "".join(
+        e["text"] for e in events if e.get("type") == "progress"
+    )
+    done = [e for e in events if e.get("type") == "done"][-1]
+
+    assert _DISPATCH_TEXT not in progress_text
+    assert "hidden-dispatch-tail" not in progress_text
+    assert _REAL_REPORT in progress_text
+    assert done["text"] == _REAL_REPORT
+
+
 def test_dr_payloads_disable_temp_chat() -> None:
     """history_and_training_disabled must be False for DR payloads.
 

--- a/tests/test_heavy_dr_parser.py
+++ b/tests/test_heavy_dr_parser.py
@@ -281,6 +281,127 @@ def test_nested_metadata_patch_preserves_citation_payload(
     assert done["search_result_groups"] == [group]
 
 
+def test_array_metadata_patch_preserves_citation_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ref = {
+        "matched_text": "OpenAI",
+        "items": [{"title": "OpenAI", "url": "https://openai.com/"}],
+        "type": "webpage",
+    }
+    group = {
+        "type": "search_result_group",
+        "entries": [{"title": "OpenAI", "url": "https://openai.com/"}],
+    }
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-report",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "content": {"content_type": "text", "parts": ["Report"]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 1,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/metadata/content_references/0",
+                "o": "replace",
+                "v": ref,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/metadata/search_result_groups/0",
+                "o": "replace",
+                "v": group,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {"p": "/message/status", "o": "replace", "v": "finished_successfully"}
+        ),
+        "data: [DONE]",
+    ]
+    events = _run_heavy_dr_with_frames(monkeypatch, frames)
+    done = [e for e in events if e.get("type") == "done"][-1]
+
+    assert done["content_references"] == [ref]
+    assert done["search_result_groups"] == [group]
+
+
+def test_connector_dispatch_replaced_by_real_report_can_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "v": {
+                    "message": {
+                        "id": "msg-dispatch",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "content": {"content_type": "text", "parts": [_DISPATCH_TEXT]},
+                        "status": "in_progress",
+                        "metadata": {},
+                    }
+                },
+                "c": 1,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "p": "/message/content/parts/0",
+                "o": "replace",
+                "v": _REAL_REPORT,
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {"p": "/message/status", "o": "replace", "v": "finished_successfully"}
+        ),
+        "data: [DONE]",
+    ]
+    events = _run_heavy_dr_with_frames(monkeypatch, frames)
+    dones = [e for e in events if e.get("type") == "done"]
+
+    assert len(dones) == 1
+    assert dones[0]["text"] == _REAL_REPORT
+    assert not dones[0].get("terminated_abnormally")
+
+
+def test_heavy_dr_in_band_sse_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    frames = [
+        "data: "
+        + json.dumps(
+            {
+                "type": "error",
+                "message": "upstream failed with Bearer eyJ" + "a" * 30,
+            }
+        ),
+        "data: [DONE]",
+    ]
+
+    with pytest.raises(RuntimeError) as exc:
+        _run_heavy_dr_with_frames(monkeypatch, frames)
+
+    message = str(exc.value)
+    assert "ChatGPT SSE error" in message
+    assert "eyJ" + "a" * 30 not in message
+    assert "Bearer <REDACTED>" in message
+
+
 def test_poll_completion_uses_citation_metadata_from_same_turn_fixture() -> None:
     from gpt2agent import sse as sse_mod
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,6 +14,7 @@ import pytest
 
 from gpt2agent.install import (
     SUPPORTED_CLIENTS,
+    _remove_toml_section,
     _replace_or_append_toml_section,
     detect_clients,
     install_claude_code,
@@ -321,6 +322,30 @@ def test_replace_toml_section_replaces_body() -> None:
     assert '[other]' in out
     assert 'k = 2' in out
     assert out.count("[mcp_servers.x]") == 1
+
+
+def test_toml_section_editors_preserve_commented_headers() -> None:
+    src = (
+        "[mcp_servers.x]\n"
+        'command = "old"\n'
+        "\n"
+        "[model] # keep this section\n"
+        'name = "gpt"\n'
+        "\n"
+        "[[profiles]] # keep this array table\n"
+        'name = "work"\n'
+    )
+    replaced = _replace_or_append_toml_section(src, "mcp_servers.x", ['command = "new"'])
+    assert 'command = "old"' not in replaced
+    assert "[model] # keep this section" in replaced
+    assert 'name = "gpt"' in replaced
+    assert "[[profiles]] # keep this array table" in replaced
+    assert 'name = "work"' in replaced
+
+    removed = _remove_toml_section(src, "mcp_servers.x")
+    assert "[mcp_servers.x]" not in removed
+    assert "[model] # keep this section" in removed
+    assert "[[profiles]] # keep this array table" in removed
 
 
 # ── detect ─────────────────────────────────────────────────────────────────

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -387,9 +387,11 @@ class _RecordConv:
         self.dr_events: list[dict] = []
         self.heavy_events: list[dict] = []
 
-    async def complete(self, model, messages, *, temporary=True, gizmo_id=None):
+    async def complete(self, model, messages, *, temporary=True, gizmo_id=None,
+                       poll_async=False):
         self.complete_calls.append({"model": model, "messages": messages,
-                                    "temporary": temporary, "gizmo_id": gizmo_id})
+                                    "temporary": temporary, "gizmo_id": gizmo_id,
+                                    "poll_async": poll_async})
         return self.reply
 
     def deep_research(self, q):
@@ -425,6 +427,16 @@ def test_agent_always_temporary_false(monkeypatch) -> None:
     asyncio.run(tools["agent"].fn("do stuff"))
     assert conv.complete_calls[-1]["temporary"] is False
     assert conv.complete_calls[-1]["model"] == "agent-mode"
+    # Agent mode must opt into async polling; plain chat must not (else an empty
+    # chat response would hang on the 5-min poll window).
+    assert conv.complete_calls[-1]["poll_async"] is True
+
+
+def test_chat_does_not_poll_async(monkeypatch) -> None:
+    conv = _RecordConv()
+    tools = _build_with_conv(monkeypatch, conv)
+    asyncio.run(tools["chat"].fn("hi"))
+    assert conv.complete_calls[-1]["poll_async"] is False
 
 
 def test_gpt_chat_temporary_false_and_passes_gizmo(monkeypatch) -> None:


### PR DESCRIPTION
## What & why

Remediates the 2026-06-26 cross-model audit findings on top of v0.0.7 and prepares a 0.0.8 release candidate.

Key changes:
- Tighten secret-bearing config/token writes and backups.
- Broaden error/tool-output secret redaction, including fine-grained `github_pat_` tokens.
- Harden SSE parsing for non-JSON responses, in-band error frames, null message patches, heavy-DR async polling, metadata array patches, connector-dispatch replacement, and dispatch-patch progress suppression.
- Align setup/auth/backend saved-token shape handling and prefer Codex auth before stale saved tokens.
- Preserve Codex TOML array-of-table and commented section headers during install replacement.
- Follow active conversation branches, keep newest turns under `max_messages`, and preserve explicit disconnected app state.
- Bump release metadata to 0.0.8 and add changelog/verification receipt.

## Verification

Local checks run from `/home/robot/workspace/47-chatgpt2agent/gpt2agent`:

- `SKIP_LIVE=1 python -m pytest -q` -> `129 passed, 9 skipped`
- `python -m ruff check gpt2agent tests` -> clean
- `shellcheck -e SC2086 -e SC2155 install.sh` -> clean
- `python -m compileall -q gpt2agent tests` -> clean
- JSON parse of `server.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` -> clean
- version consistency check -> `pyproject.toml`, `server.json`, package entry, and plugin manifest all `0.0.8`
- `python -m build --outdir /tmp/gpt2agent-dist.y7cqZ3` -> built `gpt2agent-0.0.8` wheel + sdist
- `python -m twine check /tmp/gpt2agent-dist.y7cqZ3/*` -> both passed
- isolated venv wheel smoke in `/tmp/gpt2agent-venv.cpqnZi/venv` -> imports `0.0.8`, console script reports `gpt2agent 0.0.8`, bundled skills present, installed auth prefers `CODEX_HOME`, installed redaction masks `github_pat_`
- import sanity -> all 11 changed runtime modules import clean
- `git diff --check` -> clean
- added-secret scan over PR diff -> clean
- PyPI check -> latest published remains `0.0.7`, so `0.0.8` does not collide

GitHub checks on head `1f4d7b00f9518bdae55a471e5ba616ecc1db69ff`:
- CI test matrix passes on Ubuntu/macOS Python 3.10, 3.11, 3.12, 3.13.
- `lint-installer` passes.
- CodeRabbit status passes. Prior actionable comments were fixed in `1f4d7b0` with focused regression coverage.

## Release notes

After merge, tag `v0.0.8` from `main` to trigger the release workflow. This PR does not create the tag or publish the release.
