### PR TITLE
fix: 2026-07-01 audit remediation — body redaction, TOML subtable orphan, DR clarification false-positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- `get_conversation` now redacts message `text`/`code` bodies (emails, phones,
+  JWT / bearer / API-key / GitHub-token shapes), matching the already-redacted
+  `title` and the skill-doc claim. Redaction runs before truncation so a secret
+  straddling the 2000-char cut cannot leak as a partial token.
+
+### Fixed
+
+- Codex TOML section remove/replace now treats dotted child subtables
+  (`[mcp_servers.x.env]`) as part of the section. The legacy
+  `[mcp_servers.openai]` cleanup no longer leaves an orphaned command-less
+  half-entry Codex would spawn-and-fail on, and re-install no longer keeps a
+  stale `.env` subtable from the replaced block.
+- Legacy Deep Research no longer misclassifies a long real report whose prose
+  contains an ordinary hint phrase ("to make sure", "would you like") as a
+  clarification request — that auto-proceed round overwrote the real report
+  and burned DR quota. Clarification detection now applies only to short
+  (≤ 1200 char) done-texts.
+
 ## [0.0.8] - 2026-06-27
 
 Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.7.

--- a/README.md
+++ b/README.md
@@ -263,10 +263,11 @@ has real consequences; please understand them before pointing it at your account
   `~/.gpt2agent/token.json`, chmod `600`) and sent only to `chatgpt.com`.
   gpt2agent never transmits it anywhere else. Token/secret values are redacted
   from error messages and logs (best-effort).
-- **PII redaction is limited.** Tools that return conversation/memory data strip
-  only **emails and phone numbers** from text — names, addresses, IDs, and the
-  full message bodies of `get_conversation` are returned verbatim. Don't treat
-  the output as anonymized.
+- **PII redaction is limited.** Tools that return conversation/memory data mask
+  **emails, phone numbers, and common secret shapes** (JWTs, bearer tokens,
+  `sk-`-style API keys, GitHub tokens) from text — including `get_conversation`
+  message bodies — but names, addresses, IDs, and everything else are returned
+  verbatim. Don't treat the output as anonymized.
 - **`GPT2AGENT_RAW_DUMP`** (debug) writes raw, unredacted SSE/poll traffic —
   including prompts, responses, and resume tokens — to the path you give it.
   Use only for debugging and delete the dumps after.

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -198,18 +198,34 @@ def _toml_quote(value: str) -> str:
     return f'"{escaped}"'
 
 
+# Match both standard table headers `[x]` and array-of-table headers `[[x]]`.
+# Missing the `[[...]]` form made the body-skip loop swallow a following
+# array-of-table section as if it were part of the replaced/removed block,
+# deleting unrelated valid TOML.
+_SECTION_HEADER_RE = re.compile(r"^\s*\[\[?([^\[\]\n]+)\]\]?\s*(?:#.*)?$")
+
+
+def _belongs_to_section(header_line: str, section_name: str) -> bool:
+    """True iff *header_line* is ``[section_name]`` itself or a dotted child
+    (``[section_name.env]``, ``[[section_name.x]]``). Child subtables are part
+    of the section for TOML semantics — removing/replacing the parent while
+    leaving a child behind resurrects the section as a headless half-entry.
+    """
+    m = _SECTION_HEADER_RE.match(header_line)
+    if not m:
+        return False
+    name = m.group(1).strip()
+    return name == section_name or name.startswith(section_name + ".")
+
+
 def _remove_toml_section(content: str, section_name: str) -> str:
     """Remove the ``[section_name]`` block from TOML content. No-op if absent.
 
-    A section runs from its ``[header]`` line up to the next ``[header]`` or
-    end-of-file. Other sections are preserved verbatim.
+    A section runs from its ``[header]`` line up to the next *unrelated*
+    ``[header]`` or end-of-file; dotted child subtables are removed with it.
+    Other sections are preserved verbatim.
     """
     header = f"[{section_name}]"
-    # Match both standard table headers `[x]` and array-of-table headers `[[x]]`.
-    # Missing the `[[...]]` form made the body-skip loop swallow a following
-    # array-of-table section as if it were part of the replaced/removed block,
-    # deleting unrelated valid TOML.
-    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*(?:#.*)?$")
     out: list[str] = []
     skipping = False
     for line in content.splitlines():
@@ -217,7 +233,7 @@ def _remove_toml_section(content: str, section_name: str) -> str:
             skipping = True
             continue
         if skipping:
-            if section_header_re.match(line):
+            if _SECTION_HEADER_RE.match(line) and not _belongs_to_section(line, section_name):
                 skipping = False
                 # fall through to keep this header line
             else:
@@ -249,9 +265,11 @@ def _replace_or_append_toml_section(
 ) -> str:
     """Replace ``[section_name]`` block in ``content`` or append it.
 
-    A section runs from its ``[header]`` line up to the next ``[header]`` or
-    end-of-file. Other sections are preserved verbatim. The new block is
-    written as ``[section_name]`` followed by ``new_section_lines``.
+    A section runs from its ``[header]`` line up to the next *unrelated*
+    ``[header]`` or end-of-file; dotted child subtables of the old block are
+    replaced with it (stale ``[section.env]`` must not outlive a replace).
+    Other sections are preserved verbatim. The new block is written as
+    ``[section_name]`` followed by ``new_section_lines``.
     """
     header = f"[{section_name}]"
     new_block = "\n".join([header, *new_section_lines]).strip("\n")
@@ -260,11 +278,6 @@ def _replace_or_append_toml_section(
     out: list[str] = []
     i = 0
     found = False
-    # Match both standard table headers `[x]` and array-of-table headers `[[x]]`.
-    # Missing the `[[...]]` form made the body-skip loop swallow a following
-    # array-of-table section as if it were part of the replaced/removed block,
-    # deleting unrelated valid TOML.
-    section_header_re = re.compile(r"^\s*\[\[?[^\[\]\n]+\]\]?\s*(?:#.*)?$")
 
     while i < len(lines):
         line = lines[i]
@@ -272,8 +285,12 @@ def _replace_or_append_toml_section(
             found = True
             out.append(new_block)
             i += 1
-            # Skip prior body until next section header or EOF
-            while i < len(lines) and not section_header_re.match(lines[i]):
+            # Skip prior body (incl. dotted child subtables) until the next
+            # unrelated section header or EOF.
+            while i < len(lines) and (
+                not _SECTION_HEADER_RE.match(lines[i])
+                or _belongs_to_section(lines[i], section_name)
+            ):
                 i += 1
             continue
         out.append(line)

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -361,22 +361,30 @@ _DR_AUTO_PROCEED = (
     "Do not ask further clarifying questions. Begin the research now."
 )
 
+# A genuine clarification request is a question or a short list of questions —
+# a few sentences. Anything longer is a report, even if its prose happens to
+# contain a hint phrase ("to make sure the comparison is fair, …").
+_CLARIFICATION_MAX_LEN = 1200
+
 
 def _looks_like_clarification(text: str) -> bool:
     """Heuristic: does this assistant 'done' text look like a clarification request?
 
     Matches a curated phrase list ("could you confirm", "before I start", "just
-    one key clarification", "shall I proceed", etc.). The earlier "short text
-    ending in ?" branch was removed — real reports often end with rhetorical
-    questions, and triggering an auto-proceed on a real report wastes a round
-    and can corrupt the conversation. The phrase list is conservative; if a
-    clarification slips through, the caller still gets the question text and
-    can re-invoke explicitly.
+    one key clarification", "shall I proceed", etc.), but only on short text
+    (≤ _CLARIFICATION_MAX_LEN chars). Without the length ceiling, a real
+    multi-thousand-word report containing an ordinary phrase like "to make
+    sure" anywhere in its body trips the substring match — the wrapper then
+    burns a DR round on _DR_AUTO_PROCEED and overwrites the real report with
+    the follow-up response. The earlier "short text ending in ?" branch stays
+    removed — real reports often end with rhetorical questions. The heuristic
+    is conservative; if a clarification slips through, the caller still gets
+    the question text and can re-invoke explicitly.
     """
     if not text:
         return False
     stripped = text.strip()
-    if not stripped:
+    if not stripped or len(stripped) > _CLARIFICATION_MAX_LEN:
         return False
     lower = stripped.lower()
     return any(p in lower for p in _CLARIFICATION_HINTS)

--- a/gpt2agent/tools/conversations.py
+++ b/gpt2agent/tools/conversations.py
@@ -82,7 +82,9 @@ def register(mcp, client: BackendClient) -> None:
             if ct in ("text", "multimodal_text") and parts:
                 str_parts = [p for p in parts if isinstance(p, str)]
                 if str_parts:
-                    entry["text"] = str_parts[0][:2000]
+                    # Redact BEFORE truncating so a secret straddling the cut
+                    # can't survive as a partial token (same order as _log_redact).
+                    entry["text"] = redact(str_parts[0])[:2000]
                 # Check for image assets in multimodal parts
                 img_parts = [p for p in parts if isinstance(p, dict) and p.get("content_type") == "image_asset_pointer"]
                 if img_parts:
@@ -95,7 +97,7 @@ def register(mcp, client: BackendClient) -> None:
                         for p in img_parts
                     ]
             elif ct == "code" and parts and isinstance(parts[0], str):
-                entry["code"] = parts[0][:500]
+                entry["code"] = redact(parts[0])[:500]
             messages.append(entry)
             if len(messages) >= max_messages:
                 break

--- a/tests/test_dr_clarification.py
+++ b/tests/test_dr_clarification.py
@@ -223,6 +223,26 @@ def test_clarification_detection_unit() -> None:
 
     # Negative — long real report
     assert not _looks_like_clarification("Detailed report. " * 200)
+
+    # Negative — long real report whose PROSE contains a hint phrase. Without
+    # the length ceiling this false-positived, burning a DR round and letting
+    # the auto-proceed follow-up overwrite the real report.
+    report_with_phrase = (
+        "## Findings\n\nThe data shows X. To make sure the comparison is fair, "
+        "both series were normalized to 2020 baselines.\n\n" + "More analysis. " * 120
+    )
+    assert not _looks_like_clarification(report_with_phrase)
+    assert not _looks_like_clarification(
+        "Methodology note: before I begin the appendix, caveats apply. " * 40
+    )
+
+    # Positive — a genuine multi-question clarification stays under the ceiling.
+    multi_q = (
+        "Before I begin, could you confirm: 1) which regions to cover, "
+        "2) whether to include 2025 data, and 3) the preferred output format?"
+    )
+    assert _looks_like_clarification(multi_q)
+
     # Negative — empty
     assert not _looks_like_clarification("")
     assert not _looks_like_clarification("   ")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -348,6 +348,62 @@ def test_toml_section_editors_preserve_commented_headers() -> None:
     assert "[[profiles]] # keep this array table" in removed
 
 
+def test_toml_section_editors_remove_dotted_child_subtables() -> None:
+    """A section's dotted children ([x.env]) are part of the section: removing
+    or replacing [mcp_servers.openai] must not orphan [mcp_servers.openai.env]
+    — that leaves a command-less half-entry Codex spawn-and-fails on. Siblings
+    with a shared name prefix ([mcp_servers.openai2]) are NOT children."""
+    src = (
+        "[mcp_servers.openai]\n"
+        'command = "openai-mcp"\n'
+        "\n"
+        "[mcp_servers.openai.env]\n"
+        'FOO = "bar"\n'
+        "\n"
+        "[mcp_servers.openai2]\n"
+        'command = "keep-me"\n'
+    )
+    removed = _remove_toml_section(src, "mcp_servers.openai")
+    assert "[mcp_servers.openai]" not in removed
+    assert "[mcp_servers.openai.env]" not in removed
+    assert 'FOO = "bar"' not in removed
+    assert "[mcp_servers.openai2]" in removed
+    assert 'command = "keep-me"' in removed
+
+    replaced = _replace_or_append_toml_section(
+        src, "mcp_servers.openai", ['command = "new"']
+    )
+    assert 'command = "new"' in replaced
+    assert "[mcp_servers.openai.env]" not in replaced  # stale env must not survive
+    assert 'FOO = "bar"' not in replaced
+    assert "[mcp_servers.openai2]" in replaced
+    assert 'command = "keep-me"' in replaced
+
+
+def test_codex_legacy_removal_covers_env_subtable(tmp_path: Path) -> None:
+    """End-to-end: install_codex's legacy-openai cleanup must remove the whole
+    stale entry even when it carries a [mcp_servers.openai.env] subtable,
+    leaving a config that parses with no 'openai' server at all."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[mcp_servers.openai]\n"
+        'command = "openai-mcp"\n'
+        "\n"
+        "[mcp_servers.openai.env]\n"
+        'FOO = "bar"\n'
+    )
+    result = install_codex(config_path=cfg)
+    assert result["changed"] is True
+    parsed = tomllib.loads(cfg.read_text())
+    assert "openai" not in parsed.get("mcp_servers", {})
+    assert parsed["mcp_servers"]["gpt2agent"]["command"] == "gpt2agent"
+
+
 # ── detect ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -222,6 +222,43 @@ def test_get_conversation_empty_returns_empty_dict() -> None:
     assert _reg(conversations, client).tools["get_conversation"]("X") == {}
 
 
+def test_get_conversation_redacts_message_bodies() -> None:
+    """Message text/code must go through redact() like title does — a pasted
+    secret or email in a chat body must not be echoed back to the MCP client."""
+    jwt = "eyJ" + "a" * 20 + "." + "b" * 20 + "." + "c" * 20
+    mapping = {
+        "n1": {"message": {"id": "u", "author": {"role": "user"},
+                           "content": {"content_type": "text",
+                                       "parts": [f"my key {jwt} mail bob@corp.io"]}}},
+        "n2": {"message": {"id": "a", "author": {"role": "assistant"},
+                           "content": {"content_type": "code",
+                                       "parts": [f"token = '{jwt}'"]}}},
+    }
+    client = FakeClient(routes={"/backend-api/conversation/C2": {"id": "C2", "title": "t",
+                                                                 "mapping": mapping}})
+    out = _reg(conversations, client).tools["get_conversation"]("C2")
+    by_id = {m["id"]: m for m in out["messages"]}
+    assert jwt not in by_id["u"]["text"] and "<JWT>" in by_id["u"]["text"]
+    assert "bob@corp.io" not in by_id["u"]["text"] and "<EMAIL>" in by_id["u"]["text"]
+    assert jwt not in by_id["a"]["code"] and "<JWT>" in by_id["a"]["code"]
+
+
+def test_get_conversation_redacts_before_truncation() -> None:
+    """A secret straddling the 2000-char cut must not survive as a partial token."""
+    jwt = "eyJ" + "a" * 40 + "." + "b" * 40 + "." + "c" * 40
+    body = "x" * 1990 + jwt  # JWT starts before the cut, ends after it
+    mapping = {
+        "n1": {"message": {"id": "u", "author": {"role": "user"},
+                           "content": {"content_type": "text", "parts": [body]}}},
+    }
+    client = FakeClient(routes={"/backend-api/conversation/C3": {"id": "C3", "title": "t",
+                                                                 "mapping": mapping}})
+    out = _reg(conversations, client).tools["get_conversation"]("C3")
+    text = out["messages"][0]["text"]
+    assert "eyJa" not in text  # no partial-JWT prefix leaked
+    assert text.endswith("<JWT>") or "<JWT>" in text
+
+
 # --------------------------------------------------------------------------- #
 #  tools/gpts, apps, codex
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Three verified fixes from a 2026-07-01 four-lane cross-review of v0.0.8 (sse / tools / backend-install / docs-tests). Each finding was reproduced against the old code before fixing; each new test fails on the old code and passes on this branch.

### 1. Security — `get_conversation` returned message bodies unredacted (P1)
`tools/conversations.py` redacted only `title`; message `text`/`code` parts were verbatim, so a JWT/API key/email pasted into any chat was echoed to the MCP client. Demonstrated live pre-fix. Now the same `redact()` runs on bodies, **before** truncation so a secret straddling the 2000-char cut can't leak as a partial token. This also makes the shipped skill doc (`tools-reference.md` Key Gotchas #2) true, and the README risk section is updated to match the real behavior.

### 2. Installer — TOML remove/replace orphaned dotted child subtables (P1)
The body-skip loops in `_remove_toml_section` / `_replace_or_append_toml_section` stopped at ANY header, including the section's own children: removing `[mcp_servers.openai]` left `[mcp_servers.openai.env]` behind — which re-parses as a command-less `openai` server entry, exactly the spawn-and-fail pointer the legacy cleanup exists to delete. Replaces also kept stale `.env` subtables. Skip now continues through dotted descendants; shared-prefix siblings (`openai2`) still terminate it.

### 3. Deep Research — clarification heuristic misclassified real reports (P2)
`_looks_like_clarification` substring-matched hint phrases over the ENTIRE done text, so a long real report containing ordinary prose ("to make sure", "would you like") triggered the auto-proceed round: a paid DR round was burned and the last-done-wins consumer in `server.py` overwrote the real report with the follow-up. The phrase check is now gated to ≤ 1200-char texts (genuine clarifications are short; reports are thousands of chars). The deliberately-removed "short text ending in ?" branch stays removed.

## Test evidence

Baseline (main): `129 passed, 9 skipped`

This branch:
```
$ SKIP_LIVE=1 python -m pytest -q
133 passed, 9 skipped in 1.78s
$ ruff check gpt2agent tests
All checks passed!
```

Oracle check — new tests against the UNFIXED code (sources stashed):
```
FAILED tests/test_tools.py::test_get_conversation_redacts_message_bodies
FAILED tests/test_tools.py::test_get_conversation_redacts_before_truncation
FAILED tests/test_install.py::test_toml_section_editors_remove_dotted_child_subtables
FAILED tests/test_install.py::test_codex_legacy_removal_covers_env_subtable
FAILED tests/test_dr_clarification.py::test_clarification_detection_unit
5 failed in 0.07s
```

## Notes for reviewer

- Findings from four independent review lanes; each was re-verified at the cited lines before fixing.
- Known remaining (NOT in this PR, kept scoped): sync tools run blocking HTTP on the event loop; ~10 unguarded `backend.get()`-returns-None call sites; token source pinned at construction in `BackendClient`; `load_config` crash on top-level scalar TOML keys; CLAUDE.md `tools/` module-count drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved redaction in conversation exports so emails, phone numbers, and common secret formats are masked before any truncation, reducing the risk of partial secret leakage.
* **Bug Fixes**
  * Fixed TOML section editing so related nested entries are removed or replaced together, avoiding leftover stale sub-sections.
  * Reduced false “clarification” detections for long reports while still recognizing genuine short clarification requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->