### PR TITLE
fix: harden REST tools and config loading against empty/malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- REST tools no longer crash with a raw `AttributeError`/`TypeError` when the
+  backend returns an empty 2xx body (`backend.get()` → `None`): read tools
+  (memory, account, models, custom GPTs, apps, codex lists, instructions-get)
+  degrade to empty results, and `custom_instructions_set` now refuses to
+  overwrite when the current state is unreadable instead of silently clearing
+  the field the caller did not supply.
+- `load_config` raises a clean, actionable `ValueError` for a top-level scalar
+  key in `config.toml` (e.g. `port = 9001` missing its `[server]` header)
+  instead of `TypeError: 'bool' object is not iterable`.
+
 ## [0.0.8] - 2026-06-27
 
 Patch release: follow-up hardening from the 2026-06-26 cross-model audit of 0.0.7.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server exposing full ChatGPT Plus/Pro account features to any MCP client.
 ## Build & Test
 
 ```bash
-pytest                    # 129 passed, 9 skipped (live tests gated by SKIP_LIVE)
+pytest                    # full suite must pass; live/network tests auto-skip (SKIP_LIVE)
 python -m gpt2agent run   # start MCP server (stdio)
 ```
 
@@ -14,7 +14,7 @@ python -m gpt2agent run   # start MCP server (stdio)
 - `gpt2agent/server.py` — MCP tool registration (25 tools), config loading
 - `gpt2agent/sse.py` — Async SSE client for `/backend-api/conversation` (chat, DR, agent, image gen, code interpreter, canvas)
 - `gpt2agent/backend.py` — Sync HTTP client (`curl_cffi`), token management, sentinel challenges
-- `gpt2agent/tools/` — 25 MCP tool modules, each with `register(mcp, client, conv=None)`
+- `gpt2agent/tools/` — 10 tool modules (19 of the 25 tools; the 6 SSE chat/DR/agent tools live in server.py), each with `register(mcp, client, conv=None)`
 - `gpt2agent/sentinel.py` — POW + Turnstile solver
 - `gpt2agent/install.py` — `gpt2agent install` subcommand
 

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -60,6 +60,14 @@ def load_config(path: Path | None = None) -> dict[str, Any]:
                 data = tomllib.load(f)
             merged = {k: dict(v) for k, v in _DEFAULTS.items()}
             for section, values in data.items():
+                # A top-level scalar (`port = 9001` without a [server] header)
+                # is a user error — fail with an actionable message, not the
+                # bare TypeError dict.update() would raise.
+                if not isinstance(values, dict):
+                    raise ValueError(
+                        f"config {p}: top-level key {section!r} must live inside "
+                        f"a section header such as [server] or [models]"
+                    )
                 merged.setdefault(section, {}).update(values)
             return merged
     return {k: dict(v) for k, v in _DEFAULTS.items()}

--- a/gpt2agent/tools/account.py
+++ b/gpt2agent/tools/account.py
@@ -13,11 +13,11 @@ def register(mcp, client: BackendClient) -> None:
         `subscription` (plan slug, e.g. "plus"/"pro"/None), `has_active_subscription`,
         `expires_at`, and `features_count` (number of entitled features).
         """
-        me = client.get("/backend-api/me", target_path="/backend-api/me")
+        me = client.get("/backend-api/me", target_path="/backend-api/me") or {}
         check = client.get(
             "/backend-api/accounts/check/v4-2023-04-27",
             target_path="/backend-api/accounts/check/v4-2023-04-27",
-        )
+        ) or {}
         acc_keys = list((check.get("accounts") or {}).keys())
         first = (check.get("accounts") or {}).get(acc_keys[0], {}) if acc_keys else {}
         ent = first.get("entitlement") or {}
@@ -43,7 +43,7 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(
             "/backend-api/models?history_and_training_disabled=false",
             target_path="/backend-api/models",
-        )
+        ) or {}
         return [
             {
                 "slug": m.get("slug"),

--- a/gpt2agent/tools/apps.py
+++ b/gpt2agent/tools/apps.py
@@ -18,7 +18,7 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(
             "/backend-api/apps/list",
             target_path="/backend-api/apps/list",
-        )
+        ) or {}
         return [
             {
                 "id": a.get("id"),

--- a/gpt2agent/tools/codex.py
+++ b/gpt2agent/tools/codex.py
@@ -11,7 +11,7 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(
             "/backend-api/codex/environments",
             target_path="/backend-api/codex/environments",
-        )
+        ) or {}
         envs = data if isinstance(data, list) else (data.get("environments") or [])
         return [
             {
@@ -30,7 +30,7 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(
             f"/backend-api/codex/tasks?limit={limit}",
             target_path="/backend-api/codex/tasks",
-        )
+        ) or {}
         items = data.get("items") or []
         return [
             {

--- a/gpt2agent/tools/gpts.py
+++ b/gpt2agent/tools/gpts.py
@@ -16,7 +16,7 @@ def register(mcp, client: BackendClient) -> None:
         data = client.get(
             "/backend-api/gizmos/snorlax/sidebar",
             target_path="/backend-api/gizmos/snorlax/sidebar",
-        )
+        ) or {}
         return [
             {
                 "name": redact((item.get("gizmo") or {}).get("name") or ""),

--- a/gpt2agent/tools/instructions.py
+++ b/gpt2agent/tools/instructions.py
@@ -11,7 +11,7 @@ def register(mcp, client: BackendClient) -> None:
         ci = client.get(
             "/backend-api/user_system_messages",
             target_path="/backend-api/user_system_messages",
-        )
+        ) or {}
         return {
             "enabled": ci.get("enabled"),
             "traits_enabled": ci.get("traits_enabled"),

--- a/gpt2agent/tools/memory.py
+++ b/gpt2agent/tools/memory.py
@@ -6,7 +6,7 @@ from gpt2agent.tools._redact import redact
 
 def _fetch_memories(client: BackendClient) -> list[dict]:
     data = client.get("/backend-api/memories", target_path="/backend-api/memories")
-    return data.get("memories") or []
+    return (data or {}).get("memories") or []
 
 
 def register(mcp, client: BackendClient) -> None:

--- a/gpt2agent/tools/writes.py
+++ b/gpt2agent/tools/writes.py
@@ -14,6 +14,14 @@ def register(mcp, client: BackendClient) -> None:
             "/backend-api/user_system_messages",
             target_path="/backend-api/user_system_messages",
         )
+        # None = empty-2xx glitch (backend.get contract): the current state is
+        # UNKNOWN, so blind-posting only the supplied fields would silently
+        # clear the other one. Refuse instead. ({} = known-empty is fine.)
+        if current is None:
+            raise RuntimeError(
+                "could not read current custom instructions — refusing to "
+                "overwrite; retry in a moment"
+            )
         payload = {**current}
         if about_user is not None:
             payload["about_user_message"] = about_user
@@ -55,7 +63,7 @@ def register(mcp, client: BackendClient) -> None:
             data = client.get(
                 "/backend-api/codex/environments",
                 target_path="/backend-api/codex/environments",
-            )
+            ) or {}
             envs = data if isinstance(data, list) else (data.get("environments") or [])
             matches = [e for e in envs if e.get("label") == repo_label]
             if len(matches) == 0:

--- a/tests/test_none_guards.py
+++ b/tests/test_none_guards.py
@@ -1,0 +1,126 @@
+"""backend.get() returns None on an empty 2xx body (backend.py get()).
+
+Every REST tool call site must survive that contract: read tools degrade to
+empty results (matching the already-guarded list_conversations/get_file_info
+sites), and the read-modify-write in custom_instructions_set must REFUSE to
+proceed — blind-overwriting with `{}` would silently clear whichever custom
+instructions field the caller did not supply.
+
+Also covers load_config: a top-level scalar key in config.toml (a user
+forgetting the [server] header) must raise a clean actionable error, not
+`TypeError: 'bool' object is not iterable`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gpt2agent.tools import account, apps, codex, gpts, instructions, memory, writes
+
+from tests.test_tools import FakeClient, FakeMCP
+
+
+class NoneClient(FakeClient):
+    """FakeClient whose every GET returns None — the empty-2xx contract."""
+
+    def get(self, path: str, target_path: str | None = None, **k):
+        self.gets.append(path)
+        return None
+
+
+def _tools(module) -> FakeMCP:
+    mcp = FakeMCP()
+    module.register(mcp, NoneClient())
+    return mcp
+
+
+# ── read tools: None → empty result, no AttributeError ───────────────────────
+
+
+def test_memory_tools_tolerate_none() -> None:
+    mcp = _tools(memory)
+    assert mcp.tools["memory_list"]() == []
+    assert mcp.tools["memory_search"]("anything") == []
+
+
+def test_custom_instructions_get_tolerates_none() -> None:
+    mcp = _tools(instructions)
+    out = mcp.tools["custom_instructions_get"]()
+    assert out["about_user"] == ""
+    assert out["enabled"] is None
+
+
+def test_account_tools_tolerate_none() -> None:
+    mcp = _tools(account)
+    status = mcp.tools["account_status"]()
+    assert status["email"] == ""
+    assert status["features_count"] == 0
+    assert mcp.tools["list_models"]() == []
+
+
+def test_list_custom_gpts_tolerates_none() -> None:
+    assert _tools(gpts).tools["list_custom_gpts"]() == []
+
+
+def test_list_apps_tolerates_none() -> None:
+    assert _tools(apps).tools["list_apps"]() == []
+
+
+def test_codex_list_tools_tolerate_none() -> None:
+    mcp = _tools(codex)
+    assert mcp.tools["list_codex_envs"]() == []
+    assert mcp.tools["list_codex_tasks"]() == []
+
+
+# ── write tool: None current state → refuse, do NOT clobber ─────────────────
+
+
+def test_custom_instructions_set_refuses_on_none_current() -> None:
+    client = NoneClient()
+    mcp = FakeMCP()
+    writes.register(mcp, client)
+    with pytest.raises(RuntimeError, match="custom instructions"):
+        mcp.tools["custom_instructions_set"](about_user="new about-user text")
+    assert client.posted == []  # nothing was overwritten
+
+
+def test_custom_instructions_set_known_empty_current_still_works() -> None:
+    # {} is a KNOWN-empty state (fresh account) — must still allow the write.
+    client = FakeClient(routes={"/backend-api/user_system_messages": {}})
+    mcp = FakeMCP()
+    writes.register(mcp, client)
+    mcp.tools["custom_instructions_set"](about_user="hello")
+    assert client.posted == [
+        ("/backend-api/user_system_messages", {"about_user_message": "hello"})
+    ]
+
+
+def test_codex_task_create_env_lookup_tolerates_none() -> None:
+    client = NoneClient()
+    mcp = FakeMCP()
+    writes.register(mcp, client)
+    with pytest.raises(ValueError, match="No Codex environment"):
+        mcp.tools["codex_task_create"](repo_label="myrepo", prompt="do things")
+    assert client.posted == []
+
+
+# ── load_config: top-level scalar key → clean error, not TypeError ───────────
+
+
+def test_load_config_top_level_scalar_raises_clean_error(tmp_path) -> None:
+    from gpt2agent.server import load_config
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('debug = true\n\n[server]\nport = 9001\n')
+    with pytest.raises(ValueError, match="debug"):
+        load_config(cfg)
+
+
+def test_load_config_sections_still_merge(tmp_path) -> None:
+    from gpt2agent.server import load_config
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[server]\nport = 9001\n')
+    merged = load_config(cfg)
+    assert merged["server"]["port"] == 9001
+    assert "models" in merged  # defaults preserved


### PR DESCRIPTION
## Summary

Two crash-hardening fixes from the 2026-07-01 round-2 audit (independent of open PR #17 — the two PRs share no source files except a trivial CHANGELOG `[Unreleased]` union), plus a CLAUDE.md accuracy fix.

### 1. Unguarded `backend.get()` → `None` at 11 REST call sites (P1)
`backend.get()` deliberately returns `None` on an empty 2xx body (gateway/Cloudflare glitch), but only `conversations.py` and `images.py` guarded it. The other 11 sites (memory, account ×2, models, custom GPTs, apps, codex ×2, instructions-get, and both `writes.py` paths) dereferenced the result and sent a raw `AttributeError`/`TypeError` traceback to the MCP client. Reproduced pre-fix:

```
AttributeError: 'NoneType' object has no attribute 'get'   # _fetch_memories(None-client)
```

- **Read tools** now degrade to empty results — same contract as the already-guarded sites.
- **`custom_instructions_set`** (read-modify-write) instead **refuses** on `None`: the current state is unknown, and blind-posting only the supplied fields would silently clear the other field on the account. A known-empty `{}` (fresh account) still allows the write — covered by a dedicated regression test.

### 2. `load_config` TypeError on top-level scalar keys (P2)
A user forgetting the `[server]` header (`port = 9001` at top level) killed server startup with `TypeError: 'bool' object is not iterable` (reproduced). Now a clean, actionable `ValueError` naming the offending key — consistent with `load_config`'s existing fail-loudly `FileNotFoundError`.

### 3. CLAUDE.md drift (docs)
Claimed "25 MCP tool modules" (actual: 10 modules registering 19 of the 25 tools; the 6 SSE tools live in `server.py`) and a hardcoded "129 passed" that drifts every PR.

## Test evidence

Oracle — new tests against the UNFIXED code:
```
9 failed, 2 passed in 0.29s   # tests/test_none_guards.py (2 passing = behavior-preservation controls)
```

This branch:
```
$ .venv/bin/python -m pytest tests/ -q
140 passed, 9 skipped in 0.87s
$ ruff check gpt2agent tests
All checks passed!
```
(main baseline: 129 passed, 9 skipped)

## Notes for reviewer
- CHANGELOG `[Unreleased]` will trivially conflict with PR #17's entries; union-merge both blocks.
- Known remaining, NOT in this PR (kept scoped): sync tools block the event loop (FastMCP calls sync tools inline — verified in installed SDK `func_metadata.py:92-95`); token source pinned at construction; install.py comment-tolerant-header P1 (separate stacked PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)