### PR TITLE
fix(install): commented TOML section headers corrupt ~/.codex/config.toml on re-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ versioning: [SemVer](https://semver.org/).
   `[mcp_servers.openai]` cleanup no longer leaves an orphaned command-less
   half-entry Codex would spawn-and-fail on, and re-install no longer keeps a
   stale `.env` subtable from the replaced block.
+- Codex TOML section remove/replace now recognizes the target header when it
+  carries a trailing comment (`[mcp_servers.gpt2agent] # managed`). Previously
+  re-install appended a DUPLICATE table — making the whole
+  `~/.codex/config.toml` invalid TOML ("Cannot declare ... twice") — and the
+  legacy `[mcp_servers.openai] # comment` cleanup printed "removed" while
+  removing nothing.
 - Legacy Deep Research no longer misclassifies a long real report whose prose
   contains an ordinary hint phrase ("to make sure", "would you like") as a
   clarification request — that auto-proceed round overwrote the real report

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -218,6 +218,19 @@ def _belongs_to_section(header_line: str, section_name: str) -> bool:
     return name == section_name or name.startswith(section_name + ".")
 
 
+def _is_target_header(line: str, section_name: str) -> bool:
+    """True iff *line* is the ``[section_name]`` table header itself, tolerating
+    the same whitespace / trailing-comment forms ``_SECTION_HEADER_RE`` accepts
+    as section boundaries. An exact string compare here misses
+    ``[section] # comment`` — replace then appends a DUPLICATE table (invalid
+    TOML: "Cannot declare ... twice") and remove becomes a silent no-op.
+    """
+    if line.lstrip().startswith("[["):  # array-of-table is never the target
+        return False
+    m = _SECTION_HEADER_RE.match(line)
+    return bool(m) and m.group(1).strip() == section_name
+
+
 def _remove_toml_section(content: str, section_name: str) -> str:
     """Remove the ``[section_name]`` block from TOML content. No-op if absent.
 
@@ -225,11 +238,10 @@ def _remove_toml_section(content: str, section_name: str) -> str:
     ``[header]`` or end-of-file; dotted child subtables are removed with it.
     Other sections are preserved verbatim.
     """
-    header = f"[{section_name}]"
     out: list[str] = []
     skipping = False
     for line in content.splitlines():
-        if line.strip() == header:
+        if _is_target_header(line, section_name):
             skipping = True
             continue
         if skipping:
@@ -281,7 +293,7 @@ def _replace_or_append_toml_section(
 
     while i < len(lines):
         line = lines[i]
-        if line.strip() == header:
+        if _is_target_header(line, section_name):
             found = True
             out.append(new_block)
             i += 1

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -404,6 +404,58 @@ def test_codex_legacy_removal_covers_env_subtable(tmp_path: Path) -> None:
     assert parsed["mcp_servers"]["gpt2agent"]["command"] == "gpt2agent"
 
 
+def test_toml_section_editors_recognize_commented_headers() -> None:
+    """The body-skip boundary regex tolerates '[x] # comment' headers, but the
+    TARGET-section find used an exact string match — a pre-existing
+    '[mcp_servers.gpt2agent] # comment' was not recognized, so replace APPENDED
+    a duplicate table (whole config becomes invalid TOML: 'Cannot declare ...
+    twice') and remove was a silent no-op."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore
+
+    src = (
+        "[mcp_servers.gpt2agent] # managed by gpt2agent\n"
+        'command = "old"\n'
+        "\n"
+        "[other]\n"
+        "x = 1\n"
+    )
+    replaced = _replace_or_append_toml_section(
+        src, "mcp_servers.gpt2agent", ['command = "new"']
+    )
+    parsed = tomllib.loads(replaced)  # must stay valid TOML — no duplicate table
+    assert parsed["mcp_servers"]["gpt2agent"]["command"] == "new"
+    assert parsed["other"]["x"] == 1
+
+    removed = _remove_toml_section(src, "mcp_servers.gpt2agent")
+    assert "gpt2agent" not in removed
+    assert 'command = "old"' not in removed
+    assert "[other]" in removed
+
+
+def test_codex_legacy_removal_covers_commented_header(tmp_path: Path) -> None:
+    """_legacy_codex_openai_present detects via tomllib (comment-tolerant), so
+    removal must handle '[mcp_servers.openai] # legacy' too — previously the
+    installer PRINTED 'removed stale legacy' while the broken entry survived."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[mcp_servers.openai] # legacy openai-mcp entry\n"
+        'command = "openai-mcp"\n'
+    )
+    result = install_codex(config_path=cfg)
+    assert result["changed"] is True
+    parsed = tomllib.loads(cfg.read_text())
+    assert "openai" not in parsed.get("mcp_servers", {})
+    assert parsed["mcp_servers"]["gpt2agent"]["command"] == "gpt2agent"
+
+
 # ── detect ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

**Stacked on #17** (base = `fix/audit-2026-07-01`; GitHub will auto-retarget to `main` once #17 merges). It builds directly on #17's dotted-subtable rework of the same two functions.

### The bug (P1, reproduced by execution)
`_SECTION_HEADER_RE` (install.py) deliberately tolerates `[x] # comment` as a section *boundary*, but the **target-section find** in `_remove_toml_section` / `_replace_or_append_toml_section` compared `line.strip() == "[name]"` exactly. Consequences for any user who annotated their config header (`[mcp_servers.gpt2agent] # managed by gpt2agent`):

1. **Re-install appends a DUPLICATE table** → the entire `~/.codex/config.toml` becomes invalid TOML:
   ```
   tomllib.TOMLDecodeError: Cannot declare ('mcp_servers', 'gpt2agent') twice (at line 7, column 23)
   ```
   Codex then fails to load its whole config until the user hand-repairs it (a backup exists, but the breakage is silent at install time).
2. **False success message**: `_legacy_codex_openai_present` detects via comment-tolerant `tomllib`, but removal missed the commented header — the installer printed `codex: removed stale legacy [mcp_servers.openai] block` while removing nothing, forever.

### The fix
A `_is_target_header()` helper reuses `_SECTION_HEADER_RE` (single-bracket form only — an array-of-table is never the target) so target matching accepts exactly the same header forms the boundary matching does. Composes with #17's dotted-descendant skip unchanged.

## Test evidence

Oracle — new tests on the unfixed code (the false "removed stale legacy" message is even visible in captured stdout):
```
FAILED tests/test_install.py::test_toml_section_editors_recognize_commented_headers
FAILED tests/test_install.py::test_codex_legacy_removal_covers_commented_header
2 failed, 1 passed in 0.05s
```

This branch:
```
$ .venv/bin/python -m pytest tests/ -q
135 passed, 9 skipped in 0.97s
$ ruff check gpt2agent tests
All checks passed!
```

Finding originated from a 2026-07-01 round-2 cross-review lane; independently re-verified by execution at the cited lines before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)