### PR TITLE
fix: 2026-07-02 audit remediation — date-safe redaction, DR incomplete flags, symlink-safe installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,24 @@ versioning: [SemVer](https://semver.org/).
   clarification request — that auto-proceed round overwrote the real report
   and burned DR quota. Clarification detection now applies only to short
   (≤ 1200 char) done-texts.
+- PII redaction no longer corrupts calendar dates: "2026-05-26" (and
+  `DD-MM-YYYY` / datetime / date-range forms) satisfied the phone-number
+  pattern and came back as `<PHONE>` in memories, tasks, and conversation
+  titles. Phone masking still applies to actual phone shapes.
+- `deep_research` / `deep_research_heavy` now append an explicit "⚠ Report
+  may be incomplete" note when the SSE stream ended without the server
+  marking the response finished (`terminated_abnormally`) or when completion
+  polling timed out — previously a truncated report was indistinguishable
+  from a complete one.
+- `gpt2agent install`: writing a symlinked agent config (dotfile-repo
+  setups) now writes through to the symlink target instead of replacing the
+  link with a plain file and stranding the real config.
+- `gpt2agent setup`: `~/.gpt2agent/config.toml` is backed up
+  (`.bak-gpt2agent`) before being overwritten and is written atomically;
+  a rewrite with identical content is a no-op.
+- Removed the `browser-use` session-cookie fallback that saved a NextAuth
+  session cookie as `access_token` — the saved "token" 401'd on every API
+  call. Extraction now fails visibly so the user can paste a real token.
 
 ## [0.0.8] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ versioning: [SemVer](https://semver.org/).
 - PII redaction no longer corrupts calendar dates: "2026-05-26" (and
   `DD-MM-YYYY` / datetime / date-range forms) satisfied the phone-number
   pattern and came back as `<PHONE>` in memories, tasks, and conversation
-  titles. Phone masking still applies to actual phone shapes.
+  titles. Phone masking still applies to actual phone shapes — including a
+  phone that follows a date inside the same greedy match
+  ("2026-05-26 617-555-0123" keeps the date, masks the phone).
 - `deep_research` / `deep_research_heavy` now append an explicit "⚠ Report
   may be incomplete" note when the SSE stream ended without the server
   marking the response finished (`terminated_abnormally`) or when completion
@@ -58,6 +60,9 @@ versioning: [SemVer](https://semver.org/).
 - Removed the `browser-use` session-cookie fallback that saved a NextAuth
   session cookie as `access_token` — the saved "token" 401'd on every API
   call. Extraction now fails visibly so the user can paste a real token.
+  The manual paste prompt likewise no longer suggests the
+  `__Secure-next-auth.session-token` cookie and refuses to save values that
+  are not 3-segment JWTs (a pasted session cookie only produced 401s).
 
 ## [0.0.8] - 2026-06-27
 

--- a/gpt2agent/auth.py
+++ b/gpt2agent/auth.py
@@ -71,17 +71,23 @@ def _from_browser() -> dict | None:
     print(
         '    copy(JSON.parse(localStorage["@@auth0spajs@@::..."] || "{}").body?.access_token'
     )
-    print("  OR go to:")
-    print("    Application → Cookies → __Secure-next-auth.session-token")
     print()
-    print("  Then paste the token below.")
+    print("  Then paste the access_token below. Browser cookies such as")
+    print("  __Secure-next-auth.session-token are NOT access tokens — the API")
+    print("  rejects them with 401, so they are not accepted here.")
     print("  (Tip: running `codex login` once lets gpt2agent reuse that token automatically.)")
     print()
     webbrowser.open("https://chat.openai.com")
-    token = input("  Paste access_token (or session token): ").strip()
-    if token:
-        return {"access_token": token, "source": "browser"}
-    return None
+    token = input("  Paste access_token: ").strip()
+    if not token:
+        return None
+    if not token.startswith("eyJ") or token.count(".") != 2:
+        # ChatGPT access tokens are 3-segment JWTs; session cookies (5-segment
+        # JWE) or random strings only produce 401s downstream — fail here.
+        print("  That does not look like a JWT access_token (expected eyJ...x.y.z);")
+        print("  not saving it. Use `codex login` for the reliable path.")
+        return None
+    return {"access_token": token, "source": "browser"}
 
 
 def _from_browser_use() -> dict | None:

--- a/gpt2agent/auth.py
+++ b/gpt2agent/auth.py
@@ -122,17 +122,11 @@ def _from_browser_use() -> dict | None:
                 except Exception:
                     pass
 
-        # Try cookies fallback
-        result = subprocess.run(
-            ["browser-use", "cookies", "get", "--url", "https://chat.openai.com"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        cookies = json.loads(result.stdout or "[]")
-        for c in cookies:
-            if "session-token" in c.get("name", ""):
-                return {"access_token": c["value"], "source": "browser-use-cookie"}
+        # No cookie fallback: the __Secure-next-auth.session-token cookie is a
+        # NextAuth session cookie, not the chatgpt.com-scoped access-token JWT
+        # the backend sends as `Authorization: Bearer` — saving it "succeeds"
+        # here and then every API call 401s. Better to fail visibly.
+        print("  browser-use found no access_token in localStorage.")
 
     except Exception as e:
         print(f"  browser-use extraction failed: {e}")

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -88,6 +88,11 @@ def _atomic_write(path: Path, content: str) -> None:
     contain MCP server commands that the agent will exec, so they should not
     be world-readable on shared systems.
     """
+    if path.is_symlink():
+        # Users symlink agent configs into dotfile repos; rename() over the
+        # symlink would replace the link with a plain file and strand the real
+        # target. Write through to the target instead.
+        path = path.resolve()
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + f".tmp-{os.getpid()}")
     # Open the temp file at 0o600 up front so a secret-bearing config is never

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -76,6 +76,21 @@ def load_config(path: Path | None = None) -> dict[str, Any]:
 # ── server ───────────────────────────────────────────────────────────────────
 
 
+def _dr_incomplete_note(timed_out: bool) -> str:
+    """Marker appended when a DR stream never reached finished_successfully.
+
+    Without it, a truncated or timed-out report is indistinguishable from a
+    complete one — the caller would archive partial research as final.
+    """
+    note = (
+        "\n\n---\n**⚠ Report may be incomplete** — the stream ended before the "
+        "server marked the response finished"
+    )
+    if timed_out:
+        note += " (completion polling timed out)"
+    return note + ". Retry, or use get_conversation to check for a fuller report."
+
+
 def build_server(cfg: dict[str, Any]) -> FastMCP:
     srv = cfg["server"]
     models = cfg["models"]
@@ -149,6 +164,8 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         final_text = ""
         tool_calls: list[str] = []
         refs: list = []
+        truncated = False
+        timed_out = False
 
         async for event in conv.deep_research(q):
             if event["type"] == "tool":
@@ -156,6 +173,8 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
             elif event["type"] == "done":
                 final_text = event["text"]
                 refs = event.get("content_references", [])
+                truncated = bool(event.get("terminated_abnormally"))
+                timed_out = bool(event.get("timeout"))
 
         # Append a brief sources section if citations were returned
         if refs:
@@ -169,6 +188,9 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
                         seen.add(url)
                         lines.append(f"- [{title}]({url})")
             final_text += "\n".join(lines)
+
+        if truncated:
+            final_text += _dr_incomplete_note(timed_out)
 
         return final_text or "(no response)"
 
@@ -189,6 +211,8 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         refs: list = []
         connector_failed = False
         tool_error_msg = ""
+        truncated = False
+        timed_out = False
 
         async for event in conv.deep_research_heavy(q, model=heavy_dr_model):
             etype = event.get("type")
@@ -197,6 +221,8 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
                 refs = event.get("content_references", [])
                 if event.get("connector_failed"):
                     connector_failed = True
+                truncated = bool(event.get("terminated_abnormally"))
+                timed_out = bool(event.get("timeout"))
             elif etype == "tool_error":
                 tool_error_msg = event.get("message", "")
 
@@ -225,6 +251,9 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
                 first_line = tool_error_msg.splitlines()[0][:200]
                 warning += f"\n\n*Server message:* `{first_line}`"
             final_text += warning
+
+        if truncated:
+            final_text += _dr_incomplete_note(timed_out)
 
         return final_text or "(no response)"
 

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -147,6 +147,8 @@ MCP_PORT = 9000
 
 
 def write_mcp_config(plan: str) -> None:
+    from gpt2agent.install import _atomic_write, _backup
+
     chat_model = "gpt-5-5-pro" if plan == "pro" else "gpt-5-3"
     cfg = f"""[server]
 # Loopback only — the HTTP transport is unauthenticated and proxies your full
@@ -157,7 +159,13 @@ port = {MCP_PORT}
 [models]
 chat = "{chat_model}"
 """
-    MCP_CONFIG_PATH.write_text(cfg)
+    # Users hand-edit this file (models, host opt-ins); don't clobber their
+    # copy silently — keep a .bak and write atomically.
+    if MCP_CONFIG_PATH.exists():
+        if MCP_CONFIG_PATH.read_text() == cfg:
+            return
+        _backup(MCP_CONFIG_PATH)
+    _atomic_write(MCP_CONFIG_PATH, cfg)
 
 
 # ── final summary ────────────────────────────────────────────────────────────

--- a/gpt2agent/tools/_redact.py
+++ b/gpt2agent/tools/_redact.py
@@ -4,15 +4,20 @@ import re
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
 _PHONE_RE = re.compile(r"\+?\d[\d ()\-]{8,}\d")
 # Calendar dates satisfy _PHONE_RE ("2026-05-26" is 10 digit/dash chars), so a
-# phone match that *starts* with a date shape is left alone rather than turned
-# into "<PHONE>" — dates in memories/tasks/conversations vastly outnumber
-# phone numbers written with a leading date.
-_DATE_PREFIX_RE = re.compile(r"^(?:\d{4}-\d{2}-\d{2}|\d{1,2}-\d{1,2}-\d{4})(?:$|[^\d])")
+# phone match that *starts* with a date shape keeps the date — dates in
+# memories/tasks/conversations vastly outnumber phone numbers written with a
+# leading date. Only the date itself is preserved; the rest of the match is
+# re-scanned so "2026-05-26 617-555-0123" still masks the phone.
+_DATE_PREFIX_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}|\d{1,2}-\d{1,2}-\d{4})(?=$|[^\d])")
 
 
 def _phone_repl(m: re.Match) -> str:
     text = m.group(0)
-    return text if _DATE_PREFIX_RE.match(text) else "<PHONE>"
+    dm = _DATE_PREFIX_RE.match(text)
+    if not dm:
+        return "<PHONE>"
+    prefix = dm.group(1)
+    return prefix + _PHONE_RE.sub(_phone_repl, text[len(prefix):])
 
 # Secret patterns. Users routinely paste API keys / tokens into ChatGPT, so they
 # end up in memories, tasks, and custom instructions — which these tools return

--- a/gpt2agent/tools/_redact.py
+++ b/gpt2agent/tools/_redact.py
@@ -3,6 +3,16 @@ import re
 # PII patterns.
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
 _PHONE_RE = re.compile(r"\+?\d[\d ()\-]{8,}\d")
+# Calendar dates satisfy _PHONE_RE ("2026-05-26" is 10 digit/dash chars), so a
+# phone match that *starts* with a date shape is left alone rather than turned
+# into "<PHONE>" — dates in memories/tasks/conversations vastly outnumber
+# phone numbers written with a leading date.
+_DATE_PREFIX_RE = re.compile(r"^(?:\d{4}-\d{2}-\d{2}|\d{1,2}-\d{1,2}-\d{4})(?:$|[^\d])")
+
+
+def _phone_repl(m: re.Match) -> str:
+    text = m.group(0)
+    return text if _DATE_PREFIX_RE.match(text) else "<PHONE>"
 
 # Secret patterns. Users routinely paste API keys / tokens into ChatGPT, so they
 # end up in memories, tasks, and custom instructions — which these tools return
@@ -25,5 +35,5 @@ def redact(s: object) -> object:
     s = _APIKEY_RE.sub("<APIKEY>", s)
     s = _GH_TOKEN_RE.sub("<TOKEN>", s)
     s = _EMAIL_RE.sub("<EMAIL>", s)
-    s = _PHONE_RE.sub("<PHONE>", s)
+    s = _PHONE_RE.sub(_phone_repl, s)
     return s

--- a/tests/test_audit_2026_07_02.py
+++ b/tests/test_audit_2026_07_02.py
@@ -52,6 +52,21 @@ def test_redact_still_masks_phone_numbers() -> None:
     assert redact("intl +44 20 7946 0958") == "intl <PHONE>"
 
 
+def test_redact_masks_phone_after_iso_date_in_same_match() -> None:
+    # _PHONE_RE greedily spans "2026-05-26 617-555-0123" as ONE match; the date
+    # prefix must survive but the trailing phone must still be masked (cx P1).
+    assert redact("appt 2026-05-26 617-555-0123") == "appt 2026-05-26 <PHONE>"
+
+
+def test_redact_masks_phone_after_dmy_date_in_same_match() -> None:
+    assert redact("appt 26-05-2026 617-555-0123") == "appt 26-05-2026 <PHONE>"
+
+
+def test_redact_preserves_consecutive_dates() -> None:
+    s = "between 2026-05-26 2026-06-27 only"
+    assert redact(s) == s
+
+
 # ── DR tools: truncated / timed-out reports are labeled ──────────────────────
 
 
@@ -170,3 +185,27 @@ def test_browser_use_does_not_return_session_cookie(monkeypatch) -> None:
     monkeypatch.setattr(auth_mod.time, "sleep", lambda *a: None)
 
     assert auth_mod._from_browser_use() is None
+
+
+def _run_from_browser(monkeypatch, pasted: str):
+    import gpt2agent.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda *a, **k: True)
+    monkeypatch.setattr("builtins.input", lambda *a: pasted)
+    return auth_mod._from_browser()
+
+
+def test_from_browser_rejects_non_jwt_paste(monkeypatch) -> None:
+    # A NextAuth session cookie is a 5-segment JWE, not a 3-segment JWS access
+    # token; saving it just yields 401s later (cx P2) — must be refused.
+    assert _run_from_browser(monkeypatch, "eyJa.eyJb.eyJc.eyJd.eyJe") is None
+    assert _run_from_browser(monkeypatch, "some-random-cookie-value") is None
+    assert _run_from_browser(monkeypatch, "") is None
+
+
+def test_from_browser_accepts_jwt_shaped_token(monkeypatch) -> None:
+    tok = "eyJhbGciOi.eyJzdWIiOi.c2lnbmF0dXJl"
+    assert _run_from_browser(monkeypatch, tok) == {
+        "access_token": tok,
+        "source": "browser",
+    }

--- a/tests/test_audit_2026_07_02.py
+++ b/tests/test_audit_2026_07_02.py
@@ -1,0 +1,172 @@
+"""Regressions for the 2026-07-02 audit fixes.
+
+Covers:
+  * `tools/_redact` — _PHONE_RE no longer eats calendar dates ("2026-05-26"
+    → "<PHONE>" corrupted every dated memory/task/conversation title).
+  * server.py DR tools — `terminated_abnormally`/`timeout` done-flags now
+    surface as an explicit "report may be incomplete" note instead of being
+    dropped (a truncated report was indistinguishable from a complete one).
+  * install._atomic_write — writing through a symlinked config no longer
+    replaces the symlink with a plain file (dotfile-repo setups).
+  * setup.write_mcp_config — existing ~/.gpt2agent/config.toml is backed up
+    before overwrite and the write is atomic; identical content is a no-op.
+  * auth._from_browser_use — the session-cookie fallback is gone: a NextAuth
+    session cookie saved as access_token 401s on every call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from gpt2agent.install import _atomic_write
+from gpt2agent.tools._redact import redact
+
+from tests.test_tools import _RecordConv, _build_with_conv  # noqa: F401 (harness)
+
+
+# ── redact: dates survive, phones still masked ───────────────────────────────
+
+
+def test_redact_preserves_iso_date() -> None:
+    assert redact("released 2026-05-26 as planned") == "released 2026-05-26 as planned"
+
+
+def test_redact_preserves_iso_datetime() -> None:
+    s = "run at 2026-05-26 12:34:56 UTC"
+    assert redact(s) == s
+
+
+def test_redact_preserves_date_range() -> None:
+    s = "window 2026-05-26 - 2026-06-27"
+    assert redact(s) == s
+
+
+def test_redact_preserves_dmy_date() -> None:
+    s = "due 26-05-2026 latest"
+    assert redact(s) == s
+
+
+def test_redact_still_masks_phone_numbers() -> None:
+    assert redact("call +1 (617) 555-0123 now") == "call <PHONE> now"
+    assert redact("fax 617-555-0123 ok") == "fax <PHONE> ok"
+    assert redact("intl +44 20 7946 0958") == "intl <PHONE>"
+
+
+# ── DR tools: truncated / timed-out reports are labeled ──────────────────────
+
+
+def test_deep_research_flags_abnormal_termination(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.dr_events = [{"type": "done", "text": "Partial report",
+                       "content_references": [], "terminated_abnormally": True}]
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["deep_research"].fn("topic"))
+    assert out.startswith("Partial report")
+    assert "Report may be incomplete" in out
+
+
+def test_deep_research_clean_done_has_no_incomplete_note(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.dr_events = [{"type": "done", "text": "Full report", "content_references": []}]
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["deep_research"].fn("topic"))
+    assert "incomplete" not in out
+
+
+def test_deep_research_heavy_flags_poll_timeout(monkeypatch) -> None:
+    conv = _RecordConv()
+    conv.heavy_events = [{"type": "done", "text": "Partial report",
+                          "content_references": [],
+                          "terminated_abnormally": True, "timeout": True}]
+    tools = _build_with_conv(monkeypatch, conv)
+    out = asyncio.run(tools["deep_research_heavy"].fn("topic"))
+    assert "Report may be incomplete" in out
+    assert "polling timed out" in out
+
+
+# ── _atomic_write: symlinked configs write through, not sever ────────────────
+
+
+def test_atomic_write_preserves_symlink(tmp_path) -> None:
+    real = tmp_path / "dotfiles" / "claude.json"
+    real.parent.mkdir()
+    real.write_text("{}")
+    link = tmp_path / ".claude.json"
+    link.symlink_to(real)
+
+    _atomic_write(link, '{"a": 1}')
+
+    assert link.is_symlink(), "symlink was replaced by a plain file"
+    assert real.read_text() == '{"a": 1}'
+    assert link.read_text() == '{"a": 1}'
+
+
+def test_atomic_write_plain_file_unchanged_behavior(tmp_path) -> None:
+    p = tmp_path / "cfg.toml"
+    _atomic_write(p, "x = 1\n")
+    assert p.read_text() == "x = 1\n"
+    assert (p.stat().st_mode & 0o777) == 0o600
+
+
+# ── setup.write_mcp_config: backup + atomic + idempotent ─────────────────────
+
+
+def _patched_setup(monkeypatch, tmp_path):
+    import gpt2agent.setup as setup_mod
+
+    cfg_path = tmp_path / ".gpt2agent" / "config.toml"
+    monkeypatch.setattr(setup_mod, "MCP_CONFIG_PATH", cfg_path)
+    return setup_mod, cfg_path
+
+
+def test_write_mcp_config_creates_file_and_parent(monkeypatch, tmp_path) -> None:
+    setup_mod, cfg_path = _patched_setup(monkeypatch, tmp_path)
+    setup_mod.write_mcp_config("pro")
+    assert 'chat = "gpt-5-5-pro"' in cfg_path.read_text()
+
+
+def test_write_mcp_config_backs_up_existing(monkeypatch, tmp_path) -> None:
+    setup_mod, cfg_path = _patched_setup(monkeypatch, tmp_path)
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("# user-edited config\n")
+    setup_mod.write_mcp_config("plus")
+    bak = cfg_path.with_name(cfg_path.name + ".bak-gpt2agent")
+    assert bak.read_text() == "# user-edited config\n"
+    assert 'chat = "gpt-5-3"' in cfg_path.read_text()
+
+
+def test_write_mcp_config_same_content_is_noop(monkeypatch, tmp_path) -> None:
+    setup_mod, cfg_path = _patched_setup(monkeypatch, tmp_path)
+    setup_mod.write_mcp_config("plus")
+    before = cfg_path.stat().st_mtime_ns
+    setup_mod.write_mcp_config("plus")
+    bak = cfg_path.with_name(cfg_path.name + ".bak-gpt2agent")
+    assert not bak.exists(), "identical rewrite must not create a backup"
+    assert cfg_path.stat().st_mtime_ns == before
+
+
+# ── auth: no session-cookie-as-access-token fallback ─────────────────────────
+
+
+def test_browser_use_does_not_return_session_cookie(monkeypatch) -> None:
+    import gpt2agent.auth as auth_mod
+
+    class _Result:
+        def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+            self.stdout = stdout
+            self.returncode = returncode
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:1] == ["which"]:
+            return _Result(returncode=0)
+        if "eval" in cmd:
+            return _Result(stdout="[]")  # no auth0 localStorage entries
+        if "cookies" in cmd:
+            raise AssertionError("cookie fallback must not be attempted")
+        return _Result()
+
+    monkeypatch.setattr(auth_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    monkeypatch.setattr(auth_mod.time, "sleep", lambda *a: None)
+
+    assert auth_mod._from_browser_use() is None

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -380,6 +380,33 @@ def test_toml_section_editors_remove_dotted_child_subtables() -> None:
     assert 'command = "keep-me"' in replaced
 
 
+def test_toml_section_editors_commented_header_with_commented_child() -> None:
+    """Commented target header AND commented child subtable together
+    ([x] # managed + [x.env] # stale) — replace/remove must drop both
+    (cx review 2026-07-02 P2: the two cases were only covered separately)."""
+    src = (
+        "[mcp_servers.gpt2agent] # managed\n"
+        'command = "old"\n'
+        "\n"
+        "[mcp_servers.gpt2agent.env] # stale\n"
+        'KEY = "v"\n'
+        "\n"
+        "[other]\n"
+        "k = 1\n"
+    )
+    replaced = _replace_or_append_toml_section(
+        src, "mcp_servers.gpt2agent", ['command = "new"']
+    )
+    assert 'command = "old"' not in replaced
+    assert ".env" not in replaced
+    assert replaced.count("[mcp_servers.gpt2agent]") == 1
+    assert "[other]" in replaced
+
+    removed = _remove_toml_section(src, "mcp_servers.gpt2agent")
+    assert "mcp_servers.gpt2agent" not in removed
+    assert "[other]" in removed
+
+
 def test_codex_legacy_removal_covers_env_subtable(tmp_path: Path) -> None:
     """End-to-end: install_codex's legacy-openai cleanup must remove the whole
     stale entry even when it carries a [mcp_servers.openai.env] subtable,

--- a/tests/test_none_guards.py
+++ b/tests/test_none_guards.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import pytest
 
-from gpt2agent.tools import account, apps, codex, gpts, instructions, memory, writes
+from gpt2agent.tools import account, apps, codex, conversations, gpts, images
+from gpt2agent.tools import instructions, memory, writes
 
 from tests.test_tools import FakeClient, FakeMCP
 
@@ -41,6 +42,21 @@ def test_memory_tools_tolerate_none() -> None:
     mcp = _tools(memory)
     assert mcp.tools["memory_list"]() == []
     assert mcp.tools["memory_search"]("anything") == []
+
+
+def test_conversation_tools_tolerate_none() -> None:
+    """cx review 2026-07-02 P2: the guarded conversation/task sites lacked the
+    same None-contract coverage the newly-guarded modules got."""
+    mcp = _tools(conversations)
+    assert mcp.tools["list_conversations"]() == []
+    assert mcp.tools["get_conversation"]("conv-1") == {}
+    assert mcp.tools["list_tasks"]() == []
+
+
+def test_file_tools_tolerate_none() -> None:
+    mcp = _tools(images)
+    assert mcp.tools["get_file_info"]("f1") == {}
+    assert mcp.tools["get_file_download_url"]("f1") == ""
 
 
 def test_custom_instructions_get_tolerates_none() -> None:


### PR DESCRIPTION
## Summary

Five audit fixes from the 2026-07-01 known-remaining list, plus the two P2 test gaps from the 2026-07-02 cx review of PRs #18/#20.

- **redact**: `_PHONE_RE` matched calendar dates — `"2026-05-26"` came back as `<PHONE>` in memories, tasks, and conversation titles. Phone matches that start with a date shape are now left alone; real phone shapes still mask.
- **DR**: `deep_research` / `deep_research_heavy` dropped the `terminated_abnormally` / `timeout` done-flags, so a truncated report was indistinguishable from a complete one. Both now append an explicit "⚠ Report may be incomplete" note.
- **install**: `_atomic_write` `rename()`d over symlinked configs, replacing the link with a plain file and stranding the dotfile-repo target. Now resolves and writes through.
- **setup**: `write_mcp_config` blindly `write_text`'d `~/.gpt2agent/config.toml`. Now backs up (`.bak-gpt2agent`), writes atomically, and no-ops on identical content.
- **auth**: removed the browser-use fallback that saved a NextAuth session cookie as `access_token` — that token 401s on every API call; extraction now fails visibly.

## Tests

- +17 tests: `tests/test_audit_2026_07_02.py` (14) + cx-review P2 gap coverage in `test_install.py` (combined commented header + commented child subtable) and `test_none_guards.py` (conversation/file/task None-contract).
- Local: `163 passed, 9 skipped`; `ruff check gpt2agent tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FAemSFrVynaESb72jVGwP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved date strings when redacting phone numbers, preventing calendar-style text from being altered.
  * Added clearer warnings when long-running research results end early or time out.
  * Improved login token handling by rejecting invalid pasted values and removing a broken fallback that could save unusable tokens.
  * Fixed config updates so changes write to the intended file, back up existing settings, and avoid unnecessary rewrites.

* **Tests**
  * Expanded regression coverage for redaction, config writing, token validation, and safer empty-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->