### PR TITLE
chore(release): v0.0.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-07-02
+
+Patch release: 2026-07-02 audit round — PII-redaction correctness, robustness
+against empty backend responses, Codex TOML config-editing fixes, and honest
+failure reporting (truncated Deep Research reports, invalid pasted tokens).
+Source-only test coverage baseline recorded at 59% (168 tests).
+
 ### Security
 
 - `get_conversation` now redacts message `text`/`code` bodies (emails, phones,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.8"
+version = "0.0.9"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },


### PR DESCRIPTION
Release v0.0.9 — the 2026-07-02 audit round.

## Contents (all merged to main via PRs #17, #18, #20, #21)

- **Security**: `get_conversation` redacts message bodies (emails/phones/JWT/bearer/API-key/GitHub-token shapes) before truncation.
- PII redaction no longer corrupts calendar dates, and a phone following a date in the same greedy match is still masked (cx P1).
- REST tools tolerate empty 2xx backend bodies instead of raw AttributeError/TypeError; `custom_instructions_set` refuses blind overwrite.
- Codex TOML editing: dotted child subtables and trailing-comment headers handled (no more duplicate-table invalid TOML on re-install).
- Deep Research: truncated/timed-out reports carry an explicit incomplete-note; long reports no longer misclassified as clarification requests.
- `gpt2agent install`/`setup`: symlinked configs written through; config.toml backed up + written atomically.
- auth: session-cookie-as-access-token paths removed (browser-use fallback deleted; manual paste rejects non-JWT values) (cx P2).

## Verification

- Local: 168 passed, 9 skipped; ruff clean. Coverage baseline recorded: 59% source-only.
- CI green on all merged PRs; cx (GPT-5.5) review of #21: round 1 BLOCK → fixes → round 2 **MERGE**.
- PyPI trusted publisher verified working (0.0.8 wheel+sdist live).
- Receipt: `artifacts/verify/audit-2026-07-02.md` (workspace).

After merge: tag `v0.0.9` on the merge commit → release.yml publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsBLZ8EE6o9x4KtJ5WhHbX