### PR TITLE
fix: recover release pipeline with v0.0.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,20 @@ jobs:
       - name: Require the tagged commit to be on origin/main
         run: |
           set -euo pipefail
-          if [ "$(git cat-file -t "$GITHUB_REF")" != tag ]; then
+          VERIFY_REF="refs/release-verification/tag"
+          git fetch --force --no-tags origin "$GITHUB_REF:$VERIFY_REF"
+          if [ "$(git cat-file -t "$VERIFY_REF")" != tag ]; then
             echo "::error::Release ref $GITHUB_REF must be an annotated tag"
             exit 1
           fi
+          TAG_COMMIT="$(git rev-parse "$VERIFY_REF^{}")"
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Release tag $GITHUB_REF resolves to $TAG_COMMIT, not event SHA $GITHUB_SHA"
+            exit 1
+          fi
           git fetch --no-tags origin main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Release tag commit $GITHUB_SHA is not reachable from origin/main"
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Release tag commit $TAG_COMMIT is not reachable from origin/main"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.11] - 2026-07-10
+
+Recovery release carrying forward every change in the
+[`0.0.10` changelog section](https://github.com/robotlearning123/gpt2agent/blob/v0.0.11/CHANGELOG.md#0010---2026-07-10).
+Version `0.0.10` was tagged but never published to PyPI or as a GitHub Release
+because its source gate inspected a runner-local tag ref that
+`actions/checkout` had rewritten to the peeled commit.
+
+### Fixed
+
+- Release source verification now reads the annotated tag's peeled target from
+  the remote, binds it to the workflow event SHA, and proves that exact commit
+  is on `origin/main`. This remains correct even when checkout rewrites its
+  runner-local tag ref, while still rejecting lightweight, mismatched, and
+  off-main tags.
+
 ## [0.0.10] - 2026-07-10
 
 Patch release from the 2026-07-09 end-to-end security, correctness,

--- a/README.md
+++ b/README.md
@@ -318,15 +318,15 @@ intended annotated tag. This avoids silently including a later unrelated PR:
 
 ```bash
 set -euo pipefail
-git switch main
-git pull --ff-only origin main
 git fetch --no-tags origin main:refs/remotes/origin/main
 read -r -p "Merged release PR number: " PR_NUMBER
 RELEASE_SHA=$(gh pr view "$PR_NUMBER" --json mergeCommit,state \
   --jq 'select(.state == "MERGED") | .mergeCommit.oid')
 test -n "$RELEASE_SHA"
 git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+test -z "$(git status --porcelain)"
 git switch --detach "$RELEASE_SHA"
+trap 'git switch - >/dev/null || true' EXIT
 test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
 VERSION=$(python - <<'PY'
 try:
@@ -339,22 +339,37 @@ PY
 )
 TAG="v$VERSION"
 python scripts/verify_release.py --tag "$TAG"
+REMOTE_TAG_SHA="$(
+  git ls-remote --tags origin |
+    awk -v ref="refs/tags/$TAG" '$2 == ref { print $1 }'
+)"
+if [ -n "$REMOTE_TAG_SHA" ]; then
+  echo "Release tag already exists on origin: $TAG" >&2
+  exit 1
+fi
 git tag -a "$TAG" "$RELEASE_SHA" -m "gpt2agent $VERSION"
-git switch main
 git push origin "refs/tags/$TAG"
+trap - EXIT
+git switch -
 ```
 
 The release workflow (`.github/workflows/release.yml`) verifies every version
-surface and the CHANGELOG, proves the tagged commit is on `origin/main`, runs
-the test matrix, installs and tests the built wheel and sdist in clean
-environments, publishes to PyPI via OIDC trusted publishing, and posts a GitHub
-Release with that version's CHANGELOG body.
+surface and the CHANGELOG, reads the remote annotated tag target independently
+of checkout's runner-local tag ref, binds it to the event SHA, and proves that
+commit is on `origin/main`. It then runs the test matrix, installs and tests the
+built wheel and sdist in clean environments, publishes to PyPI via OIDC trusted
+publishing, and posts a GitHub Release with that version's CHANGELOG body.
 
 If a publish or downstream release job fails, use GitHub Actions' **Re-run
 failed jobs** on that same workflow run so it reuses the original build
 artifact. Do not re-run the whole workflow after any file reaches PyPI: Python
 sdists are not guaranteed byte-reproducible, and the hash guard intentionally
 rejects different rebuilt bytes for an existing version.
+
+If the source gate itself exposes a workflow defect before anything is
+published, fix the workflow on `main` and prepare the next version. Never
+delete, move, or reuse the failed protected release tag: reruns still execute
+the workflow stored at that immutable tagged commit.
 
 > PyPI publishing requires a Trusted Publisher for this repository, workflow
 > `release.yml`, and environment `pypi`. Keep that environment restricted to

--- a/gpt2agent/__init__.py
+++ b/gpt2agent/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.10"
+version = "0.0.11"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -45,6 +46,98 @@ def _verify(root: Path, tag: str | None = None) -> subprocess.CompletedProcess[s
     if tag is not None:
         command.extend(["--tag", tag])
     return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        env=_git_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _git_env(**overrides: str) -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        **overrides,
+    }
+
+
+def _release_source_guard() -> str:
+    lines = (
+        PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8").splitlines()
+    step = lines.index("      - name: Require the tagged commit to be on origin/main")
+    assert lines[step + 1] == "        run: |"
+
+    script: list[str] = []
+    for line in lines[step + 2 :]:
+        if line.startswith("          "):
+            script.append(line[10:])
+        elif not line:
+            script.append("")
+        else:
+            break
+    return "\n".join(script)
+
+
+def _run_release_source_guard(
+    tmp_path: Path, tag_kind: str, *, mismatched_event: bool = False
+) -> subprocess.CompletedProcess[str]:
+    remote = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    checkout = tmp_path / "checkout"
+    source.mkdir()
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(source, "init", "--initial-branch=main")
+    _git(source, "config", "user.name", "Release Test")
+    _git(source, "config", "user.email", "release-test@example.invalid")
+    (source / "release.txt").write_text("main\n", encoding="utf-8")
+    _git(source, "add", "release.txt")
+    _git(source, "commit", "-m", "main release")
+    main_sha = _git(source, "rev-parse", "HEAD")
+    _git(source, "remote", "add", "origin", str(remote))
+    _git(source, "push", "origin", "main")
+
+    tag_sha = main_sha
+    if tag_kind == "off-main":
+        _git(source, "switch", "-c", "side")
+        (source / "side.txt").write_text("side\n", encoding="utf-8")
+        _git(source, "add", "side.txt")
+        _git(source, "commit", "-m", "side release")
+        tag_sha = _git(source, "rev-parse", "HEAD")
+
+    if tag_kind in {"lightweight", "lightweight-decoy"}:
+        _git(source, "tag", "v1.2.3", tag_sha)
+    else:
+        _git(source, "tag", "-a", "v1.2.3", tag_sha, "-m", "v1.2.3")
+    _git(source, "push", "origin", "refs/tags/v1.2.3")
+    if tag_kind == "lightweight-decoy":
+        decoy = "0/refs/tags/v1.2.3"
+        _git(source, "tag", "-a", decoy, tag_sha, "-m", decoy)
+        _git(source, "push", "origin", f"refs/tags/{decoy}")
+
+    _git(tmp_path, "clone", "--branch", "main", str(remote), str(checkout))
+    _git(checkout, "update-ref", "refs/tags/v1.2.3", main_sha)
+    assert _git(checkout, "cat-file", "-t", "refs/tags/v1.2.3") == "commit"
+
+    event_sha = "0" * 40 if mismatched_event else tag_sha
+    return subprocess.run(
+        ["bash", "-c", _release_source_guard()],
+        cwd=checkout,
+        env=_git_env(
+            GITHUB_REF="refs/tags/v1.2.3",
+            GITHUB_SHA=event_sha,
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 def test_release_verifier_accepts_consistent_tree(tmp_path) -> None:
@@ -191,6 +284,37 @@ def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
     assert all(re.fullmatch(r"[0-9a-f]{40}", revision) for _, _, revision in references)
 
 
+def test_release_source_guard_accepts_remote_annotated_tag_after_local_clobber(
+    tmp_path: Path,
+) -> None:
+    result = _run_release_source_guard(tmp_path, "annotated")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("tag_kind", "mismatched_event", "expected_error"),
+    [
+        ("lightweight", False, "must be an annotated tag"),
+        ("lightweight-decoy", False, "must be an annotated tag"),
+        ("annotated", True, "not event SHA"),
+        ("off-main", False, "is not reachable from origin/main"),
+    ],
+)
+def test_release_source_guard_rejects_invalid_remote_release_source(
+    tmp_path: Path,
+    tag_kind: str,
+    mismatched_event: bool,
+    expected_error: str,
+) -> None:
+    result = _run_release_source_guard(
+        tmp_path, tag_kind, mismatched_event=mismatched_event
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stdout + result.stderr
+
+
 def test_release_workflows_keep_required_source_and_artifact_gates() -> None:
     ci = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     release = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text(
@@ -205,9 +329,15 @@ def test_release_workflows_keep_required_source_and_artifact_gates() -> None:
     assert "working-directory: ${{ runner.temp }}" in ci
     assert "gpt2agent --version" in ci
     assert "needs: [quality, test, windows-smoke, lint-installer]" in ci
-    assert 'git cat-file -t "$GITHUB_REF"' in release
+    assert "workflow_dispatch:" not in release
+    assert 'VERIFY_REF="refs/release-verification/tag"' in release
+    assert 'git fetch --force --no-tags origin "$GITHUB_REF:$VERIFY_REF"' in release
+    assert 'git cat-file -t "$VERIFY_REF"' in release
     assert "must be an annotated tag" in release
-    assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main' in release
+    assert 'TAG_COMMIT="$(git rev-parse "$VERIFY_REF^{}")"' in release
+    assert 'if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then' in release
+    assert 'git merge-base --is-ancestor "$TAG_COMMIT" origin/main' in release
+    assert 'git cat-file -t "$GITHUB_REF"' not in release
     assert "python scripts/verify_release.py --tag" in release
     assert "distribution_version" in release
     assert "DIST_VERSION" in release
@@ -225,14 +355,26 @@ def test_release_workflows_keep_required_source_and_artifact_gates() -> None:
         "              tests/test_heavy_dr_parser.py"
     ) in release
     assert 'gh pr view "$PR_NUMBER" --json mergeCommit,state' in readme
-    assert "```bash\nset -euo pipefail\ngit switch main" in readme
+    assert (
+        "```bash\nset -euo pipefail\n"
+        "git fetch --no-tags origin main:refs/remotes/origin/main"
+    ) in readme
+    assert "\ngit switch main\n" not in readme
+    assert "git pull --ff-only origin main" not in readme
     assert 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' in readme
+    assert 'test -z "$(git status --porcelain)"' in readme
     assert 'git switch --detach "$RELEASE_SHA"' in readme
+    assert "trap 'git switch - >/dev/null || true' EXIT" in readme
     assert 'git tag -a "$TAG" "$RELEASE_SHA"' in readme
+    assert 'awk -v ref="refs/tags/$TAG" \'$2 == ref { print $1 }\'' in readme
     assert 'git push origin "refs/tags/$TAG"' in readme
+    assert "trap - EXIT" in readme
+    assert "\ngit switch -\n```" in readme
     assert "Re-run failed jobs" in readme_flat
     assert "Do not re-run the whole workflow" in readme_flat
-    assert "python scripts/verify_release.py --tag v0.0.10" not in readme
+    assert not re.search(
+        r"python scripts/verify_release\.py --tag v\d+\.\d+\.\d+", readme
+    )
 
 
 def test_account_reported_quota_is_not_documented_as_a_fixed_limit() -> None:


### PR DESCRIPTION
## Summary

- recover from the immutable, unpublished `v0.0.10` tag by carrying its changes into `v0.0.11`
- verify the exact remote annotated tag independently of the runner-local ref rewritten by `actions/checkout`
- bind the peeled tag target to the event SHA and require ancestry from `origin/main`
- add executable regressions for checkout clobber, lightweight tags, suffix-decoy tags, SHA mismatch, and off-main tags
- make the documented release flow linked-worktree-safe, clean-tree-only, exact-ref-aware, and self-restoring

The PyPI environment remains tag-only; this does not add a manual publishing path or weaken tag protection. The protected `v0.0.10` tag remains immutable, with no PyPI or GitHub Release artifact.

## Verification

- `SKIP_LIVE=1 python -m pytest -q` — 323 passed, 9 skipped
- `python -m ruff check gpt2agent tests scripts`
- `shellcheck -e SC2086 -e SC2155 $(git ls-files "*.sh")`
- `python scripts/verify_release.py --tag v0.0.11`
- YAML + JSON parse, compileall, and `git diff --check`
- clean committed-archive wheel/sdist build and Twine check
- clean wheel CLI/module/metadata/resources install
- packaged sdist parser tests — 18 passed
- PyPI preflight — 0.0.11 absent

Local rehearsal hashes (CI will build and independently verify its own artifacts):

- wheel: `95b1de8fb13441a004876e7dc8585fdb02f7866068fccc6e1eb24fc83369787e`
- sdist: `f85c3a392b1ed2427a6d158f5b304535dc6583276ee19ddf1bf34cfd0d180c2b`