### PR TITLE
feat(voice): v0.0.13 — ChatGPT Voice catalog discovery (list_voices)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "gpt2agent",
       "source": "./",
-      "description": "ChatGPT Plus/Pro account as 25 MCP tools + the deep-research and gpt2agent skills. Requires `pipx install gpt2agent`.",
+      "description": "ChatGPT Plus/Pro account as 26 MCP tools, including the Voice catalog, plus the deep-research and gpt2agent skills. Requires `pipx install gpt2agent`.",
       "author": { "name": "robotlearning123" },
       "license": "MIT",
       "keywords": ["mcp", "chatgpt", "openai", "deep-research"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.11",
-  "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
+  "version": "0.0.13",
+  "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode, Voice catalog) as 26 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",
     "url": "https://github.com/robotlearning123"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ versioning: [SemVer](https://semver.org/).
   bounded, stable shape per voice (`id`, `name`, `description`, `selected`,
   `has_preview`); backend voice IDs are preserved verbatim and display text is
   redacted. Brings the server to 26 MCP tools.
+- `list_voices(voice_mode=...)` — optional mode-specific catalog. Real ChatGPT
+  modes are `standard`, `advanced`, `live` (the latest, GPT-Live), and
+  `wingman`; the value is charset-validated (rejected before any request) but
+  not hard-restricted to that set. Omitting it returns the account default.
 - `docs/roadmap.md` — version lanes, the GPT-Live boundary, the language policy
   (Python core with an optional TypeScript sidecar for a future live-voice
   lane), and the release gates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ versioning: [SemVer](https://semver.org/).
   bounded, stable shape per voice (`id`, `name`, `description`, `selected`,
   `has_preview`); backend voice IDs are preserved verbatim and display text is
   redacted. Brings the server to 26 MCP tools.
-- `list_voices(voice_mode=...)` — optional mode-specific catalog. Real ChatGPT
-  modes are `standard`, `advanced`, `live` (the latest, GPT-Live), and
-  `wingman`; the value is charset-validated (rejected before any request) but
+- `list_voices(voice_mode=...)` — optional mode-specific catalog. The live
+  account contract accepted `standard`, `advanced`, and `wingman` on
+  2026-07-11; the value is charset-validated (rejected before any request) but
   not hard-restricted to that set. Omitting it returns the account default.
+  GPT-Live audio is a separate session contract, and the catalog endpoint
+  currently rejects `voice_mode=live` with HTTP 422.
 - `docs/roadmap.md` — version lanes, the GPT-Live boundary, the language policy
   (Python core with an optional TypeScript sidecar for a future live-voice
   lane), and the release gates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-07-11
+
+### Added
+
+- `list_voices` — read-only MCP tool exposing the signed-in account's Voice
+  catalog from the private `GET /backend-api/settings/voices` route. Returns a
+  bounded, stable shape per voice (`id`, `name`, `description`, `selected`,
+  `has_preview`); backend voice IDs are preserved verbatim and display text is
+  redacted. Brings the server to 26 MCP tools.
+- `docs/roadmap.md` — version lanes, the GPT-Live boundary, the language policy
+  (Python core with an optional TypeScript sidecar for a future live-voice
+  lane), and the release gates.
+
+### Notes
+
+- This release adds Voice **catalog discovery only**. It does not start a Voice
+  session, fetch preview media, capture a microphone, synthesize speech, stream
+  GPT-Live realtime audio, or guarantee transcript extraction.
+- The catalog route is a private, reverse-engineered website contract. A
+  malformed response fails closed with `voice catalog contract changed` rather
+  than pretending the catalog is empty.
+
 ## [0.0.11] - 2026-07-10
 
 Recovery release carrying forward every change in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ python -m gpt2agent run   # start MCP server (stdio)
 
 ## Key Files
 
-- `gpt2agent/server.py` — MCP tool registration (25 tools), config loading
+- `gpt2agent/server.py` — MCP tool registration (26 tools), config loading
 - `gpt2agent/sse.py` — Async SSE client for `/backend-api/conversation` (chat, DR, agent, image gen, code interpreter, canvas)
 - `gpt2agent/backend.py` — Sync HTTP client (`curl_cffi`), token management, sentinel challenges
-- `gpt2agent/tools/` — 10 tool modules (19 of the 25 tools; the 6 SSE chat/DR/agent tools live in server.py), each with `register(mcp, client, conv=None)`
+- `gpt2agent/tools/` — 11 tool modules (20 of the 26 tools; the 6 SSE chat/DR/agent tools live in server.py), each with `register(mcp, client, conv=None)`
 - `gpt2agent/sentinel.py` — POW + Turnstile solver
 - `gpt2agent/install.py` — `gpt2agent install` subcommand
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ and skipped by default). Also run `ruff check gpt2agent tests scripts` and
 - `BackendClient` (backend.py): synchronous HTTP via `curl_cffi`. Handles token loading, sentinel challenges, REST endpoints.
 - `ConversationClient` (sse.py): async SSE streaming. Handles `/backend-api/conversation` and `/backend-api/f/conversation` for chat, DR, agent mode, image gen, code interpreter, canvas.
 - `server.py`: FastMCP tool registration. Creates `BackendClient` + `ConversationClient` singletons.
-- `tools/`: 10 registration modules exposing 25 MCP tools. REST-backed handlers
+- `tools/`: 11 registration modules exposing 26 MCP tools. REST-backed handlers
   are async and offload the synchronous `BackendClient` through the shared
   tool backend helper.
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Zed, and any MCP client.
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://pypi.org/project/gpt2agent/)
 
-📖 **[Quickstart](./docs/quickstart.md)** · **[Client setup](./docs/clients.md)** · **[Troubleshooting](./docs/troubleshooting.md)** · **[FAQ](./docs/faq.md)** · **[Docs index](./docs/README.md)**
+📖 **[Quickstart](./docs/quickstart.md)** · **[Client setup](./docs/clients.md)** · **[Troubleshooting](./docs/troubleshooting.md)** · **[FAQ](./docs/faq.md)** · **[Roadmap](./docs/roadmap.md)** · **[Docs index](./docs/README.md)**
 
 ---
 
 ## What it does
 
-gpt2agent exposes **25 MCP tools** that forward requests directly to ChatGPT's backend API.
+gpt2agent exposes **26 MCP tools** that forward requests directly to ChatGPT's backend API.
 No proxy process. No separate account. No platform API key. Your `codex login`,
 your token, your quota.
 
@@ -126,7 +126,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 
 ---
 
-## Tools (25)
+## Tools (26)
 
 ### Chat & reasoning
 
@@ -159,6 +159,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 |---|---|
 | `account_status` | Plan, country, groups, feature count, subscription expiry |
 | `list_models` | All models on your account (slug, max_tokens, reasoning_type, capabilities, enabled_tools) |
+| `list_voices` | Available Voice catalog (backend ID, display metadata, selected state, preview availability) |
 | `list_conversations` | Recent ChatGPT conversations (titles: emails/phones redacted) |
 | `get_conversation` | Full message history for a specific conversation (multimodal, code, images) |
 | `list_tasks` | Scheduled / completed ChatGPT tasks |
@@ -200,11 +201,13 @@ $CODEX_HOME/auth.json (default ~/.codex/auth.json) ← auto-refreshed by Codex
    gpt2agent  (stdio MCP server, token reloaded on each call)
         |
    curl_cffi  →  chatgpt.com /backend-api/{conversation,f/conversation,me,
-                                          models, memories, codex, gizmos, ...}
+                                          models, memories, settings/voices,
+                                          codex, gizmos, ...}
         |
-   25 MCP tools  (chat, agent, DR ×2, GPT chat, image gen,
+   26 MCP tools  (chat, agent, DR ×2, GPT chat, image gen,
                   code interpreter, canvas, memory r/w,
-                  instructions r/w, codex r/w, account introspect)
+                  instructions r/w, codex r/w, Voice catalog,
+                  account introspect)
 ```
 
 ---
@@ -232,9 +235,12 @@ heavy_dr = "gpt-5-5-pro"    # override slug for deep_research_heavy
 - **Deep Research quota:** limits and reset timing are account-reported and can
   change. Run the bundled `deep-research/bin/quota.sh` before heavy work and run
   heavy Deep Research serially.
-- **Account-tier features not yet supported:** Sora video, Operator/CUA, voice
-  sessions. These use HTTP endpoints that return 404 or haven't yet been
-  reverse-engineered out of the chatgpt.com web bundle.
+- **Voice scope:** `list_voices` reads the account's current Voice catalog, but
+  it does not start a Voice session or fetch its preview media. GPT-Live
+  realtime audio, microphone/playback transport, speech synthesis, and a
+  guaranteed post-session transcript adapter are not supported.
+- **Other account-tier features not yet supported:** Sora video and
+  Operator/CUA.
 - **`gpt_chat`** is experimental — `gizmo_id` payload field verified against
   web traffic but not load-tested across all g-p-* types.
 - Requires an active ChatGPT Plus or Pro subscription.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,9 +12,11 @@ User-facing documentation. (Project/contributor internals live in
   appearing, temporary-chat feature blocks, pipx/PEP-668.
 - **[FAQ](./faq.md)** — official? ban risk? stdio vs HTTP? Plus vs Pro? quota?
 - **[How it works](./how-it-works.md)** — the no-proxy architecture.
+- **[Roadmap](./roadmap.md)** — version lanes, GPT-Live boundary, language policy,
+  and release gates.
 
 For the full per-tool reference (every argument, return shape, and gotcha for all
-25 tools), see [`gpt2agent/skills/gpt2agent/tools-reference.md`](../gpt2agent/skills/gpt2agent/tools-reference.md).
+26 tools), see [`gpt2agent/skills/gpt2agent/tools-reference.md`](../gpt2agent/skills/gpt2agent/tools-reference.md).
 
 Security model and ToS/account-ban risk are covered in the main
 [README](../README.md#security--risk--read-before-you-run-this).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,6 +49,9 @@ redacts token/secret values from error output.
 
 ### What's NOT supported?
 
-Sora video, Operator/CUA, and voice sessions — those endpoints aren't reverse-engineered
-yet. Everything else (chat, agent mode, deep research, image gen, code interpreter,
-canvas, memory, custom instructions, Codex tasks) is exposed via the 25 MCP tools.
+Sora video and Operator/CUA are not supported. The read-only `list_voices` tool
+does expose the account's current Voice catalog, but that is not a Voice
+session: GPT-Live realtime audio, microphone/playback transport, speech
+synthesis, and guaranteed transcript extraction remain unsupported. The
+catalog route is a private website contract and may change. The server exposes
+26 MCP tools in total.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -12,8 +12,9 @@ $CODEX_HOME/auth.json (default ~/.codex/auth.json) ← bearer, auto-refreshed by
    curl_cffi  ──TLS-impersonates Chrome──▶  chatgpt.com /backend-api/...
         │                                     ├── /conversation, /f/conversation   (SSE)
         │                                     └── /me, /models, /memories, /codex,  (REST)
-        │                                         /gizmos, /files, /apps, ...
-   25 MCP tools
+        │                                         /gizmos, /files, /apps,
+        │                                         /settings/voices, ...
+   26 MCP tools
 ```
 
 ## Request path
@@ -21,9 +22,10 @@ $CODEX_HOME/auth.json (default ~/.codex/auth.json) ← bearer, auto-refreshed by
 - **SSE tools** (`chat`, `agent`, `deep_research[_heavy]`, `gpt_chat`, image gen,
   code interpreter, canvas) stream from `/backend-api/conversation` and are parsed
   incrementally in `gpt2agent/sse.py`.
-- **REST tools** (account, models, memory, instructions, conversations, codex, apps,
-  files) are thin wrappers over `gpt2agent/backend.py`'s sync HTTP client, exposed
-  from `gpt2agent/tools/*.py`.
+- **REST tools** (account, models, Voice catalog, memory, instructions,
+  conversations, codex, apps, files) are thin wrappers over
+  `gpt2agent/backend.py`'s sync HTTP client, exposed from
+  `gpt2agent/tools/*.py`.
 
 ## The Sentinel challenge
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,80 @@
+# Roadmap
+
+Where gpt2agent is going, and — just as important — where the hard boundaries
+are. This page is a dated snapshot of intent, not a compatibility guarantee:
+every capability here rides private, reverse-engineered chatgpt.com routes that
+can change without notice.
+
+## Version lanes
+
+| Version | Theme | State |
+|---|---|---|
+| `0.0.11` | Recovery release; hardened release-source verification | Published to PyPI |
+| `0.0.12` | Account-native feature coverage (read-only introspection breadth) | Design + cross-model review complete; implementation on a separate lane |
+| `0.0.13` | Voice **catalog** (`list_voices`) | Code complete; release held until 0.0.12 lands |
+| `0.0.14` | **Real live voice (GPT-Live)** — experimental TypeScript WebRTC sidecar | Investigation; evidence capture first |
+
+Lanes ship in order. 0.0.13 does not invent or supersede 0.0.12; the two are
+independent branches and merge in sequence.
+
+## The GPT-Live boundary
+
+Voice is an official ChatGPT product, but the routes this project touches are
+private website contracts. The line between what ships and what does not:
+
+**Supported (0.0.13):**
+
+- Voice **catalog discovery** via `list_voices` — the account's current voice
+  IDs and display metadata from `GET /backend-api/settings/voices`, projected
+  to a bounded, redacted, read-only shape.
+
+**Not supported (and why):**
+
+- **GPT-Live realtime audio** — full-duplex low-latency speech-to-speech. MCP
+  is a request/response tool protocol, not an audio transport, so GPT-Live
+  cannot be a plain MCP tool. It rides browser-native WebRTC.
+- **Microphone / playback transport, speech synthesis, preview-media fetch** —
+  no audio ever crosses the MCP boundary today.
+- **Guaranteed post-session transcript** — official docs say a transcript lands
+  in chat history, but this project has not proven a stable adapter for that
+  shape; it stays inventory-only and unverified.
+
+The current official Voice documentation also excludes connected apps/plugins,
+Work, Codex, custom GPTs, temporary chats, and desktop from initial Live
+support — which constrains any "let Live call out to an external agent" design.
+
+**0.0.14 direction.** A real live-voice bridge is pursued as an *optional,
+disabled-by-default, experimental* lane: a small TypeScript/browser sidecar owns
+the WebRTC and media APIs; Python remains the MCP control plane exposing a
+control-only surface (`start`, `status`, `send_text`, `end`, `get_transcript`).
+Audio stays local to the sidecar and never transits MCP. No sidecar ships until
+a real captured handshake, benchmarks, and a separate safety design justify it.
+
+## Language policy
+
+- The MCP core stays **Python**. Network latency, server processing, and
+  streaming dominate this workload; the mature `curl_cffi` client, tested
+  transport, authentication, and redaction code are kept with the smallest safe
+  diff.
+- The GPT-Live lane may add an **optional TypeScript/browser sidecar** for
+  browser-native WebRTC and media APIs. It is isolated so private media churn
+  cannot destabilize the Python read server.
+- **Rust** is reserved for a measured CPU, memory, or transport bottleneck that
+  cannot be resolved in the current architecture — not adopted speculatively.
+
+## Release gates
+
+Every release must clear, in order:
+
+1. Full offline `pytest` suite green (live/network tests auto-skip).
+2. `ruff check gpt2agent tests scripts` clean.
+3. `scripts/verify_release.py` — all version fields (`pyproject.toml`,
+   `gpt2agent/__init__.py`, `.claude-plugin/plugin.json`, `server.json`) agree
+   and `CHANGELOG.md` has a dated section for the release.
+4. Wheel + sdist build, `twine check`, and a clean-environment install of each
+   artifact.
+5. One GET-only live-contract check (schema/shape only; no raw payload
+   persisted) when the change touches a private route.
+6. Independent cross-model review of the actual diff before merge.
+7. Post-merge `main` CI green on the exact merged commit before an annotated tag
+   is pushed.

--- a/gpt2agent/__init__.py
+++ b/gpt2agent/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.11"
+__version__ = "0.0.13"
 
 __all__ = ["__version__"]

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -644,7 +644,7 @@ def install_claude_skill(
     The deep-research skill calls gpt2agent's ConversationClient directly
     (bypasses MCP) so it works even before restarting Claude Code.
     The gpt2agent skill provides full account access instructions and
-    pre-approves all 25 MCP tools.
+    pre-approves all 26 MCP tools.
     """
     skills_src = Path(__file__).parent / "skills"
     target_dir = dst_dir or Path.home() / ".claude" / "skills"

--- a/gpt2agent/skills/gpt2agent/SKILL.md
+++ b/gpt2agent/skills/gpt2agent/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: gpt2agent
 description: |
-  Full ChatGPT Plus/Pro account access via MCP. 25 tools covering chat,
+  Full ChatGPT Plus/Pro account access via MCP. 26 tools covering chat,
   agent mode, deep research, image generation, code execution, canvas,
-  memory, custom instructions, conversations, Custom GPTs, and Codex.
+  memory, custom instructions, conversations, Custom GPTs, Voice catalog,
+  and Codex.
   Reuses $CODEX_HOME/auth.json (or ~/.codex/auth.json) or the manual
   ~/.gpt2agent/token.json fallback.
   Use when you need ChatGPT models, web research with citations, DALL-E
@@ -24,6 +25,7 @@ allowed-tools:
   - mcp__gpt2agent__canvas_execute
   - mcp__gpt2agent__account_status
   - mcp__gpt2agent__list_models
+  - mcp__gpt2agent__list_voices
   - mcp__gpt2agent__list_conversations
   - mcp__gpt2agent__get_conversation
   - mcp__gpt2agent__list_tasks
@@ -70,6 +72,7 @@ If any precondition fails, stop and tell the user the exact fix command.
 | Image & file | `generate_image`, `get_file_info`, `get_file_download_url` |
 | Code execution | `code_interpreter`, `canvas_execute` |
 | Account & models | `account_status`, `list_models`, `list_apps` |
+| Voice catalog | `list_voices` |
 | Conversations | `list_conversations`, `get_conversation`, `list_tasks` |
 | Custom GPTs | `list_custom_gpts`, `gpt_chat` |
 | Memory | `memory_list`, `memory_search`, `memory_create_via_chat` |
@@ -89,6 +92,7 @@ If any precondition fails, stop and tell the user the exact fix command.
 | Run Python in sandbox | `code_interpreter` | Requires temporary=False |
 | Live document editing | `canvas_execute` | Requires temporary=False |
 | Use a Custom GPT | `gpt_chat(gizmo_id, prompt)` | List IDs with `list_custom_gpts` |
+| Discover available Voice choices | `list_voices` | Catalog only; does not start or stream a Voice session |
 | Save something to ChatGPT memory | `memory_create_via_chat` | Model-initiated write (REST 405 workaround) |
 | Create a Codex coding task | `codex_task_create` | Auto-resolves environment_id from repo_label |
 
@@ -122,7 +126,8 @@ Both require a non-temporary conversation context.
 ```
 1. account_status()   -- plan, features, expiry
 2. list_models()      -- all available model slugs
-3. list_conversations() -- recent chat history
+3. list_voices()      -- current Voice IDs/display metadata; no audio session
+4. list_conversations() -- recent chat history
 ```
 
 ### Codex integration
@@ -170,6 +175,7 @@ chat = "gpt-5-3"
 | 401 / auth error | Re-run `codex login` or `gpt2agent setup`, then restart the MCP server |
 | Image/code/canvas fails | Ensure `temporary=False` — these features are blocked in temporary chats |
 | DR connector unavailable | Enable Deep Research at chatgpt.com > Settings > Connectors |
+| "voice catalog contract changed" | ChatGPT's private Voice route changed; update gpt2agent before retrying |
 | "memory_add not available" | Use `memory_create_via_chat` instead (REST POST returns 405) |
 
 ## Detailed Reference

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -307,7 +307,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 
 - **Purpose**: Return the Voice choices currently available to the signed-in ChatGPT account.
 - **Parameters**:
-  - `voice_mode` (str, optional) -- select a mode-specific catalog. Real ChatGPT modes: `standard`, `advanced`, `live` (the latest, GPT-Live), `wingman`. Omit for the account default. Not restricted to that list (modes change), but must be a short lowercase token or it is rejected before any request.
+  - `voice_mode` (str, optional) -- select a mode-specific catalog. Values accepted by the live account contract on 2026-07-11 are `standard`, `advanced`, and `wingman`. Omit for the account default. The value is not restricted to that list (modes change), but must be a short lowercase token or it is rejected before any request. GPT-Live audio is a separate session contract, not a currently accepted catalog mode.
 - **Returns**: `list[dict]` -- each dict contains exactly:
   - `id` (str) -- the opaque backend Voice ID; preserved verbatim and not derived from the display name
   - `name` (str) -- display name, with common PII/secret patterns redacted
@@ -317,8 +317,8 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **When to use**: Discover account/rollout-specific Voice IDs and display metadata.
 - **Example**:
   ```python
-  voices = list_voices()                     # account default
-  live_voices = list_voices(voice_mode="live")  # GPT-Live catalog
+  voices = list_voices()                          # account default
+  advanced_voices = list_voices(voice_mode="advanced")
   selected = next((voice for voice in voices if voice["selected"] is True), None)
   ```
 - **Notes**:

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -306,7 +306,8 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 ### list_voices
 
 - **Purpose**: Return the Voice choices currently available to the signed-in ChatGPT account.
-- **Parameters**: None.
+- **Parameters**:
+  - `voice_mode` (str, optional) -- select a mode-specific catalog. Real ChatGPT modes: `standard`, `advanced`, `live` (the latest, GPT-Live), `wingman`. Omit for the account default. Not restricted to that list (modes change), but must be a short lowercase token or it is rejected before any request.
 - **Returns**: `list[dict]` -- each dict contains exactly:
   - `id` (str) -- the opaque backend Voice ID; preserved verbatim and not derived from the display name
   - `name` (str) -- display name, with common PII/secret patterns redacted
@@ -316,11 +317,12 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **When to use**: Discover account/rollout-specific Voice IDs and display metadata.
 - **Example**:
   ```python
-  voices = list_voices()
+  voices = list_voices()                     # account default
+  live_voices = list_voices(voice_mode="live")  # GPT-Live catalog
   selected = next((voice for voice in voices if voice["selected"] is True), None)
   ```
 - **Notes**:
-  - Uses the private `GET /backend-api/settings/voices` website route. Voice is an official ChatGPT product, but this adapter is not an official API and may drift.
+  - Uses the private `GET /backend-api/settings/voices` website route (with `?voice_mode=` when a mode is given). Voice is an official ChatGPT product, but this adapter is not an official API and may drift.
   - The catalog is live and rollout-specific; names, IDs, ordering, selection, and count are not hard-coded.
   - Raw preview URLs, colors, gain values, unknown response fields, and account identifiers are not returned.
   - This tool does not fetch preview audio, start a Voice session, capture a microphone, synthesize speech, stream GPT-Live audio, or guarantee transcript extraction.

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -1,6 +1,6 @@
 # gpt2agent MCP Tools Reference
 
-Complete parameter reference for all 25 MCP tools exposed by the gpt2agent server.
+Complete parameter reference for all 26 MCP tools exposed by the gpt2agent server.
 Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 
 ---
@@ -10,7 +10,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - [Chat & Reasoning (5)](#chat--reasoning)
 - [Image & File (3)](#image--file)
 - [Code Execution (2)](#code-execution)
-- [Account Introspection (7)](#account-introspection)
+- [Account Introspection (8)](#account-introspection)
 - [Memory & Instructions (5)](#memory--instructions)
 - [Codex (3)](#codex)
 
@@ -299,6 +299,32 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
   ```
 - **Notes**:
   - Returns models for `history_and_training_disabled=false` variant. Some models may differ in capabilities between temporary/non-temporary modes.
+  - Async handler; offloads the REST call to the synchronous backend client.
+
+---
+
+### list_voices
+
+- **Purpose**: Return the Voice choices currently available to the signed-in ChatGPT account.
+- **Parameters**: None.
+- **Returns**: `list[dict]` -- each dict contains exactly:
+  - `id` (str) -- the opaque backend Voice ID; preserved verbatim and not derived from the display name
+  - `name` (str) -- display name, with common PII/secret patterns redacted
+  - `description` (str) -- display description, with common PII/secret patterns redacted
+  - `selected` (bool or None) -- `True`/`False` only when the response identifies a selected ID present in the returned catalog; otherwise `None`
+  - `has_preview` (bool) -- whether the private response advertised preview media
+- **When to use**: Discover account/rollout-specific Voice IDs and display metadata.
+- **Example**:
+  ```python
+  voices = list_voices()
+  selected = next((voice for voice in voices if voice["selected"] is True), None)
+  ```
+- **Notes**:
+  - Uses the private `GET /backend-api/settings/voices` website route. Voice is an official ChatGPT product, but this adapter is not an official API and may drift.
+  - The catalog is live and rollout-specific; names, IDs, ordering, selection, and count are not hard-coded.
+  - Raw preview URLs, colors, gain values, unknown response fields, and account identifiers are not returned.
+  - This tool does not fetch preview audio, start a Voice session, capture a microphone, synthesize speech, stream GPT-Live audio, or guarantee transcript extraction.
+  - A malformed private response fails closed with `voice catalog contract changed` rather than pretending the catalog is empty.
   - Async handler; offloads the REST call to the synchronous backend client.
 
 ---

--- a/gpt2agent/tools/__init__.py
+++ b/gpt2agent/tools/__init__.py
@@ -11,6 +11,7 @@ from gpt2agent.tools import (
     instructions,
     memory,
     tools_features,
+    voice,
     writes,
 )
 
@@ -24,6 +25,7 @@ def register_all(mcp, client: BackendClient, conv=None) -> None:
     gpts.register(mcp, client)
     conversations.register(mcp, client)
     apps.register(mcp, client)
+    voice.register(mcp, client)
     writes.register(mcp, client)
     images.register(mcp, client, conv)
     tools_features.register(mcp, client, conv)

--- a/gpt2agent/tools/voice.py
+++ b/gpt2agent/tools/voice.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from typing import Any
+from urllib.parse import urlencode
 
 from mcp.types import ToolAnnotations
 
@@ -12,6 +14,15 @@ from gpt2agent.tools._redact import redact
 _ROUTE = "/backend-api/settings/voices"
 _CONTRACT_ERROR = "voice catalog contract changed"
 _MAX_VOICES = 128
+# ChatGPT serves a mode-specific catalog: `standard`, `advanced`, `live` (the
+# latest, GPT-Live), and `wingman` are the modes observed live. The set is not
+# hard-coded — any short lowercase token is forwarded — but the value is bounded
+# to this charset so it cannot inject into the query string.
+_VOICE_MODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+_VOICE_MODE_ERROR = (
+    "voice_mode must be a short lowercase token like 'standard', 'advanced', "
+    "'live', or 'wingman'"
+)
 
 
 def _fail_contract() -> None:
@@ -82,12 +93,23 @@ def register(mcp, client: BackendClient) -> None:
             openWorldHint=True,
         )
     )
-    async def list_voices() -> list[dict[str, Any]]:
+    async def list_voices(voice_mode: str | None = None) -> list[dict[str, Any]]:
         """List Voice choices currently available to the signed-in account.
+
+        `voice_mode` optionally selects a mode-specific catalog. ChatGPT serves
+        several modes — `standard`, `advanced`, `live` (the latest, GPT-Live),
+        and `wingman`; omit it for the account default. The value is not
+        restricted to that list (modes change), but must be a short lowercase
+        token.
 
         Returns only stable catalog metadata: `id`, `name`, `description`,
         `selected`, and `has_preview`. This does not start a Voice session,
         fetch preview audio, synthesize speech, or expose GPT-Live audio.
         """
-        data = await async_get(client, _ROUTE, target_path=_ROUTE)
+        path = _ROUTE
+        if voice_mode is not None:
+            if not _VOICE_MODE_RE.fullmatch(voice_mode):
+                raise ValueError(_VOICE_MODE_ERROR)
+            path = f"{_ROUTE}?{urlencode({'voice_mode': voice_mode})}"
+        data = await async_get(client, path, target_path=_ROUTE)
         return _normalize_catalog(data)

--- a/gpt2agent/tools/voice.py
+++ b/gpt2agent/tools/voice.py
@@ -11,6 +11,7 @@ from gpt2agent.tools._redact import redact
 
 _ROUTE = "/backend-api/settings/voices"
 _CONTRACT_ERROR = "voice catalog contract changed"
+_MAX_VOICES = 128
 
 
 def _fail_contract() -> None:
@@ -35,7 +36,7 @@ def _normalize_catalog(data: object) -> list[dict[str, Any]]:
         _fail_contract()
 
     raw_voices = data.get("voices")
-    if not isinstance(raw_voices, list):
+    if not isinstance(raw_voices, list) or len(raw_voices) > _MAX_VOICES:
         _fail_contract()
 
     normalized: list[dict[str, Any]] = []

--- a/gpt2agent/tools/voice.py
+++ b/gpt2agent/tools/voice.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.types import ToolAnnotations
+
+from gpt2agent.backend import BackendClient
+from gpt2agent.tools._backend import async_get
+from gpt2agent.tools._redact import redact
+
+
+_ROUTE = "/backend-api/settings/voices"
+_CONTRACT_ERROR = "voice catalog contract changed"
+
+
+def _fail_contract() -> None:
+    """Raise a payload-free error for a private response-shape change."""
+    raise RuntimeError(_CONTRACT_ERROR)
+
+
+def _bounded_text(value: object, *, max_length: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > max_length
+        or not value.isprintable()
+    ):
+        _fail_contract()
+    return value
+
+
+def _normalize_catalog(data: object) -> list[dict[str, Any]]:
+    """Project the private Voice response onto the stable MCP contract."""
+    if not isinstance(data, dict):
+        _fail_contract()
+
+    raw_voices = data.get("voices")
+    if not isinstance(raw_voices, list):
+        _fail_contract()
+
+    normalized: list[dict[str, Any]] = []
+    voice_ids: set[str] = set()
+    for raw in raw_voices:
+        if not isinstance(raw, dict):
+            _fail_contract()
+
+        voice_id = _bounded_text(raw.get("voice"), max_length=128)
+        name = _bounded_text(raw.get("name"), max_length=256)
+        description = _bounded_text(raw.get("description"), max_length=2_000)
+        preview_url = raw.get("preview_url")
+        if preview_url is not None and not isinstance(preview_url, str):
+            _fail_contract()
+        if voice_id in voice_ids:
+            _fail_contract()
+        voice_ids.add(voice_id)
+
+        normalized.append(
+            {
+                "id": voice_id,
+                "name": redact(name),
+                "description": redact(description),
+                "selected": None,
+                "has_preview": bool(preview_url),
+            }
+        )
+
+    selected = data.get("selected")
+    if isinstance(selected, str) and selected in voice_ids:
+        for item in normalized:
+            item["selected"] = item["id"] == selected
+
+    return normalized
+
+
+def register(mcp, client: BackendClient) -> None:
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )
+    async def list_voices() -> list[dict[str, Any]]:
+        """List Voice choices currently available to the signed-in account.
+
+        Returns only stable catalog metadata: `id`, `name`, `description`,
+        `selected`, and `has_preview`. This does not start a Voice session,
+        fetch preview audio, synthesize speech, or expose GPT-Live audio.
+        """
+        data = await async_get(client, _ROUTE, target_path=_ROUTE)
+        return _normalize_catalog(data)

--- a/gpt2agent/tools/voice.py
+++ b/gpt2agent/tools/voice.py
@@ -14,14 +14,15 @@ from gpt2agent.tools._redact import redact
 _ROUTE = "/backend-api/settings/voices"
 _CONTRACT_ERROR = "voice catalog contract changed"
 _MAX_VOICES = 128
-# ChatGPT serves a mode-specific catalog: `standard`, `advanced`, `live` (the
-# latest, GPT-Live), and `wingman` are the modes observed live. The set is not
-# hard-coded — any short lowercase token is forwarded — but the value is bounded
-# to this charset so it cannot inject into the query string.
+# ChatGPT currently serves mode-specific catalogs for `standard`, `advanced`,
+# and `wingman`. The set is not hard-coded — any short lowercase token is
+# forwarded so a future rollout can be probed — but the value is bounded to this
+# charset so it cannot inject into the query string. GPT-Live is a product/audio
+# session name, not a currently accepted value for this catalog query.
 _VOICE_MODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _VOICE_MODE_ERROR = (
     "voice_mode must be a short lowercase token like 'standard', 'advanced', "
-    "'live', or 'wingman'"
+    "or 'wingman'"
 )
 
 
@@ -96,11 +97,11 @@ def register(mcp, client: BackendClient) -> None:
     async def list_voices(voice_mode: str | None = None) -> list[dict[str, Any]]:
         """List Voice choices currently available to the signed-in account.
 
-        `voice_mode` optionally selects a mode-specific catalog. ChatGPT serves
-        several modes — `standard`, `advanced`, `live` (the latest, GPT-Live),
-        and `wingman`; omit it for the account default. The value is not
-        restricted to that list (modes change), but must be a short lowercase
-        token.
+        `voice_mode` optionally selects a mode-specific catalog. ChatGPT
+        currently accepts `standard`, `advanced`, and `wingman`; omit it for
+        the account default. The value is not restricted to that list (modes
+        change), but must be a short lowercase token. GPT-Live audio is a
+        separate session contract, not a catalog mode exposed by this tool.
 
         Returns only stable catalog metadata: `id`, `name`, `description`,
         `selected`, and `has_preview`. This does not start a Voice session,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.11"
+version = "0.0.13"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
-  "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.11",
+  "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent, Voice catalog) as 26 MCP tools.",
+  "version": "0.0.13",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.11",
+      "version": "0.0.13",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },

--- a/tests/test_audit_2026_07_09_tools.py
+++ b/tests/test_audit_2026_07_09_tools.py
@@ -22,6 +22,7 @@ from gpt2agent.tools import (
     images,
     instructions,
     memory,
+    voice,
     writes,
 )
 from gpt2agent.tools._redact import redact
@@ -288,6 +289,7 @@ def test_all_registered_rest_handlers_are_async() -> None:
         images: {"generate_image", "get_file_info", "get_file_download_url"},
         instructions: {"custom_instructions_get"},
         memory: {"memory_list", "memory_search"},
+        voice: {"list_voices"},
         writes: {"custom_instructions_set", "codex_task_create"},
     }
 

--- a/tests/test_audit_2026_07_09_tools.py
+++ b/tests/test_audit_2026_07_09_tools.py
@@ -218,13 +218,22 @@ async def test_custom_instruction_setter_serializes_read_modify_write() -> None:
 
 
 @pytest.mark.asyncio
-async def test_slow_rest_backend_does_not_block_event_loop() -> None:
+@pytest.mark.parametrize(
+    ("module", "tool_name", "response"),
+    [
+        (account, "list_models", {"models": []}),
+        (voice, "list_voices", {"selected": None, "voices": []}),
+    ],
+)
+async def test_slow_rest_backend_does_not_block_event_loop(
+    module, tool_name: str, response: dict[str, Any]
+) -> None:
     class _SlowClient(_Client):
         def get(self, path: str, **kwargs: Any) -> Any:
             sleep(0.30)
-            return {"models": []}
+            return response
 
-    tool = _register(account, _SlowClient()).tools["list_models"]
+    tool = _register(module, _SlowClient()).tools[tool_name]
     tool_task = asyncio.create_task(_invoke(tool))
     heartbeat = asyncio.create_task(asyncio.sleep(0.05))
     try:

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -1,19 +1,30 @@
-"""Integration test: BackendClient.account_status() against live chatgpt.com.
+"""GET-only live contracts against chatgpt.com.
 
-Skipped automatically when ~/.codex/auth.json is absent.
+Skipped by default. Opt in with ``SKIP_LIVE=0`` and a Codex login.
 """
 
 from __future__ import annotations
 
+import asyncio
+import os
 from pathlib import Path
 
 import pytest
 
 
-@pytest.mark.skipif(
+_SKIP_LIVE = os.environ.get("SKIP_LIVE", "1") == "1"
+_NEEDS_AUTH = pytest.mark.skipif(
     not (Path.home() / ".codex" / "auth.json").exists(),
-    reason="~/.codex/auth.json not present",
+    reason="requires ~/.codex/auth.json",
 )
+_LIVE_ONLY = pytest.mark.skipif(
+    _SKIP_LIVE,
+    reason="SKIP_LIVE=1 (default); set SKIP_LIVE=0 to run",
+)
+
+
+@_NEEDS_AUTH
+@_LIVE_ONLY
 def test_account_status_has_subscription() -> None:
     from gpt2agent.backend import BackendClient
 
@@ -34,3 +45,27 @@ def test_account_status_has_subscription() -> None:
 
     assert "subscription_plan" in ent, f"subscription field missing; entitlement={ent}"
     assert ent.get("subscription_plan"), "subscription_plan is empty"
+
+
+@_NEEDS_AUTH
+@_LIVE_ONLY
+def test_voice_catalog_live_contract() -> None:
+    """Exercise one registered GET without starting or fetching Voice media."""
+    from gpt2agent.backend import BackendClient
+    from gpt2agent.tools import voice
+    from tests.test_tools import FakeMCP
+
+    mcp = FakeMCP()
+    voice.register(mcp, BackendClient())
+    result = asyncio.run(mcp.tools["list_voices"]())
+
+    assert isinstance(result, list)
+    assert result
+    assert all(
+        set(item) == {"id", "name", "description", "selected", "has_preview"}
+        for item in result
+    )
+    assert all(isinstance(item["id"], str) and item["id"] for item in result)
+    assert len({item["id"] for item in result}) == len(result)
+    assert sum(item["selected"] is True for item in result) == 1
+    assert all(item["selected"] in (True, False) for item in result)

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -47,11 +47,12 @@ def test_account_status_has_subscription() -> None:
     assert ent.get("subscription_plan"), "subscription_plan is empty"
 
 
-# None = account default; the rest are real ChatGPT voice modes ("live" is the
-# latest, GPT-Live). Each is exercised as a genuine GET against the account.
+# None = account default; the rest are values accepted by the live account
+# contract on 2026-07-11. GPT-Live audio is a separate session contract; the
+# catalog endpoint rejects `voice_mode=live` with a typed HTTP 422 response.
 @_NEEDS_AUTH
 @_LIVE_ONLY
-@pytest.mark.parametrize("voice_mode", [None, "standard", "advanced", "live", "wingman"])
+@pytest.mark.parametrize("voice_mode", [None, "standard", "advanced", "wingman"])
 def test_voice_catalog_live_contract(voice_mode: str | None) -> None:
     """Exercise one registered GET without starting or fetching Voice media."""
     from gpt2agent.backend import BackendClient
@@ -74,3 +75,21 @@ def test_voice_catalog_live_contract(voice_mode: str | None) -> None:
     assert len({item["id"] for item in result}) == len(result)
     assert sum(item["selected"] is True for item in result) <= 1
     assert all(item["selected"] in (True, False, None) for item in result)
+
+
+@_NEEDS_AUTH
+@_LIVE_ONLY
+def test_voice_catalog_removed_live_alias_is_rejected() -> None:
+    """Keep the GPT-Live product name separate from the catalog enum."""
+    from gpt2agent.backend import BackendClient
+    from gpt2agent.tools import voice
+    from tests.test_tools import FakeMCP
+
+    mcp = FakeMCP()
+    voice.register(mcp, BackendClient())
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^HTTP 422 for /backend-api/settings/voices\?voice_mode=live$",
+    ):
+        asyncio.run(mcp.tools["list_voices"](voice_mode="live"))

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -47,9 +47,12 @@ def test_account_status_has_subscription() -> None:
     assert ent.get("subscription_plan"), "subscription_plan is empty"
 
 
+# None = account default; the rest are real ChatGPT voice modes ("live" is the
+# latest, GPT-Live). Each is exercised as a genuine GET against the account.
 @_NEEDS_AUTH
 @_LIVE_ONLY
-def test_voice_catalog_live_contract() -> None:
+@pytest.mark.parametrize("voice_mode", [None, "standard", "advanced", "live", "wingman"])
+def test_voice_catalog_live_contract(voice_mode: str | None) -> None:
     """Exercise one registered GET without starting or fetching Voice media."""
     from gpt2agent.backend import BackendClient
     from gpt2agent.tools import voice
@@ -57,15 +60,17 @@ def test_voice_catalog_live_contract() -> None:
 
     mcp = FakeMCP()
     voice.register(mcp, BackendClient())
-    result = asyncio.run(mcp.tools["list_voices"]())
+    kwargs = {} if voice_mode is None else {"voice_mode": voice_mode}
+    result = asyncio.run(mcp.tools["list_voices"](**kwargs))
 
+    # A mode the account cannot serve may legitimately return an empty catalog;
+    # what must always hold is the normalized schema and identity invariants.
     assert isinstance(result, list)
-    assert result
     assert all(
         set(item) == {"id", "name", "description", "selected", "has_preview"}
         for item in result
     )
     assert all(isinstance(item["id"], str) and item["id"] for item in result)
     assert len({item["id"] for item in result}) == len(result)
-    assert sum(item["selected"] is True for item in result) == 1
-    assert all(item["selected"] in (True, False) for item in result)
+    assert sum(item["selected"] is True for item in result) <= 1
+    assert all(item["selected"] in (True, False, None) for item in result)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -276,6 +276,18 @@ def test_skill_install(tmp_path: Path) -> None:
     assert ga.exists()
     assert (ga / "SKILL.md").exists()
     assert (ga / "tools-reference.md").exists()
+    skill = (ga / "SKILL.md").read_text()
+    reference = (ga / "tools-reference.md").read_text()
+    allowed = [
+        line.strip()
+        for line in skill.splitlines()
+        if line.strip().startswith("- mcp__gpt2agent__")
+    ]
+    assert len(allowed) == 26
+    assert allowed.count("- mcp__gpt2agent__list_voices") == 1
+    assert "Complete parameter reference for all 26 MCP tools" in reference
+    assert reference.count("### list_voices") == 1
+    assert "GPT-Live" in reference
 
 
 def test_skill_backup_on_overwrite(tmp_path: Path) -> None:

--- a/tests/test_none_guards.py
+++ b/tests/test_none_guards.py
@@ -1,10 +1,11 @@
 """backend.get() returns None on an empty 2xx body (backend.py get()).
 
-Every REST tool call site must survive that contract: read tools degrade to
-empty results (matching the already-guarded list_conversations/get_file_info
-sites), and the read-modify-write in custom_instructions_set must REFUSE to
-proceed — blind-overwriting with `{}` would silently clear whichever custom
-instructions field the caller did not supply.
+Established lenient REST read tools degrade to empty results (matching the
+already-guarded list_conversations/get_file_info sites). Strict private-schema
+adapters may instead fail closed with a payload-free contract error. The
+read-modify-write in custom_instructions_set must REFUSE to proceed —
+blind-overwriting with `{}` would silently clear whichever custom instructions
+field the caller did not supply.
 
 Also covers load_config: a top-level scalar key in config.toml (a user
 forgetting the [server] header) must raise a clean actionable error, not
@@ -18,7 +19,7 @@ import asyncio
 import pytest
 
 from gpt2agent.tools import account, apps, codex, conversations, gpts, images
-from gpt2agent.tools import instructions, memory, writes
+from gpt2agent.tools import instructions, memory, voice, writes
 
 from tests.test_tools import FakeClient, FakeMCP
 
@@ -92,6 +93,11 @@ def test_codex_list_tools_tolerate_none() -> None:
     mcp = _tools(codex)
     assert _run(mcp.tools["list_codex_envs"]) == []
     assert _run(mcp.tools["list_codex_tasks"]) == []
+
+
+def test_voice_catalog_fails_closed_on_none() -> None:
+    with pytest.raises(RuntimeError, match="^voice catalog contract changed$"):
+        _run(_tools(voice).tools["list_voices"])
 
 
 # ── write tool: None current state → refuse, do NOT clobber ─────────────────

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 """Unit tests for the MCP tool layer — no network.
 
-Round-2 coverage: the 25-tool handler surface (the product's actual value) had
+Round-2 coverage: the 26-tool handler surface (the product's actual value) had
 zero direct unit tests. These exercise every `tools/*.py` handler through its
 real `register(mcp, client, conv=None)` signature using a recording FakeMCP +
 FakeClient, and the server.py SSE closures via FastMCP's tool manager with a
@@ -238,6 +238,30 @@ def test_list_voices_empty_catalog_is_not_contract_drift() -> None:
         "voices": [],
     }})
     assert _run(_reg(voice, client).tools["list_voices"]) == []
+
+
+def test_list_voices_accepts_catalog_at_documented_bound() -> None:
+    items = [_voice_item(f"voice-{index}") for index in range(128)]
+    client = FakeClient(routes={"/backend-api/settings/voices": {
+        "selected": "voice-0",
+        "voices": items,
+    }})
+
+    out = _run(_reg(voice, client).tools["list_voices"])
+
+    assert len(out) == 128
+    assert out[0]["selected"] is True
+
+
+def test_list_voices_rejects_catalog_above_documented_bound() -> None:
+    items = [_voice_item(f"voice-{index}") for index in range(129)]
+    client = FakeClient(routes={"/backend-api/settings/voices": {
+        "selected": "voice-0",
+        "voices": items,
+    }})
+
+    with pytest.raises(RuntimeError, match="^voice catalog contract changed$"):
+        _run(_reg(voice, client).tools["list_voices"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -274,12 +274,11 @@ def test_list_voices_default_sends_no_voice_mode() -> None:
     assert client.get_calls == [(route, route)]
 
 
-@pytest.mark.parametrize("mode", ["standard", "advanced", "live", "wingman"])
+@pytest.mark.parametrize("mode", ["standard", "advanced", "wingman"])
 def test_list_voices_passes_observed_voice_mode(mode: str) -> None:
-    # Real ChatGPT voice modes: `standard`, `advanced`, `live` (the latest,
-    # GPT-Live), and `wingman` (observed on the live /backend-api/settings/voices
-    # route, 2026-07-11). The bare route (target_path) is unchanged; the mode
-    # rides the query string.
+    # Values accepted by the live /backend-api/settings/voices route on
+    # 2026-07-11. The bare route (target_path) is unchanged; the mode rides the
+    # query string. GPT-Live audio uses a separate session contract.
     route = "/backend-api/settings/voices"
     client = FakeClient(routes={route: {
         "selected": "cove",
@@ -296,6 +295,16 @@ def test_list_voices_passes_observed_voice_mode(mode: str) -> None:
         "selected": True,
         "has_preview": True,
     }]
+
+
+def test_list_voices_forwards_a_bounded_future_mode_without_hard_coding() -> None:
+    route = "/backend-api/settings/voices"
+    client = FakeClient(routes={route: {"selected": None, "voices": []}})
+
+    out = _run(_reg(voice, client).tools["list_voices"], voice_mode="future_mode")
+
+    assert out == []
+    assert client.get_calls == [(f"{route}?voice_mode=future_mode", route)]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -249,7 +249,12 @@ def test_list_voices_empty_catalog_is_not_contract_drift() -> None:
         {"voices": {}},
         {"voices": [None]},
         {"voices": [{"voice": "", "name": "Name", "description": "Desc"}]},
+        {"voices": [{"voice": "   ", "name": "Name", "description": "Desc"}]},
+        {"voices": [{"voice": "bad\n", "name": "Name", "description": "Desc"}]},
+        {"voices": [{"voice": "v" * 129, "name": "Name", "description": "Desc"}]},
         {"voices": [{"voice": "v", "name": 3, "description": "Desc"}]},
+        {"voices": [{"voice": "v", "name": "n" * 257, "description": "Desc"}]},
+        {"voices": [{"voice": "v", "name": "Name", "description": "d" * 2_001}]},
         {"voices": [{"voice": "v", "name": "Name", "description": "Desc",
                       "preview_url": 3}]},
         {"voices": [_voice_item("same"), _voice_item("same")]},
@@ -610,6 +615,57 @@ def _build_with_conv(monkeypatch, conv):
     mcp = build_server({"server": {"host": "127.0.0.1", "port": 9000},
                         "models": {"chat": "gpt-5-3", "agent": "agent-mode"}})
     return mcp._tool_manager._tools
+
+
+def test_server_registers_exact_26_tool_surface_and_voice_once(monkeypatch) -> None:
+    calls = 0
+    original_register = voice.register
+
+    def counted_register(mcp, client):
+        nonlocal calls
+        calls += 1
+        return original_register(mcp, client)
+
+    monkeypatch.setattr(voice, "register", counted_register)
+    tools = _build_with_conv(monkeypatch, _RecordConv())
+
+    assert set(tools) == {
+        "account_status",
+        "agent",
+        "canvas_execute",
+        "chat",
+        "code_interpreter",
+        "codex_task_create",
+        "custom_instructions_get",
+        "custom_instructions_set",
+        "deep_research",
+        "deep_research_heavy",
+        "generate_image",
+        "get_conversation",
+        "get_file_download_url",
+        "get_file_info",
+        "gpt_chat",
+        "list_apps",
+        "list_codex_envs",
+        "list_codex_tasks",
+        "list_conversations",
+        "list_custom_gpts",
+        "list_models",
+        "list_tasks",
+        "list_voices",
+        "memory_create_via_chat",
+        "memory_list",
+        "memory_search",
+    }
+    assert len(tools) == 26
+    assert calls == 1
+
+    annotations = tools["list_voices"].annotations
+    assert annotations is not None
+    assert annotations.readOnlyHint is True
+    assert annotations.destructiveHint is False
+    assert annotations.idempotentHint is True
+    assert annotations.openWorldHint is True
 
 
 def test_agent_always_temporary_false(monkeypatch) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from gpt2agent.tools import account, apps, codex, conversations, gpts, images
-from gpt2agent.tools import instructions, memory, tools_features, writes
+from gpt2agent.tools import instructions, memory, tools_features, voice, writes
 from gpt2agent.tools._redact import redact
 
 
@@ -25,10 +25,12 @@ class FakeMCP:
 
     def __init__(self) -> None:
         self.tools: dict[str, Any] = {}
+        self.tool_options: dict[str, dict[str, Any]] = {}
 
     def tool(self, *a: Any, **k: Any):
         def deco(fn):
             self.tools[fn.__name__] = fn
+            self.tool_options[fn.__name__] = dict(k)
             return fn
         return deco
 
@@ -41,9 +43,11 @@ class FakeClient:
         self.posts = posts or {}
         self.posted: list[tuple[str, Any]] = []
         self.gets: list[str] = []
+        self.get_calls: list[tuple[str, str | None]] = []
 
     def get(self, path: str, target_path: str | None = None, **k: Any) -> Any:
         self.gets.append(path)
+        self.get_calls.append((path, target_path))
         for pat, val in self.routes.items():
             if path == pat or path.startswith(pat):
                 return val
@@ -136,6 +140,150 @@ def test_list_models_exposes_slug() -> None:
         {"slug": "gpt-5-5-pro", "title": "Pro", "max_tokens": 410000}]}})
     out = _run(_reg(account, client).tools["list_models"])
     assert out[0]["slug"] == "gpt-5-5-pro"
+
+
+# --------------------------------------------------------------------------- #
+#  tools/voice
+# --------------------------------------------------------------------------- #
+
+
+def _voice_item(
+    voice_id: str = "fathom",
+    *,
+    name: str = "Arbor",
+    description: str = "Easygoing and versatile",
+    preview_url: str | None = "https://persistent.example.invalid/arbor.m4a",
+) -> dict[str, Any]:
+    return {
+        "voice": voice_id,
+        "name": name,
+        "description": description,
+        "preview_url": preview_url,
+        "bloop_color": "#abcdef",
+        "gain_db": None,
+        "future_private_field": "must-not-escape",
+    }
+
+
+def test_list_voices_normalizes_live_shape_and_preserves_backend_ids() -> None:
+    route = "/backend-api/settings/voices"
+    client = FakeClient(routes={route: {
+        "selected": "fathom",
+        "voices": [
+            _voice_item(),
+            _voice_item(
+                "glimmer",
+                name="Sol",
+                description="Savvy and relaxed",
+                preview_url=None,
+            ),
+        ],
+    }})
+
+    mcp = _reg(voice, client)
+    out = _run(mcp.tools["list_voices"])
+
+    assert out == [
+        {
+            "id": "fathom",
+            "name": "Arbor",
+            "description": "Easygoing and versatile",
+            "selected": True,
+            "has_preview": True,
+        },
+        {
+            "id": "glimmer",
+            "name": "Sol",
+            "description": "Savvy and relaxed",
+            "selected": False,
+            "has_preview": False,
+        },
+    ]
+    assert client.get_calls == [(route, route)]
+    rendered = repr(out)
+    assert "persistent.example.invalid" not in rendered
+    assert "#abcdef" not in rendered
+    assert "gain_db" not in rendered
+    assert "future_private_field" not in rendered
+    # These IDs deliberately differ from their display names. The adapter must
+    # never derive an identifier by lower-casing the name.
+    assert [item["id"] for item in out] == ["fathom", "glimmer"]
+
+
+def test_list_voices_redacts_display_text() -> None:
+    secret = "sk-ABCDEFGHIJKLMNOPQRST"
+    client = FakeClient(routes={"/backend-api/settings/voices": {
+        "selected": "safe-id",
+        "voices": [_voice_item(
+            "safe-id",
+            name="Contact voice@example.com",
+            description=f"Call +1 (415) 555-1212 with {secret}",
+        )],
+    }})
+
+    out = _run(_reg(voice, client).tools["list_voices"])
+
+    rendered = repr(out)
+    assert "voice@example.com" not in rendered
+    assert "415" not in rendered
+    assert secret not in rendered
+    assert "<EMAIL>" in out[0]["name"]
+    assert "<PHONE>" in out[0]["description"]
+    assert "<APIKEY>" in out[0]["description"]
+
+
+def test_list_voices_empty_catalog_is_not_contract_drift() -> None:
+    client = FakeClient(routes={"/backend-api/settings/voices": {
+        "selected": None,
+        "voices": [],
+    }})
+    assert _run(_reg(voice, client).tools["list_voices"]) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {},
+        {"voices": {}},
+        {"voices": [None]},
+        {"voices": [{"voice": "", "name": "Name", "description": "Desc"}]},
+        {"voices": [{"voice": "v", "name": 3, "description": "Desc"}]},
+        {"voices": [{"voice": "v", "name": "Name", "description": "Desc",
+                      "preview_url": 3}]},
+        {"voices": [_voice_item("same"), _voice_item("same")]},
+    ],
+)
+def test_list_voices_fails_closed_on_contract_drift(payload: Any) -> None:
+    client = FakeClient(routes={"/backend-api/settings/voices": payload})
+
+    with pytest.raises(RuntimeError, match="^voice catalog contract changed$") as exc:
+        _run(_reg(voice, client).tools["list_voices"])
+
+    assert repr(payload) not in str(exc.value)
+
+
+@pytest.mark.parametrize("selected", [None, 3, "missing-id"])
+def test_list_voices_reports_unknown_selection_as_none(selected: Any) -> None:
+    client = FakeClient(routes={"/backend-api/settings/voices": {
+        "selected": selected,
+        "voices": [_voice_item("voice-id")],
+    }})
+
+    out = _run(_reg(voice, client).tools["list_voices"])
+
+    assert out[0]["selected"] is None
+
+
+def test_list_voices_has_read_only_mcp_annotations() -> None:
+    mcp = _reg(voice, FakeClient())
+    annotations = mcp.tool_options["list_voices"]["annotations"]
+
+    assert annotations.readOnlyHint is True
+    assert annotations.destructiveHint is False
+    assert annotations.idempotentHint is True
+    assert annotations.openWorldHint is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -264,6 +264,60 @@ def test_list_voices_rejects_catalog_above_documented_bound() -> None:
         _run(_reg(voice, client).tools["list_voices"])
 
 
+def test_list_voices_default_sends_no_voice_mode() -> None:
+    route = "/backend-api/settings/voices"
+    client = FakeClient(routes={route: {"selected": None, "voices": [_voice_item()]}})
+
+    _run(_reg(voice, client).tools["list_voices"])
+
+    # Default preserves the bare route — no query string appended.
+    assert client.get_calls == [(route, route)]
+
+
+@pytest.mark.parametrize("mode", ["standard", "advanced", "live", "wingman"])
+def test_list_voices_passes_observed_voice_mode(mode: str) -> None:
+    # Real ChatGPT voice modes: `standard`, `advanced`, `live` (the latest,
+    # GPT-Live), and `wingman` (observed on the live /backend-api/settings/voices
+    # route, 2026-07-11). The bare route (target_path) is unchanged; the mode
+    # rides the query string.
+    route = "/backend-api/settings/voices"
+    client = FakeClient(routes={route: {
+        "selected": "cove",
+        "voices": [_voice_item("cove", name="Breeze", description="Animated and earnest")],
+    }})
+
+    out = _run(_reg(voice, client).tools["list_voices"], voice_mode=mode)
+
+    assert client.get_calls == [(f"{route}?voice_mode={mode}", route)]
+    assert out == [{
+        "id": "cove",
+        "name": "Breeze",
+        "description": "Animated and earnest",
+        "selected": True,
+        "has_preview": True,
+    }]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", " ", "Advanced", "a b", "../secret", "x?y=z", "voice_mode=1", "m" * 33],
+)
+def test_list_voices_rejects_malformed_voice_mode(bad: str) -> None:
+    route = "/backend-api/settings/voices"
+    client = FakeClient(routes={route: {"selected": None, "voices": [_voice_item()]}})
+
+    with pytest.raises(ValueError) as exc:
+        _run(_reg(voice, client).tools["list_voices"], voice_mode=bad)
+
+    message = str(exc.value)
+    assert "voice_mode" in message
+    # Payload-free: a meaningful rejected value is never echoed back into the
+    # error (whitespace-only inputs trivially appear in ordinary spacing).
+    assert not bad.strip() or bad not in message
+    # A malformed mode must be rejected before any backend call.
+    assert client.get_calls == []
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
## v0.0.13 — ChatGPT Voice catalog discovery

Adds `list_voices`, a read-only MCP tool exposing the signed-in account's Voice catalog from the private `GET /backend-api/settings/voices` route. Brings the server to **26 MCP tools**.

### What's in it
- `list_voices` — bounded, stable per-voice shape (`id`, `name`, `description`, `selected`, `has_preview`); backend voice IDs preserved verbatim, display text redacted.
- `list_voices(voice_mode=...)` — optional mode-specific catalog (`standard` / `advanced` / `wingman` accepted by the live contract on 2026-07-11); charset-validated before any request. `voice_mode=live` is rejected by the catalog route (HTTP 422) — GPT-Live is a separate session contract, out of scope here.
- Clean separation of the **catalog** surface (this release) from the **live voice** lane (v0.0.14, still an investigation).
- `docs/roadmap.md` — version lanes, GPT-Live boundary, language policy (Python core + optional TS sidecar), release gates.

### Scope guard
Catalog **discovery only**. Does not start a Voice session, fetch preview media, capture a microphone, synthesize speech, stream GPT-Live audio, or extract transcripts. Malformed responses fail closed (`voice catalog contract changed`) rather than pretending the catalog is empty.

### Verification
- `pytest`: **360 passed, 15 skipped** (skips are `SKIP_LIVE`-gated live/network tests; no credentials configured).
- `ruff check gpt2agent tests scripts`: clean (mirrors CI).
- `scripts/verify_release.py`: `release metadata verified: 0.0.13`.

### Merge ordering
Per the roadmap, this release is **held until v0.0.12 (#30) lands**. This branch is based on current `main` and is independent of #30's 47 commits — after #30 merges, `main` should be merged in before release so 0.0.12's changes are carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Voice catalog tool for viewing available voices and selection status.
  * Added optional voice mode filtering with validation and clear handling of unsupported modes.
  * Expanded the available MCP toolset to 26 tools.

* **Documentation**
  * Updated guides, references, roadmap, skill instructions, and FAQ with Voice catalog coverage and GPT-Live limitations.
  * Added release notes for version 0.0.13.

* **Chores**
  * Updated release metadata and version identifiers to 0.0.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->