### PR TITLE
fix(cli): exit cleanly when no ChatGPT token is present

### DIFF
--- a/gpt2agent/backend.py
+++ b/gpt2agent/backend.py
@@ -19,6 +19,17 @@ _CLIENT_VERSION = "prod-be885abbfcfe7b1f511e88b3003d9ee44757fbad"
 _CLIENT_BUILD = "5955942"
 
 
+class TokenNotFoundError(RuntimeError):
+    """No ChatGPT token could be located from any known source.
+
+    A ``RuntimeError`` subclass so existing ``except RuntimeError`` handlers and
+    ``pytest.raises(RuntimeError, ...)`` assertions keep working, while callers
+    that want to distinguish "not logged in yet" (an expected first-run state)
+    from a genuine backend failure can catch this specific type — e.g. the CLI
+    turns it into a clean one-line message instead of a traceback.
+    """
+
+
 def _load_token_with_source() -> tuple[str, Path | None]:
     """Load the ChatGPT bearer token and return its source file for mtime tracking.
 
@@ -69,11 +80,11 @@ def _load_token_with_source() -> tuple[str, Path | None]:
     # Nothing worked — surface the most informative error we have.
     if codex_err or wizard_err:
         details = "; ".join(e for e in (codex_err, wizard_err) if e)
-        raise RuntimeError(
+        raise TokenNotFoundError(
             f"No ChatGPT token found — run `codex login` or `gpt2agent setup` "
             f"({details})"
         )
-    raise RuntimeError(
+    raise TokenNotFoundError(
         "No ChatGPT token found — run `codex login` or `gpt2agent setup` "
         f"(checked {codex_path} and {wizard_path})"
     )

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -406,7 +406,16 @@ def main() -> None:
     if getattr(args, "host", None):
         cfg["server"]["host"] = args.host
 
-    mcp = build_server(cfg)
+    from gpt2agent.backend import TokenNotFoundError
+
+    try:
+        mcp = build_server(cfg)
+    except TokenNotFoundError as exc:
+        # Common first-run state: installed + registered with the MCP client, but
+        # `codex login` / `gpt2agent setup` not run yet, so no token exists. Exit
+        # with a clean, actionable one-liner (like the HTTP-bind refusal below)
+        # instead of dumping a backend.py traceback into the client's MCP logs.
+        raise SystemExit(str(exc)) from None
     tools = list(cfg["models"].keys())
     stdio = getattr(args, "stdio", False)
 

--- a/tests/test_audit_2026_07_13_startup.py
+++ b/tests/test_audit_2026_07_13_startup.py
@@ -1,0 +1,40 @@
+"""Regression tests: a missing ChatGPT token must fail the server start with a
+clean, actionable message — not a raw backend traceback.
+
+The most common first-run state is "installed + registered with the MCP client,
+but `codex login` / `gpt2agent setup` not run yet". Before this fix, spawning
+`gpt2agent run --stdio` in that state dumped a backend.py traceback into the
+client's MCP logs. It now exits cleanly like the HTTP-bind refusal does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_missing_token_raises_dedicated_subclass(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+
+    from gpt2agent import backend as be
+
+    # Subclass of RuntimeError so existing `except RuntimeError` handlers and
+    # `pytest.raises(RuntimeError)` assertions keep working.
+    assert issubclass(be.TokenNotFoundError, RuntimeError)
+    with pytest.raises(be.TokenNotFoundError, match="No ChatGPT token found"):
+        be._load_token_with_source()
+
+
+def test_run_without_token_exits_cleanly_no_traceback(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setattr("sys.argv", ["gpt2agent", "run", "--stdio"])
+
+    from gpt2agent import server
+
+    with pytest.raises(SystemExit) as exc_info:
+        server.main()
+
+    # SystemExit carries the actionable message as its code (a string), so the
+    # interpreter prints it to stderr and exits 1 — no traceback.
+    assert "No ChatGPT token found" in str(exc_info.value.code)


### PR DESCRIPTION
## Problem

The most common first-run state for a new user is **installed + registered with the MCP client, but `codex login` / `gpt2agent setup` not run yet** — so no token exists. The `install` flow does *not* require a token (it prints "No auth.json yet, run codex login"), so this state is normal after a one-line install + client restart.

In that state, the MCP client spawns `gpt2agent run --stdio`, which raised a bare `RuntimeError` out of `BackendClient()` inside `build_server()` and dumped a **`backend.py` traceback** into the client's MCP server logs:

```
Traceback (most recent call last):
  File ".../bin/gpt2agent", line 6, in <module>
    sys.exit(main())
  ...
  File ".../gpt2agent/backend.py", line 76, in _load_token_with_source
    raise RuntimeError(...)
RuntimeError: No ChatGPT token found — run `codex login` or `gpt2agent setup` (...)
```

The unauthenticated-HTTP-bind refusal path right below it already exits cleanly via `SystemExit`; the far more common missing-token path did not. This is a launch-quality inconsistency.

## Fix

- Introduce `TokenNotFoundError(RuntimeError)` in `backend.py` and raise it (instead of bare `RuntimeError`) from `_load_token_with_source()`. It's a `RuntimeError` **subclass**, so every existing `except RuntimeError` handler and `pytest.raises(RuntimeError, ...)` assertion keeps working unchanged.
- Catch it in `server.main()` and exit `1` with the actionable one-line message via `SystemExit` — matching the HTTP-bind refusal path — instead of a traceback.

## Before / after (real output)

```
# before:  HOME=<empty> gpt2agent run --stdio
Traceback (most recent call last): ... RuntimeError: No ChatGPT token found ...

# after:   HOME=<empty> gpt2agent run --stdio
No ChatGPT token found — run `codex login` or `gpt2agent setup` (checked .../.codex/auth.json and .../.gpt2agent/token.json)
$ echo $?
1
```

Server still boots normally when a token is present (verified: exit 0 on stdin close).

## Tests

Adds `tests/test_audit_2026_07_13_startup.py`:
- `TokenNotFoundError` is a `RuntimeError` subclass and is raised on missing token.
- `main()` with `run --stdio` and no token raises `SystemExit` carrying the actionable message (no traceback).

Full suite: **325 passed, 9 skipped**; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)