### PR TITLE
fix(sse): guard SSE message parsing against present-but-null fields (deep_research P1)

### DIFF
--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -669,7 +669,7 @@ class ConversationClient:
                 if not isinstance(msg, dict):
                     continue
                 _track_message_lifecycle(msg)
-                if msg.get("author", {}).get("role") != "assistant":
+                if (msg.get("author") or {}).get("role") != "assistant":
                     continue
                 content = msg.get("content") or {}
                 ct = content.get("content_type")
@@ -867,7 +867,7 @@ class ConversationClient:
                 msg = obj.get("message", {})
                 if not isinstance(msg, dict):
                     continue
-                role = msg.get("author", {}).get("role", "")
+                role = (msg.get("author") or {}).get("role", "")
                 ct = (msg.get("content") or {}).get("content_type", "")
                 parts = (msg.get("content") or {}).get("parts", [])
 
@@ -1047,7 +1047,7 @@ class ConversationClient:
                 msg = obj.get("message", {})
                 if not isinstance(msg, dict):
                     continue
-                role = msg.get("author", {}).get("role", "")
+                role = (msg.get("author") or {}).get("role", "")
                 recipient = msg.get("recipient", "all")
                 content = msg.get("content") or {}
                 ct = content.get("content_type", "")
@@ -1240,11 +1240,11 @@ class ConversationClient:
                         if not isinstance(msg, dict):
                             continue
 
-                        role = msg.get("author", {}).get("role", "")
-                        content = msg.get("content", {})
+                        role = (msg.get("author") or {}).get("role", "")
+                        content = msg.get("content") or {}
                         ct = content.get("content_type", "")
                         status = msg.get("status", "")
-                        meta = msg.get("metadata", {})
+                        meta = msg.get("metadata") or {}
                         recipient = msg.get("recipient")
 
                         # Capture latest assistant message id so the next turn

--- a/tests/test_audit_2026_07_13_sse_null_guards.py
+++ b/tests/test_audit_2026_07_13_sse_null_guards.py
@@ -1,0 +1,118 @@
+"""Regression: SSE message parsing must tolerate present-but-null fields.
+
+The backend can send a frame whose ``author`` / ``content`` / ``metadata`` key is
+present with an explicit JSON ``null`` (system/tether/echo frames, moderation
+placeholders). ``dict.get(key, {})`` returns ``None`` (not ``{}``) for such a
+frame, so a following ``.get(...)`` raised ``AttributeError`` and aborted the
+whole stream. For ``deep_research`` this killed a multi-minute, quota-consuming
+run on a single unrelated frame, because ``content`` is dereferenced for every
+frame before any role filter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from gpt2agent import sse as sse_mod
+
+
+class _FrameResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _Backend:
+    class _Session:
+        headers: dict[str, str] = {"User-Agent": "test-agent"}
+
+    _session = _Session()
+
+    def _reload_token_if_stale(self) -> None:
+        pass
+
+    def post(self, *_: Any, **__: Any) -> dict:
+        return {"limits_progress": [{"feature_name": "deep_research", "remaining": 100}]}
+
+
+class _SentinelStub:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def get_tokens(self) -> dict[str, str]:
+        return {"chat-requirements": "stub", "proof": "", "turnstile": ""}
+
+
+def _patch_frames(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    class _FrameSession:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FrameSession":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def post(self, *_: Any, **__: Any) -> _FrameResponse:
+            return _FrameResponse(lines)
+
+    monkeypatch.setattr(sse_mod, "AsyncSession", _FrameSession)
+    monkeypatch.setattr(sse_mod, "SentinelGate", _SentinelStub)
+
+
+def _frame(message: dict) -> str:
+    return "data: " + json.dumps({"message": message})
+
+
+_REAL_REPORT = _frame(
+    {
+        "id": "m-report",
+        "author": {"role": "assistant"},
+        "recipient": "all",
+        "content": {"content_type": "text", "parts": ["THE REAL REPORT"]},
+        "status": "finished_successfully",
+        "metadata": {},
+    }
+)
+
+
+def _run_deep_research(monkeypatch, poison_frames: list[str]) -> list[dict]:
+    _patch_frames(monkeypatch, [*poison_frames, _REAL_REPORT, "data: [DONE]"])
+    client = sse_mod.ConversationClient(_Backend())  # type: ignore[arg-type]
+
+    async def _collect() -> list[dict]:
+        return [ev async for ev in client.deep_research("q")]
+
+    return asyncio.run(_collect())
+
+
+def test_deep_research_survives_null_content_frame(monkeypatch) -> None:
+    poison = _frame({"id": "m0", "author": {"role": "system"}, "content": None,
+                     "status": "finished"})
+    events = _run_deep_research(monkeypatch, [poison])
+    dones = [e for e in events if e.get("type") == "done"]
+    assert dones and dones[-1]["text"] == "THE REAL REPORT"
+
+
+def test_deep_research_survives_null_author_and_metadata(monkeypatch) -> None:
+    null_author = _frame({"id": "m0", "author": None,
+                          "content": {"content_type": "text", "parts": ["x"]},
+                          "status": "in_progress"})
+    null_metadata = _frame({"id": "m1", "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "content": {"content_type": "text", "parts": ["y"]},
+                            "status": "in_progress", "metadata": None})
+    events = _run_deep_research(monkeypatch, [null_author, null_metadata])
+    dones = [e for e in events if e.get("type") == "done"]
+    assert dones and dones[-1]["text"] == "THE REAL REPORT"


### PR DESCRIPTION
## Problem (P1 for Deep Research)

The chatgpt.com backend can send an SSE frame whose `author`, `content`, or `metadata` key is **present with an explicit JSON `null`** (system/tether/echo frames, moderation placeholders). `dict.get(key, {})` returns `None` — not `{}` — for such a frame, so the following `.get(...)` raised `AttributeError` and aborted the entire stream.

For `deep_research()` this is a **launch-quality P1**: `content` is dereferenced for *every* frame (`content.get("content_type")` at `sse.py:1245`) **before any role filter**, so a single unrelated `content:null` frame kills a multi-minute, DR-quota-consuming Deep Research run — Deep Research being a headline feature of this tool.

### Reproduced end-to-end (real generator, not a unit stub)

```
# before: feed one {"message":{"content":null,...}} frame, then the real report
CRASH: AttributeError: 'NoneType' object has no attribute 'get'

# after
NO CRASH — events: 1 | done texts: ['THE REAL REPORT']
```

The same null-crash class existed on the `author` field in three sibling parse paths — `stream()` Format-B (`sse.py:672`), `image_gen()` (`:870`), `tool_call()` (`:1050`) — where an `author:null` frame would abort the stream before `[DONE]`.

## Fix

Change the unsafe `msg.get(key, {})` to `(msg.get(key) or {})` at all six sites (author×4, content, metadata). This matches the null-safe pattern **this same file already uses** at lines 37/39/191–193/605/674/775/1052/1510/1798/1803, so it's a consistency fix, not a new convention.

```diff
- role = msg.get("author", {}).get("role", "")
- content = msg.get("content", {})
+ role = (msg.get("author") or {}).get("role", "")
+ content = msg.get("content") or {}
- meta = msg.get("metadata", {})
+ meta = msg.get("metadata") or {}
```

## Tests

Adds `tests/test_audit_2026_07_13_sse_null_guards.py` — drives the **real** `deep_research` generator with `content:null`, `author:null`, and `metadata:null` frames and asserts the run completes and returns the real report instead of crashing. Both would fail before this fix.

Full suite: **325 passed, 9 skipped**; `ruff check` clean.

## Not addressed here (separate concerns, noted for maintainers)

- `deep_research()` can emit more than one clean `type:"done"` when an intermediate assistant message finishes before the report; both in-repo consumers already work around this (`server.py` last-wins, the DR skill longest-wins). Pre-existing, documented, non-crashing — left out to keep this PR to the crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)