### PR TITLE
feat: add Grok Build account surface for v0.0.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "gpt2agent",
       "source": "./",
-      "description": "ChatGPT Plus/Pro account as 32 MCP tools + the deep-research and gpt2agent skills. Requires `pipx install gpt2agent`.",
+      "description": "ChatGPT tools plus Grok Build tools with the deep-research and gpt2agent skills. Requires `pipx install gpt2agent`.",
       "author": { "name": "robotlearning123" },
       "license": "MIT",
       "keywords": ["mcp", "chatgpt", "openai", "deep-research"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "gpt2agent",
   "displayName": "gpt2agent",
   "version": "0.0.12",
-  "description": "Your ChatGPT Plus/Pro account as 32 MCP tools and 2 static resources — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
+  "description": "ChatGPT tools plus Grok Build tools and 2 static resources — each provider keeps independent auth. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",
     "url": "https://github.com/robotlearning123"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Codex, Cursor, Windsurf, Zed, and any MCP client.
 
 ## What it does
 
-gpt2agent exposes **32 MCP tools and 2 static MCP resources** backed by ChatGPT's
-private account surface. No proxy process. No separate account. No platform API
-key. Your `codex login`, your token, your quota.
+gpt2agent exposes **ChatGPT tools plus Grok Build tools and 2 static MCP
+resources**. The ChatGPT tools use ChatGPT's private account surface; the Grok
+Build tools use the official Grok Build CLI subscription/OAuth lane. The two
+accounts and credentials stay independent, with no cross-provider fallback.
 
 If you already have the [`codex`](https://github.com/openai/codex) CLI logged in,
 setup is **zero extra steps** — gpt2agent reuses `$CODEX_HOME/auth.json` (or
@@ -125,7 +126,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 
 ---
 
-## Tools (32)
+## Tools
 
 ### Chat & reasoning
 
@@ -189,6 +190,20 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 | `list_codex_tasks` | Recent Codex tasks + status |
 | `codex_task_create` | Kick off a new Codex task (resolves env from `repo_label`) |
 
+### Grok Build (official CLI lane)
+
+| Tool | What it does |
+|---|---|
+| `grok_build_agent` | Run one bounded repository-coding session. It defaults to `mode="plan"`; `mode="apply"` is an explicit source-changing choice. |
+| `grok_build_models` | Read the authenticated Grok Build account model catalog. |
+| `grok_build_status` | Read secret-free CLI installation, version, authentication, and catalog status. |
+
+Configure at least one explicit `[grok_build].roots` entry first. `roots = []`
+fails closed, and status/model probes also require the MCP server's current
+working directory to be within a configured root. The official CLI owns its
+session history; gpt2agent returns only a sanitized session ID and does not copy
+transcripts or expose resume/deletion tools.
+
 ---
 
 ## Architecture
@@ -208,10 +223,18 @@ $CODEX_HOME/auth.json (default ~/.codex/auth.json) ← auto-refreshed by Codex
    curl_cffi  →  chatgpt.com /backend-api/{conversation,f/conversation,me,
                                           models, memories, codex, gizmos, ...}
         |
-   32 MCP tools + 2 static resources
+   all registered ChatGPT tools + 2 static resources
         (chat, agent, DR ×2, GPT chat, image gen, code interpreter,
          canvas, memory/instructions/codex, Apps, Plugins, Work,
          automations, Sites, capability truth, release evidence)
+```
+
+```text
+Configured repository root
+        |
+   gpt2agent (stdio MCP server; bounded child process)
+        |
+   official Grok Build CLI (subscription/OAuth; CLI-owned session history)
 ```
 
 ---
@@ -230,7 +253,32 @@ port = 9000          # retained for compatibility; stdio does not bind it
 chat     = "gpt-5-3"        # default for chat tool
 agent    = "agent-mode"     # default for agent tool
 heavy_dr = "gpt-5-5-pro"    # override slug for deep_research_heavy
+
+[grok_build]
+command = "grok"
+# home = "~/.grok"
+# auth_path = "~/.grok/auth.json"
+roots = []                   # fail-closed until an explicit root is added
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20
 ```
+
+Run the MCP server from a current working directory inside a configured root
+before calling `grok_build_status` or `grok_build_models`. `grok_build_agent`
+defaults to `mode="plan"`, which uses the CLI's plan/read-only sandbox. The
+explicit `mode="apply"` path uses the CLI's strict sandbox and bypass-permissions
+mode; the MCP tool remains annotated destructive on every invocation because
+annotations cannot vary by argument. See xAI's [enterprise/authentication
+guidance](https://docs.x.ai/build/enterprise), [CLI
+reference](https://docs.x.ai/build/cli/reference), [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands).
+
+gpt2agent removes `XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` from the CLI child
+environment. Authentication therefore stays on the official CLI subscription
+lane. Optional `home` and `auth_path` map to explicit `GROK_HOME` and
+`GROK_AUTH_PATH` values; never paste either credential into a prompt or log.
 
 Ordinary REST/JSON account requests share a process-wide limit of four in-flight
 calls. `GPT2AGENT_MAX_IN_FLIGHT` may be set to an integer from 1 through 8.
@@ -241,7 +289,7 @@ should run serially.
 
 ### MCP contract
 
-All 32 tools declare the four standard MCP tool annotations (`readOnlyHint`,
+All registered tools declare the four standard MCP tool annotations (`readOnlyHint`,
 `destructiveHint`, `idempotentHint`, and `openWorldHint`). These are client hints,
 not an authorization boundary. The package stays on the stable MCP Python v1
 line with `mcp>=1.26,<2` and tests the minimum and latest resolvable v1 versions.
@@ -274,6 +322,9 @@ Plugin bundles distribution.
   established adapter. Version 0.0.12 exposes no Voice tool, audio, microphone,
   WebRTC session, or OpenAI API fallback. A bounded read-only voice catalog is
   planned for 0.0.13; later AgentRTC work is a separate transport project.
+- **Grok website chat is not exposed by this documented surface.** This release
+  documents only the three implemented official-CLI Build tools. It does not
+  fall back from ChatGPT auth to Grok Build OAuth or to a website session.
 - **GPT-Live is not a supported MCP audio capability.** Current official
   [Voice guidance](https://help.openai.com/en/articles/20001274) describes Live
   as a separate human feature and says it does not initially support connected
@@ -320,6 +371,11 @@ has real consequences; please understand them before pointing it at your account
   to `chatgpt.com`.
   gpt2agent never transmits it anywhere else. Token/secret values are redacted
   from error messages and logs (best-effort).
+- **Grok Build uses a separate official CLI login.** gpt2agent removes ambient
+  xAI API-key variables from the child, constrains execution to configured
+  roots, bounds time/output, and treats apply mode as destructive. Empty roots
+  disable every Build action and probe. ChatGPT credentials are never used as a
+  Grok fallback.
 - **Keep the account transport in its dedicated MCP child process.** It ignores
   ambient proxy and CA-bundle variables, uses the directly declared `certifi`
   trust bundle, and refuses account I/O while `SSLKEYLOGFILE` is set. Libcurl

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,14 @@ not bugs:
   commitment. Safe publication also requires independent live tag-creation and
   protected-environment approval controls, with self-review and administrator
   bypass disabled; without them, do not tag or publish.
+- **Grok Build is a separate official CLI boundary.** It uses the CLI's own
+  subscription/OAuth login and never falls back to ChatGPT authentication.
+  gpt2agent removes `XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` from the child
+  environment, fails closed while `[grok_build].roots` is empty, constrains the
+  working directory to configured roots, and bounds execution time and output.
+  Plan mode is read-only; apply mode is an explicit destructive choice. The CLI
+  retains its own session history, while gpt2agent returns only a sanitized
+  session ID and does not copy transcripts.
 
 In-scope reports we want to hear about: token/secret leakage in logs or errors,
 ways to expose a network transport or cross the stdio process boundary, injection that makes a

--- a/config.example.toml
+++ b/config.example.toml
@@ -16,3 +16,14 @@ chat = "gpt-5-3"
 
 # Override the model for `deep_research_heavy` (default: gpt-5-5-pro)
 # heavy_dr = "gpt-5-5-pro"
+
+# Official Grok Build CLI subscription/OAuth lane. Empty roots fail closed:
+# configure at least one explicit repository root before calling Build tools.
+[grok_build]
+command = "grok"
+# home = "~/.grok"
+# auth_path = "~/.grok/auth.json"
+roots = []
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ User-facing documentation. (Project/contributor internals live in
 - **[Quickstart](./quickstart.md)** — prereqs → one-line install → verify → first call.
 - **[Client setup](./clients.md)** — per-host config (Claude Code, Codex, Cursor,
   Windsurf, Claude Desktop, Zed, VS Code, Cline, generic stdio).
-- **[Configuration](./configuration.md)** — config file paths, `[server]`/`[models]`
-  keys, local transports, and bounded request concurrency.
+- **[Configuration](./configuration.md)** — config file paths, ChatGPT models,
+  fail-closed Grok Build roots, local transports, and bounded execution.
 - **[Migrating to 0.0.12](./migration-0.0.12.md)** — new account discovery,
   removed legacy escape hatches, Deep Research artifacts, Voice boundary, and
   the exact-commit release receipt.
@@ -17,7 +17,7 @@ User-facing documentation. (Project/contributor internals live in
 - **[How it works](./how-it-works.md)** — the no-proxy architecture.
 
 For the full per-tool and resource reference (every argument, return shape, and
-gotcha for all 32 tools and both resources), see
+gotcha for all registered tools and both resources), see
 [`gpt2agent/skills/gpt2agent/tools-reference.md`](../gpt2agent/skills/gpt2agent/tools-reference.md).
 
 Security model and ToS/account-ban risk are covered in the main

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,15 @@ port = 9000
 chat     = "gpt-5-3"      # default model for the `chat` tool
 agent    = "agent-mode"   # default for the `agent` tool
 heavy_dr = "gpt-5-5-pro"  # override slug for `deep_research_heavy`
+
+[grok_build]
+command = "grok"
+# home = "~/.grok"
+# auth_path = "~/.grok/auth.json"
+roots = []
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20
 ```
 
 `chat` and `agent` validate their selected slug against the live general model
@@ -26,6 +35,34 @@ catalog. Optional `thinking_effort` values must appear in that model's
 models from `list_work_models` remain a separate namespace.
 
 The host and port fields are inert under the supported stdio transport.
+
+## Grok Build
+
+The Grok Build provider is an independent official CLI subscription/OAuth lane.
+It does not reuse or fall back to ChatGPT auth, and gpt2agent removes
+`XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` from every Build child environment.
+Optional `home` and `auth_path` set explicit `GROK_HOME` and `GROK_AUTH_PATH`
+locations; do not paste or log their contents.
+
+`roots = []` is fail-closed: every Build probe and action remains disabled until
+at least one explicit repository root is configured. Start the MCP server with
+its current working directory inside a configured root so the no-argument
+`grok_build_status` and `grok_build_models` probes have an allowed directory.
+Both tools are read-only; the latter reads the authenticated account catalog.
+
+`grok_build_agent` defaults to `mode="plan"`, mapped to the CLI plan permission
+mode and read-only sandbox. `mode="apply"` must be selected explicitly and is
+mapped to bypass-permissions plus the strict sandbox. Because MCP annotations
+cannot vary per call, the tool remains annotated destructive even for plan
+mode. These mappings follow the tested headless CLI surface; see xAI's
+[enterprise/authentication guidance](https://docs.x.ai/build/enterprise), [CLI
+reference](https://docs.x.ai/build/cli/reference), [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands).
+
+The official CLI owns and retains session history. gpt2agent returns a
+sanitized session ID but does not copy transcripts or expose resume/deletion
+operations in this surface.
 
 ## Environment variables
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,6 +64,25 @@ its auth file; gpt2agent creates or tightens the manual fallback to mode `600`
 where POSIX supports it. The token is sent only to `chatgpt.com`, and gpt2agent
 redacts token/secret values from error output.
 
+### Does Grok Build reuse my ChatGPT login or an xAI API key?
+
+No. The three Grok Build tools use the official CLI's independent
+subscription/OAuth state. gpt2agent strips `XAI_API_KEY` and
+`GROK_CODE_XAI_API_KEY` from the child environment and never falls back between
+ChatGPT auth, Grok Build OAuth, or a website session. Optional `GROK_HOME` and
+`GROK_AUTH_PATH` locations are configured as paths, not pasted credentials.
+
+Build remains disabled while `roots = []`. Once an explicit root is configured,
+`grok_build_status` and `grok_build_models` are read-only; `grok_build_agent`
+defaults to plan mode and requires an explicit `mode="apply"` choice for source
+changes. The official CLI retains session history. gpt2agent returns a sanitized
+session ID but does not copy transcripts or expose resume/deletion tools.
+
+See xAI's [enterprise/authentication guidance](https://docs.x.ai/build/enterprise),
+[CLI reference](https://docs.x.ai/build/cli/reference), [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands).
+
 ### What's NOT supported?
 
 Sora video, Operator/CUA, Projects, and Voice sessions. The Projects candidate
@@ -74,5 +93,5 @@ read-only voice catalog is planned for 0.0.13; AgentRTC is later work.
 The current official [Voice in ChatGPT](https://help.openai.com/en/articles/20001274)
 guidance describes Live as a separate human-facing feature and says it does not
 initially support connected apps or Plugins, Work, Codex, Custom GPTs, Temporary
-Chats, or desktop. gpt2agent therefore does not present GPT-Live audio as one of
-its 32 MCP tools or as a supported account capability.
+Chats, or desktop. gpt2agent therefore does not present GPT-Live audio among its
+registered tools or as a supported account capability.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -13,7 +13,17 @@ $CODEX_HOME/auth.json (default ~/.codex/auth.json) ← bearer, auto-refreshed by
         │                                     ├── /conversation, /f/conversation   (SSE)
         │                                     └── /me, /models, /memories, /codex,  (REST)
         │                                         /gizmos, /files, /apps, ...
-   32 MCP tools + 2 packaged MCP resources
+   all registered ChatGPT tools + 2 packaged MCP resources
+```
+
+The Grok Build path is separate:
+
+```text
+configured repository root
+        │
+   gpt2agent (bounded stdio child)
+        │
+   official Grok Build CLI (subscription/OAuth; CLI-owned session history)
 ```
 
 ## Request path
@@ -75,6 +85,20 @@ General and Work model metadata use separate 60-second caches keyed by that auth
 generation. `chat` and `agent` validate their selected general model; `chat`
 also validates any optional `thinking_effort`. Work-only identifiers never leak
 into general chat validation.
+
+Grok Build never receives either ChatGPT auth source. gpt2agent also strips
+`XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` from the CLI environment, so the Build
+path uses the official CLI's separate subscription/OAuth state. Explicit
+`GROK_HOME` and `GROK_AUTH_PATH` locations can be configured. No ChatGPT, Build,
+or website authentication lane falls back to another.
+
+Build command execution is constrained to configured roots and bounded by time
+and output size. Empty roots disable both probes and agent sessions. Plan mode
+uses the CLI's plan/read-only sandbox; apply is an explicit destructive choice
+using the strict sandbox. The CLI retains history; gpt2agent exposes only a
+sanitized session ID, not a transcript or resume/delete operation. See xAI's
+[CLI reference](https://docs.x.ai/build/cli/reference) and [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting).
 
 ## Bounded request policy
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,6 +41,24 @@ If you've run `codex login`, you're done — gpt2agent picks up the token automa
 No codex? Run `gpt2agent setup` to paste a ChatGPT token once
 (saved to `~/.gpt2agent/token.json`, mode `600`).
 
+For Grok repository coding, install and authenticate the official Grok Build
+CLI separately using xAI's [enterprise/authentication
+guidance](https://docs.x.ai/build/enterprise). Do not paste its credential into
+gpt2agent. Add an explicit root to `~/.gpt2agent/config.toml`; the empty default
+disables all Build probes and actions:
+
+```toml
+[grok_build]
+command = "grok"
+roots = ["/absolute/path/to/repository-root"]
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20
+```
+
+Start the MCP server from within that root. ChatGPT auth and Grok Build OAuth
+remain independent and never fall back to one another.
+
 ## 4. Verify
 
 ```bash
@@ -50,9 +68,10 @@ gpt2agent run --stdio        # smoke test: should start and wait on stdin (Ctrl-
 
 Then **restart your MCP client** (Claude Code spawns the server fresh on restart;
 Codex picks it up on next run). Ask your agent to call `account_status`, then
-list the server's MCP tools and resources. Version 0.0.12 exposes exactly 32
-tools plus the static `chatgpt://feature-coverage` and
-`chatgpt://update-evidence` resources.
+list all registered tools and resources. The ChatGPT provider exposes the static
+`chatgpt://feature-coverage` and `chatgpt://update-evidence` resources. For the
+official CLI lane, call read-only `grok_build_status` and `grok_build_models`
+only after configuring a root.
 
 ## 5. First calls
 
@@ -63,6 +82,15 @@ tools plus the static `chatgpt://feature-coverage` and
 - `account_capabilities` — get shape-only, explicit current account truth.
 - `list_scheduled_tasks` — inspect scheduled automations; use `list_tasks` for
   generic background jobs.
+- `grok_build_agent` — repository coding through the official CLI. Use the
+  default `mode="plan"`; select `mode="apply"` only when the user explicitly
+  authorizes source changes. The tool is always annotated destructive.
+
+The CLI retains its own session history. gpt2agent returns a sanitized session
+ID but does not copy transcripts or expose resume/deletion operations. See the
+official [CLI reference](https://docs.x.ai/build/cli/reference), [headless
+scripting](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands) documentation.
 
 > **Heads up:** `chat` defaults to `temporary=True`, which disables image gen / code
 > interpreter / canvas. Use the dedicated tools (`generate_image`, `code_interpreter`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,28 @@ way. `unverified` means the release intentionally made no live claim, including
 Voice in 0.0.12. Update gpt2agent and inspect the public radar or sanitized local
 account receipt before assuming the feature is absent.
 
+### Grok Build errors
+
+Grok Build uses the official CLI's subscription/OAuth state, never the ChatGPT
+token or an ambient xAI API key. Configure at least one `[grok_build].roots`
+entry and run the MCP server from within a configured root before probing. Use
+these bounded actions; never paste credentials, auth files, or raw CLI output
+into prompts, logs, or bug reports.
+
+| Code | Bounded action |
+|---|---|
+| `GROK_BUILD_CLI_NOT_FOUND` | Install the official CLI or set `grok_build.command` to its reviewed executable, then restart the MCP server. |
+| `GROK_BUILD_AUTH_MISSING` | Open the official CLI locally and complete xAI's OAuth flow; then call `grok_build_status` again. |
+| `GROK_BUILD_QUOTA` | Stop retrying and wait for the account-reported quota window before one deliberate retry. |
+| `GROK_BUILD_TIMEOUT` | Reduce task scope or raise `timeout_seconds` within 1–600 seconds, then retry once. |
+| `GROK_BUILD_OUTPUT_TOO_LARGE` | Reduce requested output or raise `max_output_bytes` within the configured bound, then retry once. |
+| `GROK_BUILD_FAILED` | Call secret-free `grok_build_status`, verify the configured root and official CLI version, then retry one smaller plan-mode request. |
+
+`grok_build_status` and `grok_build_models` are read-only. The
+`grok_build_agent` default is `mode="plan"`; `mode="apply"` is an explicit
+destructive choice. See xAI's [CLI reference](https://docs.x.ai/build/cli/reference)
+and [headless scripting guide](https://docs.x.ai/build/cli/headless-scripting).
+
 ### `thinking_effort ... is not valid` / unsupported model
 
 Call `list_models` and use one of the selected general model's advertised

--- a/gpt2agent/_bounded_process.py
+++ b/gpt2agent/_bounded_process.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+class BoundedProcessError(RuntimeError):
+    def __init__(self, code: Literal["timeout", "output_too_large"]) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+class _WindowsJob:
+    """Own a Windows process tree through a kill-on-close Job Object."""
+
+    def __init__(self, handle: Any) -> None:
+        self._handle = handle
+
+    @classmethod
+    def create(cls) -> _WindowsJob:
+        import ctypes
+        from ctypes import wintypes
+
+        class IoCounters(ctypes.Structure):
+            _fields_ = [
+                ("ReadOperationCount", ctypes.c_ulonglong),
+                ("WriteOperationCount", ctypes.c_ulonglong),
+                ("OtherOperationCount", ctypes.c_ulonglong),
+                ("ReadTransferCount", ctypes.c_ulonglong),
+                ("WriteTransferCount", ctypes.c_ulonglong),
+                ("OtherTransferCount", ctypes.c_ulonglong),
+            ]
+
+        class BasicLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", ctypes.c_longlong),
+                ("PerJobUserTimeLimit", ctypes.c_longlong),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.c_size_t),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD),
+            ]
+
+        class ExtendedLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", BasicLimitInformation),
+                ("IoInfo", IoCounters),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.SetInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        handle = kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        limits = ExtendedLimitInformation()
+        limits.BasicLimitInformation.LimitFlags = 0x00002000
+        if not kernel32.SetInformationJobObject(
+            handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+        ):
+            error = ctypes.get_last_error()
+            kernel32.CloseHandle(handle)
+            raise ctypes.WinError(error)
+        return cls(handle)
+
+    def assign(self, pid: int) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        process_handle = kernel32.OpenProcess(0x0001 | 0x0100, False, pid)
+        if not process_handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        try:
+            if not kernel32.AssignProcessToJobObject(self._handle, process_handle):
+                raise ctypes.WinError(ctypes.get_last_error())
+        finally:
+            kernel32.CloseHandle(process_handle)
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        import ctypes
+        from ctypes import wintypes
+
+        handle = self._handle
+        self._handle = None
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle(handle)
+
+
+def _resume_windows_process(pid: int) -> None:
+    """Resume the sole initial thread of a CREATE_SUSPENDED process."""
+    import ctypes
+    from ctypes import wintypes
+
+    class ThreadEntry32(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ThreadID", wintypes.DWORD),
+            ("th32OwnerProcessID", wintypes.DWORD),
+            ("tpBasePri", wintypes.LONG),
+            ("tpDeltaPri", wintypes.LONG),
+            ("dwFlags", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Thread32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(ThreadEntry32)]
+    kernel32.Thread32First.restype = wintypes.BOOL
+    kernel32.Thread32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(ThreadEntry32)]
+    kernel32.Thread32Next.restype = wintypes.BOOL
+    kernel32.OpenThread.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenThread.restype = wintypes.HANDLE
+    kernel32.ResumeThread.argtypes = [wintypes.HANDLE]
+    kernel32.ResumeThread.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(0x00000004, 0)
+    if snapshot == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    thread_id: int | None = None
+    try:
+        entry = ThreadEntry32()
+        entry.dwSize = ctypes.sizeof(entry)
+        has_entry = kernel32.Thread32First(snapshot, ctypes.byref(entry))
+        while has_entry:
+            if entry.th32OwnerProcessID == pid:
+                thread_id = entry.th32ThreadID
+                break
+            has_entry = kernel32.Thread32Next(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    if thread_id is None:
+        raise ctypes.WinError(1168)
+
+    thread_handle = kernel32.OpenThread(0x0002, False, thread_id)
+    if not thread_handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        if kernel32.ResumeThread(thread_handle) == 0xFFFFFFFF:
+            raise ctypes.WinError(ctypes.get_last_error())
+    finally:
+        kernel32.CloseHandle(thread_handle)
+
+
+async def _read_limited(
+    stream: asyncio.StreamReader | None, max_output_bytes: int
+) -> bytes:
+    if stream is None:
+        return b""
+    chunks: list[bytes] = []
+    size = 0
+    while True:
+        chunk = await stream.read(min(65_536, max_output_bytes + 1))
+        if not chunk:
+            return b"".join(chunks)
+        size += len(chunk)
+        if size > max_output_bytes:
+            raise BoundedProcessError("output_too_large")
+        chunks.append(chunk)
+
+
+async def _discard_stream(stream: asyncio.StreamReader | None) -> None:
+    """Drain remaining output without retaining it in memory."""
+    if stream is None:
+        return
+    while await stream.read(65_536):
+        pass
+
+
+async def _terminate_process_group(
+    process: asyncio.subprocess.Process, windows_job: _WindowsJob | None
+) -> None:
+    cleanup_tasks = [
+        asyncio.create_task(process.wait()),
+        asyncio.create_task(_discard_stream(process.stdout)),
+        asyncio.create_task(_discard_stream(process.stderr)),
+    ]
+    if os.name == "posix":
+        deadline = asyncio.get_running_loop().time() + 1.0
+        try:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            while True:
+                try:
+                    os.killpg(process.pid, 0)
+                except ProcessLookupError:
+                    break
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    break
+                await asyncio.sleep(min(0.05, remaining))
+        finally:
+            await asyncio.gather(*cleanup_tasks)
+        return
+
+    if windows_job is not None:
+        windows_job.close()
+    elif process.returncode is None:
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            pass
+    cleanup = asyncio.gather(*cleanup_tasks)
+    try:
+        await asyncio.wait_for(asyncio.shield(cleanup), timeout=1.0)
+    except asyncio.TimeoutError:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        await cleanup
+
+
+async def run_bounded_process(
+    argv: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    timeout_seconds: float,
+    max_output_bytes: int,
+) -> ProcessResult:
+    """Run one argv without a shell and own its complete process tree."""
+    windows_job: _WindowsJob | None = None
+    creation: dict[str, Any] = {"start_new_session": True}
+    if os.name == "nt":
+        windows_job = _WindowsJob.create()
+        creation = {
+            "creationflags": subprocess.CREATE_NEW_PROCESS_GROUP
+            | 0x00000004  # CREATE_SUSPENDED; assign the Job before child code runs.
+        }
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(cwd),
+            env=dict(env),
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            **creation,
+        )
+    except BaseException:
+        if windows_job is not None:
+            windows_job.close()
+        raise
+    if windows_job is not None:
+        try:
+            windows_job.assign(process.pid)
+            _resume_windows_process(process.pid)
+        except BaseException:
+            windows_job.close()
+            if process.returncode is None:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+            await process.wait()
+            raise
+
+    tasks = [
+        asyncio.create_task(process.wait()),
+        asyncio.create_task(_read_limited(process.stdout, max_output_bytes)),
+        asyncio.create_task(_read_limited(process.stderr, max_output_bytes)),
+    ]
+    try:
+        returncode, stdout, stderr = await asyncio.wait_for(
+            asyncio.gather(*tasks), timeout=timeout_seconds
+        )
+        return ProcessResult(returncode, stdout, stderr)
+    except asyncio.TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await _terminate_process_group(process, windows_job)
+        raise BoundedProcessError("timeout") from exc
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await _terminate_process_group(process, windows_job)
+        raise
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        if windows_job is not None:
+            windows_job.close()

--- a/gpt2agent/_bounded_process.py
+++ b/gpt2agent/_bounded_process.py
@@ -316,7 +316,10 @@ async def run_bounded_process(
         returncode, stdout, stderr = await asyncio.wait_for(
             asyncio.gather(*tasks), timeout=timeout_seconds
         )
-        return ProcessResult(returncode, stdout, stderr)
+        result = ProcessResult(returncode, stdout, stderr)
+        if os.name == "posix":
+            await _terminate_process_group(process, windows_job)
+        return result
     except asyncio.TimeoutError as exc:
         for task in tasks:
             if not task.done():

--- a/gpt2agent/_log_redact.py
+++ b/gpt2agent/_log_redact.py
@@ -16,7 +16,7 @@ import re
 
 # 1. JSON-encoded session-scoped headers — redact the value, keep the key.
 _SENSITIVE_KEY_RE = re.compile(
-    r'"(Openai-Sentinel-[A-Za-z-]+-Token|Authorization|OAI-[A-Za-z-]+)"\s*:\s*"[^"]*"',
+    r'"(Openai-Sentinel-[A-Za-z-]+-Token|Authorization|Cookie|Set-Cookie|OAI-[A-Za-z-]+)"\s*:\s*"[^"]*"',
     re.IGNORECASE,
 )
 
@@ -47,8 +47,30 @@ _COOKIE_RE = re.compile(
 # 5. Token-bearing query params, e.g. `?access_token=…` / `&token=…` / `&accessToken=…`.
 _QUERY_TOKEN_RE = re.compile(
     r"([?&](?:access[_-]?token|accessToken|session[_-]?token|sessionToken|auth[_-]?token"
-    r"|id_token|refresh_token|token|sig|signature)=)[^&\s\"]+",
+    r"|id_token|refresh_token|token|sig|signature|credential|googleaccessid"
+    r"|x-amz-credential|x-amz-security-token|x-amz-signature|x-goog-credential"
+    r"|x-goog-signature)=)[^&\s\"]+",
     re.IGNORECASE,
+)
+
+_COOKIE_HEADER_RE = re.compile(r"\b(Cookie|Set-Cookie)\s*:\s*[^\r\n]+", re.IGNORECASE)
+_GROK_COOKIE_RE = re.compile(
+    r'''\b(sso-rw|sso|cf_clearance|grok_device_id)=(?:"[^"\r\n]*"|'[^'\r\n]*'|[^;\s"&]+)''',
+    re.IGNORECASE,
+)
+_XAI_TOKEN_RE = re.compile(r"\bxai-[A-Za-z0-9._~+/\-]{12,}=*", re.IGNORECASE)
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_IDENTITY_FIELD_RE = re.compile(
+    r"(?P<prefix>\b(?:account|identity|profile|user|workspace|organization|org)"
+    r"(?:[_-]?id|Id)\s*(?:=|:)\s*[\"']?)[^\s,;}\]\"']+",
+    re.IGNORECASE,
+)
+_GROK_OPAQUE_ID_RE = re.compile(
+    r"\b(?:conv|resp|attach)(?:[-_][A-Za-z0-9]+)+\b", re.IGNORECASE
+)
+_UUID_RE = re.compile(
+    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}\b"
 )
 
 
@@ -66,10 +88,17 @@ def redact_error(text: str, max_len: int = 200) -> str:
     if not isinstance(text, str):
         text = str(text)
     cleaned = _SENSITIVE_KEY_RE.sub(r'"\1":"<REDACTED>"', text)
+    cleaned = _COOKIE_HEADER_RE.sub(r"\1: <REDACTED>", cleaned)
+    cleaned = _GROK_COOKIE_RE.sub(r"\1=<REDACTED>", cleaned)
     cleaned = _TOKEN_FIELD_RE.sub(r'"\1":"<REDACTED>"', cleaned)
     cleaned = _BEARER_RE.sub("Bearer <REDACTED>", cleaned)
+    cleaned = _XAI_TOKEN_RE.sub("<TOKEN>", cleaned)
     cleaned = _COOKIE_RE.sub(r"\1=<REDACTED>", cleaned)
     cleaned = _QUERY_TOKEN_RE.sub(r"\1<REDACTED>", cleaned)
+    cleaned = _EMAIL_RE.sub("<EMAIL>", cleaned)
+    cleaned = _IDENTITY_FIELD_RE.sub(r"\g<prefix><REDACTED>", cleaned)
+    cleaned = _GROK_OPAQUE_ID_RE.sub("<ID>", cleaned)
+    cleaned = _UUID_RE.sub("<ID>", cleaned)
     if len(cleaned) > max_len:
         cleaned = cleaned[:max_len] + "...[truncated]"
     return cleaned

--- a/gpt2agent/_secure_file.py
+++ b/gpt2agent/_secure_file.py
@@ -184,13 +184,24 @@ def read_private_json(
                 raise _private_json_failure(path, "changed while being read")
         except OSError:
             raise _private_json_failure(path, "could not be read as private JSON") from None
-    finally:
-        os.close(fd)
-
-    try:
-        return json.loads(b"".join(chunks).decode("utf-8"))
-    except (UnicodeError, ValueError, RecursionError):
-        raise _private_json_failure(path, "must contain valid UTF-8 JSON") from None
+        try:
+            decoded = json.loads(b"".join(chunks).decode("utf-8"))
+        except (UnicodeError, ValueError, RecursionError):
+            raise _private_json_failure(path, "must contain valid UTF-8 JSON") from None
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    else:
+        try:
+            os.close(fd)
+        except OSError:
+            raise _private_json_failure(
+                path, "could not be closed after reading private JSON"
+            ) from None
+    return decoded
 
 
 def _validate_owner(path: Path, owner: int, expected: int | None) -> None:

--- a/gpt2agent/_secure_file.py
+++ b/gpt2agent/_secure_file.py
@@ -115,6 +115,84 @@ def _current_uid() -> int | None:
     return get_euid() if get_euid is not None else None
 
 
+def _private_json_failure(path: Path, invariant: str) -> RuntimeError:
+    return RuntimeError(f"{path} {invariant}")
+
+
+def read_private_json(
+    path: Path,
+    *,
+    maximum_bytes: int = 131_072,
+) -> Any:
+    """Read bounded JSON only from a current-user regular 0600 file."""
+    path = Path(path)
+    if (
+        isinstance(maximum_bytes, bool)
+        or not isinstance(maximum_bytes, int)
+        or maximum_bytes <= 0
+    ):
+        raise ValueError(f"{path} maximum_bytes must be a positive integer")
+
+    try:
+        observed = path.lstat()
+    except OSError:
+        raise _private_json_failure(path, "could not be inspected as a private JSON file") from None
+    if stat.S_ISLNK(observed.st_mode) or not stat.S_ISREG(observed.st_mode):
+        raise _private_json_failure(path, "must be a regular non-symlink file")
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        raise _private_json_failure(path, "could not be opened as a private JSON file") from None
+
+    try:
+        try:
+            opened = os.fstat(fd)
+            if not stat.S_ISREG(opened.st_mode):
+                raise _private_json_failure(path, "must be a regular non-symlink file")
+            if (opened.st_dev, opened.st_ino) != (observed.st_dev, observed.st_ino):
+                raise _private_json_failure(path, "changed while being validated")
+
+            expected_uid = _current_uid()
+            if expected_uid is not None and opened.st_uid != expected_uid:
+                raise _private_json_failure(path, "must be owned by the current user")
+            if os.name == "posix" and opened.st_mode & 0o077:
+                raise _private_json_failure(path, "must use owner-only mode")
+            if not 0 < opened.st_size <= maximum_bytes:
+                raise _private_json_failure(path, "must have a positive bounded size")
+
+            remaining = opened.st_size
+            chunks: list[bytes] = []
+            while remaining:
+                try:
+                    chunk = os.read(fd, min(65_536, remaining))
+                except InterruptedError:
+                    continue
+                if not chunk:
+                    raise _private_json_failure(path, "changed while being read")
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            if os.read(fd, 1):
+                raise _private_json_failure(path, "changed while being read")
+            final = os.fstat(fd)
+            if (
+                (final.st_dev, final.st_ino, final.st_size)
+                != (opened.st_dev, opened.st_ino, opened.st_size)
+            ):
+                raise _private_json_failure(path, "changed while being read")
+        except OSError:
+            raise _private_json_failure(path, "could not be read as private JSON") from None
+    finally:
+        os.close(fd)
+
+    try:
+        return json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeError, ValueError, RecursionError):
+        raise _private_json_failure(path, "must contain valid UTF-8 JSON") from None
+
+
 def _validate_owner(path: Path, owner: int, expected: int | None) -> None:
     if expected is not None and owner != expected:
         raise RuntimeError(

--- a/gpt2agent/grok_build.py
+++ b/gpt2agent/grok_build.py
@@ -342,8 +342,9 @@ class GrokBuildClient:
         self._runner = runner
         self._resolver = resolver
         self._cwd_policy = cwd_policy or RootPolicy(config.roots)
+        self._command = self._discover_command()
 
-    def _resolved_command(self) -> str:
+    def _discover_command(self) -> str | None:
         expanded = str(Path(self.config.command).expanduser())
         is_explicit = (
             Path(expanded).is_absolute()
@@ -351,17 +352,22 @@ class GrokBuildClient:
             or bool(os.altsep and os.altsep in expanded)
         )
         if is_explicit:
-            return self._validated_executable(expanded)
+            try:
+                return self._validated_executable(expanded)
+            except GrokError:
+                return None
         resolved = self._resolver(expanded)
         if not resolved:
-            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND")
-        if (
-            Path(resolved).is_absolute()
-            or os.sep in resolved
-            or bool(os.altsep and os.altsep in resolved)
-        ):
+            return None
+        try:
             return self._validated_executable(resolved)
-        return resolved
+        except GrokError:
+            return None
+
+    def _resolved_command(self) -> str:
+        if self._command is None:
+            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND")
+        return self._validated_executable(self._command)
 
     @staticmethod
     def _validated_executable(value: str) -> str:
@@ -443,6 +449,7 @@ class GrokBuildClient:
 
     async def status(self) -> dict[str, Any]:
         """Return installed/version/authenticated/catalog counts without identity."""
+        cwd = self._cwd_policy.directory(None)
         try:
             self._resolved_command()
         except GrokError as exc:
@@ -455,7 +462,6 @@ class GrokBuildClient:
                 "default_model": None,
                 "models_count": 0,
             }
-        cwd = self._cwd_policy.directory(None)
         try:
             version_stdout, _ = self._decode(
                 await self._run(["--version"], cwd=cwd)
@@ -591,5 +597,5 @@ class GrokBuildClient:
             size = len(prompt.encode("utf-8"))
         except UnicodeEncodeError:
             raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes") from None
-        if not prompt.strip() or size > _PROMPT_MAX_BYTES:
+        if not prompt.strip() or "\x00" in prompt or size > _PROMPT_MAX_BYTES:
             raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")

--- a/gpt2agent/grok_build.py
+++ b/gpt2agent/grok_build.py
@@ -73,10 +73,14 @@ def _finite_float(value: Any, invariant: str) -> float:
         raise _invalid(invariant)
     if isinstance(value, float) and not math.isfinite(value):
         raise _invalid(invariant)
+    conversion_failed = False
+    result = 0.0
     try:
         result = float(value)
     except (TypeError, ValueError, OverflowError):
-        raise _invalid(invariant) from None
+        conversion_failed = True
+    if conversion_failed:
+        raise _invalid(invariant)
     if not math.isfinite(result):
         raise _invalid(invariant)
     return result
@@ -89,10 +93,14 @@ def _bounded_int(value: Any, invariant: str, minimum: int, maximum: int) -> int:
         not math.isfinite(value) or not value.is_integer()
     ):
         raise _invalid(invariant)
+    conversion_failed = False
+    result = 0
     try:
         result = int(value)
     except (TypeError, ValueError, OverflowError):
-        raise _invalid(invariant) from None
+        conversion_failed = True
+    if conversion_failed:
+        raise _invalid(invariant)
     if not minimum <= result <= maximum:
         raise _invalid(invariant)
     return result
@@ -593,9 +601,13 @@ class GrokBuildClient:
     def _validate_prompt(prompt: str) -> None:
         if not isinstance(prompt, str):
             raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")
+        encoding_failed = False
+        size = 0
         try:
             size = len(prompt.encode("utf-8"))
         except UnicodeEncodeError:
-            raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes") from None
+            encoding_failed = True
+        if encoding_failed:
+            raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")
         if not prompt.strip() or "\x00" in prompt or size > _PROMPT_MAX_BYTES:
             raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")

--- a/gpt2agent/grok_build.py
+++ b/gpt2agent/grok_build.py
@@ -365,11 +365,15 @@ class GrokBuildClient:
 
     @staticmethod
     def _validated_executable(value: str) -> str:
+        failure: GrokError | None = None
+        path: Path | None = None
         try:
             path = Path(value).expanduser().resolve(strict=True)
         except (OSError, RuntimeError, ValueError):
-            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND") from None
-        if not path.is_file() or not os.access(path, os.X_OK):
+            failure = _grok_error("GROK_BUILD_CLI_NOT_FOUND")
+        if failure is not None:
+            raise failure
+        if path is None or not path.is_file() or not os.access(path, os.X_OK):
             raise _grok_error("GROK_BUILD_CLI_NOT_FOUND")
         return str(path)
 
@@ -383,13 +387,13 @@ class GrokBuildClient:
             env["GROK_AUTH_PATH"] = str(self.config.auth_path)
         return env
 
-    async def _run(
-        self, args: Sequence[str], *, cwd: Path | None = None
-    ) -> ProcessResult:
-        process_cwd = Path.cwd().resolve() if cwd is None else cwd
+    async def _run(self, args: Sequence[str], *, cwd: Path) -> ProcessResult:
+        process_cwd = self._cwd_policy.directory(cwd)
         argv = [self._resolved_command(), "--no-auto-update", *args]
+        failure: GrokError | InputValidationError | None = None
+        result: ProcessResult | None = None
         try:
-            return await self._runner(
+            result = await self._runner(
                 argv,
                 cwd=process_cwd,
                 env=self._environment(),
@@ -398,38 +402,66 @@ class GrokBuildClient:
             )
         except BoundedProcessError as exc:
             if exc.code == "timeout":
-                raise _grok_error("GROK_BUILD_TIMEOUT") from exc
-            raise _grok_error("GROK_BUILD_OUTPUT_TOO_LARGE") from exc
-        except FileNotFoundError as exc:
+                failure = _grok_error("GROK_BUILD_TIMEOUT")
+            else:
+                failure = _grok_error("GROK_BUILD_OUTPUT_TOO_LARGE")
+        except FileNotFoundError:
             if not process_cwd.is_dir():
-                raise InputValidationError(_CWD_INVARIANT) from exc
-            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND") from exc
+                failure = InputValidationError(_CWD_INVARIANT)
+            else:
+                failure = _grok_error("GROK_BUILD_CLI_NOT_FOUND")
+        if failure is not None:
+            raise failure
+        if result is None:  # pragma: no cover - runner contract guard
+            raise _grok_error("GROK_BUILD_FAILED")
+        return result
 
     @staticmethod
     def _decode(result: ProcessResult) -> tuple[str, str]:
+        failure: GrokError | None = None
+        stdout = ""
+        stderr = ""
         try:
             stdout = result.stdout.decode("utf-8")
             stderr = result.stderr.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            raise _grok_error("GROK_BUILD_FAILED") from exc
+        except UnicodeDecodeError:
+            failure = _grok_error("GROK_BUILD_FAILED")
+        if failure is not None:
+            raise failure
         if result.returncode != 0:
             raise _classified_error(f"{stderr}\n{stdout}")
         return stdout, stderr
 
-    async def _model_catalog(self) -> GrokBuildModelCatalog:
-        stdout, _ = self._decode(await self._run(["models"]))
+    async def _model_catalog(self, cwd: Path) -> GrokBuildModelCatalog:
+        stdout, _ = self._decode(await self._run(["models"], cwd=cwd))
         return _parse_models(stdout)
 
     async def models(self) -> dict[str, Any]:
         """Return authenticated/default_model/models/count from ``grok models``."""
-        return (await self._model_catalog()).as_dict()
+        cwd = self._cwd_policy.directory(None)
+        return (await self._model_catalog(cwd)).as_dict()
 
     async def status(self) -> dict[str, Any]:
         """Return installed/version/authenticated/catalog counts without identity."""
         try:
-            version_stdout, _ = self._decode(await self._run(["--version"]))
+            self._resolved_command()
+        except GrokError as exc:
+            if exc.code != "GROK_BUILD_CLI_NOT_FOUND":
+                raise
+            return {
+                "installed": False,
+                "version": None,
+                "authenticated": False,
+                "default_model": None,
+                "models_count": 0,
+            }
+        cwd = self._cwd_policy.directory(None)
+        try:
+            version_stdout, _ = self._decode(
+                await self._run(["--version"], cwd=cwd)
+            )
             version = _parse_version(version_stdout)
-            catalog = await self._model_catalog()
+            catalog = await self._model_catalog(cwd)
         except GrokError as exc:
             if exc.code != "GROK_BUILD_CLI_NOT_FOUND":
                 raise
@@ -469,7 +501,7 @@ class GrokBuildClient:
             raise _invalid("grok_build.subagents must be boolean")
         validated_cwd = self._cwd_policy.directory(cwd)
 
-        catalog = await self._model_catalog()
+        catalog = await self._model_catalog(validated_cwd)
         if not catalog.authenticated:
             raise _grok_error("GROK_BUILD_AUTH_MISSING")
         selected_model = (
@@ -509,10 +541,14 @@ class GrokBuildClient:
             args.append("--no-subagents")
         args.extend(("--model", selected_model))
         stdout, stderr = self._decode(await self._run(args, cwd=validated_cwd))
+        parse_failure: GrokError | None = None
+        payload: Any = None
         try:
             payload = json.loads(stdout)
-        except json.JSONDecodeError as exc:
-            raise _classified_error(f"{stderr}\n{stdout}") from exc
+        except (ValueError, RecursionError):
+            parse_failure = _classified_error(f"{stderr}\n{stdout}")
+        if parse_failure is not None:
+            raise parse_failure
         if not isinstance(payload, dict):
             raise _grok_error("GROK_BUILD_FAILED")
         if payload.get("type") == "error":

--- a/gpt2agent/grok_build.py
+++ b/gpt2agent/grok_build.py
@@ -1,0 +1,559 @@
+"""Bounded official-CLI client for Grok Build account operations."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Literal
+
+from ._bounded_process import (
+    BoundedProcessError,
+    ProcessResult,
+    run_bounded_process,
+)
+from .errors import InputValidationError
+from .grok_errors import GrokError
+from .grok_paths import RootPolicy
+
+
+_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_VERSION_RE = re.compile(
+    r"^grok[ \t]+([A-Za-z0-9][A-Za-z0-9._+-]{0,63})(?:[ \t]|$)",
+    re.MULTILINE,
+)
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_STOP_REASON_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$")
+_PROMPT_MAX_BYTES = 65_536
+_CHANGED_PATH_MAX_BYTES = 1_024
+_CHANGED_PATH_MAX_COUNT = 256
+_USAGE_MAX = 2**63 - 1
+_USAGE_KEYS = (
+    "inputTokens",
+    "outputTokens",
+    "totalTokens",
+    "cacheReadTokens",
+    "cacheCreationTokens",
+)
+_AUTH_MARKERS = (
+    "not authenticated",
+    "authentication required",
+    "please log in",
+    "login --oauth",
+    "unauthorized",
+)
+_QUOTA_MARKERS = (
+    "quota",
+    "rate limit",
+    "rate-limit",
+    "too many requests",
+    "usage limit",
+    "resource exhausted",
+)
+_CWD_INVARIANT = (
+    "grok_build.cwd must be an existing directory under a configured root"
+)
+
+
+Runner = Callable[..., Awaitable[ProcessResult]]
+Resolver = Callable[[str], str | None]
+
+
+def _invalid(invariant: str) -> InputValidationError:
+    return InputValidationError(invariant)
+
+
+def _finite_float(value: Any, invariant: str) -> float:
+    if isinstance(value, bool):
+        raise _invalid(invariant)
+    if isinstance(value, float) and not math.isfinite(value):
+        raise _invalid(invariant)
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise _invalid(invariant) from None
+    if not math.isfinite(result):
+        raise _invalid(invariant)
+    return result
+
+
+def _bounded_int(value: Any, invariant: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise _invalid(invariant)
+    if isinstance(value, float) and (
+        not math.isfinite(value) or not value.is_integer()
+    ):
+        raise _invalid(invariant)
+    try:
+        result = int(value)
+    except (TypeError, ValueError, OverflowError):
+        raise _invalid(invariant) from None
+    if not minimum <= result <= maximum:
+        raise _invalid(invariant)
+    return result
+
+
+@dataclass(frozen=True)
+class GrokBuildConfig:
+    command: str
+    home: Path | None
+    auth_path: Path | None
+    roots: tuple[Path, ...]
+    default_model: str | None
+    timeout_seconds: float
+    max_output_bytes: int
+    default_max_turns: int
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any] | None) -> GrokBuildConfig:
+        data = dict(values or {})
+        command = str(data.get("command", "grok")).strip()
+        if not command:
+            raise _invalid("grok_build.command must not be empty")
+        raw_roots = data.get("roots", [])
+        if not isinstance(raw_roots, list) or not all(
+            isinstance(value, str) and value.strip() for value in raw_roots
+        ):
+            raise _invalid("grok_build.roots must be a string list")
+        roots = tuple(Path(value).expanduser().resolve() for value in raw_roots)
+        home_value = data.get("home")
+        auth_value = data.get("auth_path")
+        model_value = data.get("default_model")
+        default_model = str(model_value).strip() if model_value else None
+        if default_model is not None and not _MODEL_ID_RE.fullmatch(default_model):
+            raise _invalid("grok_build.default_model is invalid")
+        timeout_seconds = _finite_float(
+            data.get("timeout_seconds", 120.0),
+            "grok_build.timeout_seconds must be 1..600",
+        )
+        if not 1.0 <= timeout_seconds <= 600.0:
+            raise _invalid("grok_build.timeout_seconds must be 1..600")
+        max_output_bytes = _bounded_int(
+            data.get("max_output_bytes", 1_048_576),
+            "grok_build.max_output_bytes is out of range",
+            1_024,
+            16_777_216,
+        )
+        default_max_turns = _bounded_int(
+            data.get("default_max_turns", 20),
+            "grok_build.default_max_turns must be 1..100",
+            1,
+            100,
+        )
+        return cls(
+            command=command,
+            home=Path(str(home_value)).expanduser().resolve()
+            if home_value
+            else None,
+            auth_path=Path(str(auth_value)).expanduser().resolve()
+            if auth_value
+            else None,
+            roots=roots,
+            default_model=default_model,
+            timeout_seconds=timeout_seconds,
+            max_output_bytes=max_output_bytes,
+            default_max_turns=default_max_turns,
+        )
+
+
+@dataclass(frozen=True)
+class GrokBuildModelCatalog:
+    authenticated: bool
+    default_model: str | None
+    models: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "authenticated": self.authenticated,
+            "default_model": self.default_model,
+            "models": list(self.models),
+            "count": len(self.models),
+        }
+
+
+@dataclass(frozen=True)
+class GrokBuildResult:
+    surface: str
+    status: str
+    session_id: str | None
+    model: str
+    text: str
+    stop_reason: str | None
+    usage: dict[str, int] | None
+    changed_files: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "surface": self.surface,
+            "status": self.status,
+            "session_id": self.session_id,
+            "model": self.model,
+            "text": self.text,
+            "stop_reason": self.stop_reason,
+            "usage": dict(self.usage) if self.usage is not None else None,
+            "changed_files": list(self.changed_files),
+        }
+
+
+def _grok_error(code: str) -> GrokError:
+    return GrokError(
+        code,
+        retryable=code in {"GROK_BUILD_QUOTA", "GROK_BUILD_TIMEOUT"},
+    )
+
+
+def _classified_error(text: str) -> GrokError:
+    lowered = text.lower()
+    if any(marker in lowered for marker in _AUTH_MARKERS):
+        return _grok_error("GROK_BUILD_AUTH_MISSING")
+    if any(marker in lowered for marker in _QUOTA_MARKERS):
+        return _grok_error("GROK_BUILD_QUOTA")
+    return _grok_error("GROK_BUILD_FAILED")
+
+
+def _parse_version(text: str) -> str:
+    match = _VERSION_RE.search(text)
+    if match is None:
+        raise _grok_error("GROK_BUILD_FAILED")
+    return match.group(1)
+
+
+def _parse_models(text: str) -> GrokBuildModelCatalog:
+    lowered = text.lower()
+    authenticated = not any(marker in lowered for marker in _AUTH_MARKERS)
+
+    default_model: str | None = None
+    models: list[str] = []
+    saw_catalog = False
+    in_models = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        lowered_line = line.lower()
+        if lowered_line.startswith("default model:"):
+            saw_catalog = True
+            candidate = line.split(":", 1)[1].strip()
+            if not _MODEL_ID_RE.fullmatch(candidate):
+                raise _grok_error("GROK_BUILD_FAILED")
+            default_model = candidate
+            continue
+        if lowered_line == "available models:":
+            saw_catalog = True
+            in_models = True
+            continue
+        if not in_models or not line:
+            continue
+
+        bullet = next(
+            (prefix for prefix in ("- ", "* ", "• ") if line.startswith(prefix)),
+            None,
+        )
+        if bullet is not None:
+            candidate = line[len(bullet) :].split(None, 1)[0].rstrip(":")
+        else:
+            if not raw_line[:1].isspace():
+                break
+            raw_candidate = line.split(None, 1)[0]
+            candidate = raw_candidate.rstrip(":")
+            if not any(marker in candidate for marker in "-./:"):
+                break
+        if not _MODEL_ID_RE.fullmatch(candidate):
+            break
+        if candidate not in models:
+            models.append(candidate)
+
+    if not authenticated:
+        return GrokBuildModelCatalog(False, default_model, ())
+    if (
+        not saw_catalog
+        or not models
+        or (default_model is not None and default_model not in models)
+    ):
+        raise _grok_error("GROK_BUILD_FAILED")
+    return GrokBuildModelCatalog(True, default_model, tuple(models))
+
+
+def _parse_usage(value: Any) -> dict[str, int] | None:
+    if not isinstance(value, Mapping):
+        return None
+    usage = {
+        key: raw_value
+        for key in _USAGE_KEYS
+        if isinstance((raw_value := value.get(key)), int)
+        and not isinstance(raw_value, bool)
+        and 0 <= raw_value <= _USAGE_MAX
+    }
+    return usage or None
+
+
+def _safe_changed_path(value: Any) -> str | None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or not value.isprintable()
+        or "\x00" in value
+    ):
+        return None
+    try:
+        if len(value.encode("utf-8")) > _CHANGED_PATH_MAX_BYTES:
+            return None
+    except UnicodeEncodeError:
+        return None
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or bool(windows_path.drive)
+        or bool(windows_path.root)
+    ):
+        return None
+    parts = value.replace("\\", "/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return value
+
+
+def _parse_changed_files(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    changed: list[str] = []
+    for raw_path in value[:_CHANGED_PATH_MAX_COUNT]:
+        path = _safe_changed_path(raw_path)
+        if path is not None and path not in changed:
+            changed.append(path)
+    return tuple(changed)
+
+
+class GrokBuildClient:
+    def __init__(
+        self,
+        config: GrokBuildConfig,
+        *,
+        runner: Runner = run_bounded_process,
+        resolver: Resolver = shutil.which,
+        cwd_policy: RootPolicy | None = None,
+    ) -> None:
+        self.config = config
+        self._runner = runner
+        self._resolver = resolver
+        self._cwd_policy = cwd_policy or RootPolicy(config.roots)
+
+    def _resolved_command(self) -> str:
+        expanded = str(Path(self.config.command).expanduser())
+        is_explicit = (
+            Path(expanded).is_absolute()
+            or os.sep in expanded
+            or bool(os.altsep and os.altsep in expanded)
+        )
+        if is_explicit:
+            return self._validated_executable(expanded)
+        resolved = self._resolver(expanded)
+        if not resolved:
+            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND")
+        if (
+            Path(resolved).is_absolute()
+            or os.sep in resolved
+            or bool(os.altsep and os.altsep in resolved)
+        ):
+            return self._validated_executable(resolved)
+        return resolved
+
+    @staticmethod
+    def _validated_executable(value: str) -> str:
+        try:
+            path = Path(value).expanduser().resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND") from None
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND")
+        return str(path)
+
+    def _environment(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.pop("XAI_API_KEY", None)
+        env.pop("GROK_CODE_XAI_API_KEY", None)
+        if self.config.home is not None:
+            env["GROK_HOME"] = str(self.config.home)
+        if self.config.auth_path is not None:
+            env["GROK_AUTH_PATH"] = str(self.config.auth_path)
+        return env
+
+    async def _run(
+        self, args: Sequence[str], *, cwd: Path | None = None
+    ) -> ProcessResult:
+        process_cwd = Path.cwd().resolve() if cwd is None else cwd
+        argv = [self._resolved_command(), "--no-auto-update", *args]
+        try:
+            return await self._runner(
+                argv,
+                cwd=process_cwd,
+                env=self._environment(),
+                timeout_seconds=self.config.timeout_seconds,
+                max_output_bytes=self.config.max_output_bytes,
+            )
+        except BoundedProcessError as exc:
+            if exc.code == "timeout":
+                raise _grok_error("GROK_BUILD_TIMEOUT") from exc
+            raise _grok_error("GROK_BUILD_OUTPUT_TOO_LARGE") from exc
+        except FileNotFoundError as exc:
+            if not process_cwd.is_dir():
+                raise InputValidationError(_CWD_INVARIANT) from exc
+            raise _grok_error("GROK_BUILD_CLI_NOT_FOUND") from exc
+
+    @staticmethod
+    def _decode(result: ProcessResult) -> tuple[str, str]:
+        try:
+            stdout = result.stdout.decode("utf-8")
+            stderr = result.stderr.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise _grok_error("GROK_BUILD_FAILED") from exc
+        if result.returncode != 0:
+            raise _classified_error(f"{stderr}\n{stdout}")
+        return stdout, stderr
+
+    async def _model_catalog(self) -> GrokBuildModelCatalog:
+        stdout, _ = self._decode(await self._run(["models"]))
+        return _parse_models(stdout)
+
+    async def models(self) -> dict[str, Any]:
+        """Return authenticated/default_model/models/count from ``grok models``."""
+        return (await self._model_catalog()).as_dict()
+
+    async def status(self) -> dict[str, Any]:
+        """Return installed/version/authenticated/catalog counts without identity."""
+        try:
+            version_stdout, _ = self._decode(await self._run(["--version"]))
+            version = _parse_version(version_stdout)
+            catalog = await self._model_catalog()
+        except GrokError as exc:
+            if exc.code != "GROK_BUILD_CLI_NOT_FOUND":
+                raise
+            return {
+                "installed": False,
+                "version": None,
+                "authenticated": False,
+                "default_model": None,
+                "models_count": 0,
+            }
+        return {
+            "installed": True,
+            "version": version,
+            "authenticated": catalog.authenticated,
+            "default_model": catalog.default_model,
+            "models_count": len(catalog.models),
+        }
+
+    async def agent(
+        self,
+        prompt: str,
+        *,
+        cwd: str | None = None,
+        mode: Literal["plan", "apply"] = "plan",
+        model: str | None = None,
+        max_turns: int | None = None,
+        subagents: bool = False,
+    ) -> dict[str, Any]:
+        """Run one bounded official Build headless agent session."""
+        self._validate_prompt(prompt)
+        if mode not in ("plan", "apply"):
+            raise _invalid("grok_build.mode must be plan or apply")
+        turns = self.config.default_max_turns if max_turns is None else max_turns
+        if isinstance(turns, bool) or not isinstance(turns, int) or not 1 <= turns <= 100:
+            raise _invalid("grok_build.max_turns must be 1..100")
+        if not isinstance(subagents, bool):
+            raise _invalid("grok_build.subagents must be boolean")
+        validated_cwd = self._cwd_policy.directory(cwd)
+
+        catalog = await self._model_catalog()
+        if not catalog.authenticated:
+            raise _grok_error("GROK_BUILD_AUTH_MISSING")
+        selected_model = (
+            model
+            if model is not None
+            else self.config.default_model or catalog.default_model
+        )
+        if (
+            not isinstance(selected_model, str)
+            or _MODEL_ID_RE.fullmatch(selected_model) is None
+            or selected_model not in catalog.models
+        ):
+            raise _invalid("grok_build.model must be in the account catalog")
+
+        validated_cwd = self._cwd_policy.directory(validated_cwd)
+        permission_mode, sandbox = (
+            ("plan", "read-only")
+            if mode == "plan"
+            else ("bypassPermissions", "strict")
+        )
+        args = [
+            "--cwd",
+            str(validated_cwd),
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            "--max-turns",
+            str(turns),
+            "--no-memory",
+            "--permission-mode",
+            permission_mode,
+            "--sandbox",
+            sandbox,
+        ]
+        if not subagents:
+            args.append("--no-subagents")
+        args.extend(("--model", selected_model))
+        stdout, stderr = self._decode(await self._run(args, cwd=validated_cwd))
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise _classified_error(f"{stderr}\n{stdout}") from exc
+        if not isinstance(payload, dict):
+            raise _grok_error("GROK_BUILD_FAILED")
+        if payload.get("type") == "error":
+            message = payload.get("message")
+            raise _classified_error(message if isinstance(message, str) else "")
+        text = payload.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise _grok_error("GROK_BUILD_FAILED")
+
+        raw_session_id = payload.get("sessionId")
+        session_id = (
+            raw_session_id
+            if isinstance(raw_session_id, str)
+            and _SESSION_ID_RE.fullmatch(raw_session_id) is not None
+            else None
+        )
+        raw_stop_reason = payload.get("stopReason")
+        stop_reason = (
+            raw_stop_reason
+            if isinstance(raw_stop_reason, str)
+            and _STOP_REASON_RE.fullmatch(raw_stop_reason) is not None
+            else None
+        )
+        return GrokBuildResult(
+            surface="build",
+            status="completed",
+            session_id=session_id,
+            model=selected_model,
+            text=text,
+            stop_reason=stop_reason,
+            usage=_parse_usage(payload.get("usage")),
+            changed_files=_parse_changed_files(payload.get("changedFiles")),
+        ).as_dict()
+
+    @staticmethod
+    def _validate_prompt(prompt: str) -> None:
+        if not isinstance(prompt, str):
+            raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")
+        try:
+            size = len(prompt.encode("utf-8"))
+        except UnicodeEncodeError:
+            raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes") from None
+        if not prompt.strip() or size > _PROMPT_MAX_BYTES:
+            raise _invalid("grok_build.prompt must be 1..65536 UTF-8 bytes")

--- a/gpt2agent/grok_errors.py
+++ b/gpt2agent/grok_errors.py
@@ -1,0 +1,168 @@
+"""Closed, secret-safe error contract for Grok account integrations."""
+
+from __future__ import annotations
+
+import math
+import re
+from urllib.parse import urlsplit
+
+
+GROK_ERROR_CODES = frozenset(
+    {
+        "GROK_BUILD_CLI_NOT_FOUND",
+        "GROK_BUILD_AUTH_MISSING",
+        "GROK_BUILD_QUOTA",
+        "GROK_BUILD_TIMEOUT",
+        "GROK_BUILD_OUTPUT_TOO_LARGE",
+        "GROK_BUILD_FAILED",
+        "GROK_WEB_AUTH_MISSING",
+        "GROK_WEB_AUTH_EXPIRED",
+        "GROK_WEB_RATE_LIMITED",
+        "GROK_WEB_CONTRACT_CHANGED",
+        "GROK_WEB_TIMEOUT",
+        "GROK_WEB_OUTPUT_TOO_LARGE",
+        "GROK_UPLOAD_BLOCKED",
+        "GROK_WEB_FAILED",
+    }
+)
+
+_MAX_METHOD_LENGTH = 16
+_MAX_ROUTE_LENGTH = 160
+_METHOD_RE = re.compile(r"[A-Z]+")
+_UUID_RE = re.compile(
+    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}\b"
+)
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_XAI_TOKEN_RE = re.compile(r"\bxai-[A-Za-z0-9._~+/\-]{12,}=*", re.IGNORECASE)
+_GROK_ID_RE = re.compile(
+    r"\b(?:conv|resp|attach)(?:[-_][A-Za-z0-9]+)+\b", re.IGNORECASE
+)
+_ID_COLLECTIONS = frozenset(
+    {
+        "accounts",
+        "attachments",
+        "identities",
+        "organizations",
+        "profiles",
+        "responses",
+        "users",
+        "workspaces",
+    }
+)
+
+
+def normalize_grok_route(route: str | None) -> str | None:
+    """Return a bounded endpoint label without queries or resource IDs."""
+    if route is None:
+        return None
+    if not isinstance(route, str):
+        raise ValueError("Grok error route must be a string or None")
+    try:
+        path = urlsplit(route).path
+    except ValueError:
+        return "<route>"
+    if (
+        not path.startswith("/")
+        or not path.isascii()
+        or not path.isprintable()
+        or "%" in path
+    ):
+        return "<route>"
+
+    segments = path.split("/")
+    for index, segment in enumerate(segments):
+        previous = segments[index - 1] if index else ""
+        if previous in _ID_COLLECTIONS:
+            segments[index] = "{id}"
+        elif previous == "conversations" and segment not in {
+            "new",
+            "reconnect-response-v2",
+        }:
+            segments[index] = "{id}"
+        elif (
+            index >= 2
+            and segments[index - 2] == "conversations"
+            and previous == "reconnect-response-v2"
+        ):
+            segments[index] = "{id}"
+        else:
+            segment = _UUID_RE.sub("{id}", segment)
+            segment = _EMAIL_RE.sub("{id}", segment)
+            segment = _XAI_TOKEN_RE.sub("{id}", segment)
+            segments[index] = _GROK_ID_RE.sub("{id}", segment)
+
+    normalized = "/".join(segments)
+    if len(normalized) > _MAX_ROUTE_LENGTH:
+        return "<route>"
+    return normalized
+
+
+class GrokError(RuntimeError):
+    """A bounded failure containing only allowlisted operational metadata."""
+
+    code: str
+    method: str | None
+    route: str | None
+    status_code: int | None
+    retryable: bool
+    retry_after: float | None
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        method: str | None = None,
+        route: str | None = None,
+        status_code: int | None = None,
+        retryable: bool,
+        retry_after: float | None = None,
+    ) -> None:
+        if not isinstance(code, str) or code not in GROK_ERROR_CODES:
+            raise ValueError("unsupported Grok error code")
+        if method is not None:
+            if not isinstance(method, str):
+                raise ValueError("Grok error method must be a bounded HTTP method")
+            method = method.strip().upper()
+            if (
+                not method
+                or len(method) > _MAX_METHOD_LENGTH
+                or _METHOD_RE.fullmatch(method) is None
+            ):
+                raise ValueError("Grok error method must be a bounded HTTP method")
+        if status_code is not None and (
+            isinstance(status_code, bool)
+            or not isinstance(status_code, int)
+            or not 100 <= status_code <= 599
+        ):
+            raise ValueError("Grok error status must be an HTTP status code")
+        if not isinstance(retryable, bool):
+            raise ValueError("Grok error retryable flag must be boolean")
+        if retry_after is not None:
+            if (
+                isinstance(retry_after, bool)
+                or not isinstance(retry_after, (int, float))
+                or not math.isfinite(retry_after)
+            ):
+                raise ValueError("Grok error retry timing must be finite")
+            retry_after = min(60.0, max(0.0, float(retry_after)))
+
+        self.code = code
+        self.method = method
+        self.route = normalize_grok_route(route)
+        self.status_code = status_code
+        self.retryable = retryable
+        self.retry_after = retry_after
+
+        context = " ".join(value for value in (self.method, self.route) if value)
+        message = f"{self.code}: {context + ' ' if context else ''}failed"
+        if self.status_code is not None:
+            message += f" ({self.status_code})"
+        retry_metadata: list[str] = []
+        if self.retryable:
+            retry_metadata.append("retryable")
+        if self.retry_after is not None:
+            retry_metadata.append(f"retry after {self.retry_after:g}s")
+        if retry_metadata:
+            message += f" [{'; '.join(retry_metadata)}]"
+        super().__init__(message)

--- a/gpt2agent/grok_errors.py
+++ b/gpt2agent/grok_errors.py
@@ -27,28 +27,40 @@ GROK_ERROR_CODES = frozenset(
 )
 
 _MAX_METHOD_LENGTH = 16
-_MAX_ROUTE_LENGTH = 160
+_MAX_INPUT_ROUTE_LENGTH = 2_048
 _METHOD_RE = re.compile(r"[A-Z]+")
-_UUID_RE = re.compile(
-    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
-    r"[0-9a-f]{4}-[0-9a-f]{12}\b"
-)
-_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
-_XAI_TOKEN_RE = re.compile(r"\bxai-[A-Za-z0-9._~+/\-]{12,}=*", re.IGNORECASE)
-_GROK_ID_RE = re.compile(
-    r"\b(?:conv|resp|attach)(?:[-_][A-Za-z0-9]+)+\b", re.IGNORECASE
-)
-_ID_COLLECTIONS = frozenset(
+_STATIC_ROUTE_TEMPLATES = frozenset(
     {
-        "accounts",
-        "attachments",
-        "identities",
-        "organizations",
-        "profiles",
-        "responses",
-        "users",
-        "workspaces",
+        "/rest/app-chat/conversations/new",
+        "/rest/models",
+        "/rest/modes",
     }
+)
+_DYNAMIC_ROUTE_TEMPLATES = (
+    (
+        re.compile(
+            r"/rest/app-chat/conversations/reconnect-response-v2/[^/\s]+"
+        ),
+        "/rest/app-chat/conversations/reconnect-response-v2/{id}",
+    ),
+    (
+        re.compile(
+            r"/rest/app-chat/conversations/(?!new\Z|reconnect-response-v2\Z)[^/\s]+"
+        ),
+        "/rest/app-chat/conversations/{id}",
+    ),
+    (
+        re.compile(r"/rest/app-chat/attachments/[^/\s]+"),
+        "/rest/app-chat/attachments/{id}",
+    ),
+    (
+        re.compile(r"/rest/app-chat/responses/[^/\s]+"),
+        "/rest/app-chat/responses/{id}",
+    ),
+    (
+        re.compile(r"/rest/app-chat/events/[^/\s]+"),
+        "/rest/app-chat/events/{id}",
+    ),
 )
 
 
@@ -63,39 +75,19 @@ def normalize_grok_route(route: str | None) -> str | None:
     except ValueError:
         return "<route>"
     if (
-        not path.startswith("/")
+        len(path) > _MAX_INPUT_ROUTE_LENGTH
+        or not path.startswith("/")
         or not path.isascii()
         or not path.isprintable()
         or "%" in path
     ):
         return "<route>"
-
-    segments = path.split("/")
-    for index, segment in enumerate(segments):
-        previous = segments[index - 1] if index else ""
-        if previous in _ID_COLLECTIONS:
-            segments[index] = "{id}"
-        elif previous == "conversations" and segment not in {
-            "new",
-            "reconnect-response-v2",
-        }:
-            segments[index] = "{id}"
-        elif (
-            index >= 2
-            and segments[index - 2] == "conversations"
-            and previous == "reconnect-response-v2"
-        ):
-            segments[index] = "{id}"
-        else:
-            segment = _UUID_RE.sub("{id}", segment)
-            segment = _EMAIL_RE.sub("{id}", segment)
-            segment = _XAI_TOKEN_RE.sub("{id}", segment)
-            segments[index] = _GROK_ID_RE.sub("{id}", segment)
-
-    normalized = "/".join(segments)
-    if len(normalized) > _MAX_ROUTE_LENGTH:
-        return "<route>"
-    return normalized
+    if path in _STATIC_ROUTE_TEMPLATES:
+        return path
+    for pattern, normalized in _DYNAMIC_ROUTE_TEMPLATES:
+        if pattern.fullmatch(path) is not None:
+            return normalized
+    return "<route>"
 
 
 class GrokError(RuntimeError):

--- a/gpt2agent/grok_paths.py
+++ b/gpt2agent/grok_paths.py
@@ -1,0 +1,34 @@
+"""Configured-root path policy shared by Grok local-file surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from .errors import InputValidationError
+
+
+_CWD_INVARIANT = (
+    "grok_build.cwd must be an existing directory under a configured root"
+)
+
+
+class RootPolicy:
+    def __init__(self, roots: Sequence[Path]) -> None:
+        self.roots = tuple(path.expanduser().resolve() for path in roots)
+
+    def directory(self, value: str | Path | None) -> Path:
+        """Return one existing directory contained by a configured root."""
+        if not self.roots:
+            raise InputValidationError(_CWD_INVARIANT)
+        try:
+            candidate = Path.cwd() if value is None else Path(value).expanduser()
+            resolved = candidate.resolve(strict=True)
+            is_directory = resolved.is_dir()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            raise InputValidationError(_CWD_INVARIANT) from None
+        if not is_directory or not any(
+            resolved == root or root in resolved.parents for root in self.roots
+        ):
+            raise InputValidationError(_CWD_INVARIANT)
+        return resolved

--- a/gpt2agent/grok_paths.py
+++ b/gpt2agent/grok_paths.py
@@ -21,12 +21,17 @@ class RootPolicy:
         """Return one existing directory contained by a configured root."""
         if not self.roots:
             raise InputValidationError(_CWD_INVARIANT)
+        resolution_failed = False
+        resolved: Path | None = None
+        is_directory = False
         try:
             candidate = Path.cwd() if value is None else Path(value).expanduser()
             resolved = candidate.resolve(strict=True)
             is_directory = resolved.is_dir()
         except (OSError, RuntimeError, TypeError, ValueError):
-            raise InputValidationError(_CWD_INVARIANT) from None
+            resolution_failed = True
+        if resolution_failed or resolved is None:
+            raise InputValidationError(_CWD_INVARIANT)
         if not is_directory or not any(
             resolved == root or root in resolved.parents for root in self.roots
         ):

--- a/gpt2agent/grok_setup.py
+++ b/gpt2agent/grok_setup.py
@@ -1,0 +1,404 @@
+"""Secret-safe setup flow for independent Grok Build and website auth lanes."""
+
+from __future__ import annotations
+
+import getpass
+import json
+import math
+import os
+import re
+import secrets
+import shutil
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from ._bounded_process import (
+    BoundedProcessError,
+    ProcessResult,
+    run_bounded_process,
+)
+from ._secure_file import write_private_json
+from .errors import InputValidationError
+from .grok_build import GrokBuildClient, GrokBuildConfig
+from .grok_errors import GrokError
+from .grok_web_auth import (
+    GrokWebAuthStore,
+    browser_impersonation_by_major,
+)
+
+
+Runner = Callable[..., Awaitable[ProcessResult]]
+Resolver = Callable[[str], str | None]
+SessionFactory = Callable[[], str]
+Getpass = Callable[[str], str]
+Probe = Callable[[], Awaitable[dict[str, Any]]]
+
+_GROK_URL = "https://grok.com/"
+_BROWSER_TIMEOUT_SECONDS = 120.0
+_BROWSER_OUTPUT_BYTES = 131_072
+_MANUAL_LIFETIME_SECONDS = 30 * 24 * 60 * 60
+_SESSION_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_CHROME_UA_RE = re.compile(r"(?:^|[^A-Za-z0-9])Chrome/([0-9]{1,3})(?:\.|\s|$)")
+_IMPORTED_COOKIE_NAMES = frozenset(
+    {"sso", "sso-rw", "grok_device_id", "cf_clearance"}
+)
+_REQUIRED_COOKIE_NAMES = frozenset({"sso", "sso-rw"})
+
+
+def _error(code: str) -> GrokError:
+    return GrokError(code, retryable=False)
+
+
+def _owned_session() -> str:
+    return f"gpt2agent-grok-{secrets.token_hex(12)}"
+
+
+async def _browser_call(
+    runner: Runner,
+    argv: Sequence[str],
+) -> ProcessResult:
+    env = os.environ.copy()
+    env.pop("XAI_API_KEY", None)
+    env.pop("GROK_CODE_XAI_API_KEY", None)
+    return await runner(
+        argv,
+        cwd=Path.cwd().resolve(),
+        env=env,
+        timeout_seconds=_BROWSER_TIMEOUT_SECONDS,
+        max_output_bytes=_BROWSER_OUTPUT_BYTES,
+    )
+
+
+def _response_data(result: ProcessResult) -> dict[str, Any]:
+    if result.returncode != 0:
+        raise _error("GROK_WEB_FAILED")
+    try:
+        payload = json.loads(result.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise _error("GROK_WEB_FAILED") from None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("success") is not True
+        or not isinstance(payload.get("data"), dict)
+    ):
+        raise _error("GROK_WEB_FAILED")
+    return payload["data"]
+
+
+def _chrome_profile_from_ua(user_agent: Any) -> str | None:
+    if not isinstance(user_agent, str) or len(user_agent) > 4_096:
+        return None
+    match = _CHROME_UA_RE.search(user_agent)
+    if match is None:
+        return None
+    return browser_impersonation_by_major().get(int(match.group(1)))
+
+
+def _default_browser_profile() -> str:
+    profiles = browser_impersonation_by_major()
+    if not profiles:  # pragma: no cover - dependency contract guard
+        raise _error("GROK_WEB_FAILED")
+    return profiles[max(profiles)]
+
+
+def _normalize_expiry(value: Any) -> int | None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 1
+        or value > 2**53 - 1
+    ):
+        return None
+    converted = int(value)
+    return converted if converted > int(time.time()) else None
+
+
+def _stored_browser_cookies(
+    raw_cookies: Any,
+    *,
+    compatible_profile: str | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(raw_cookies, list) or len(raw_cookies) > 4_096:
+        raise _error("GROK_WEB_FAILED")
+    selected: dict[str, dict[str, Any]] = {}
+    for raw in raw_cookies:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("name")
+        if not isinstance(name, str) or name not in _IMPORTED_COOKIE_NAMES:
+            continue
+        if name == "cf_clearance" and compatible_profile is None:
+            continue
+        if name in selected:
+            raise _error("GROK_WEB_FAILED")
+        expires = _normalize_expiry(raw.get("expires"))
+        value = raw.get("value")
+        bounded_value = False
+        if isinstance(value, str) and value:
+            try:
+                encoded_value = value.encode("utf-8")
+            except UnicodeEncodeError:
+                pass
+            else:
+                bounded_value = len(encoded_value) <= 16_384 and all(
+                    ord(char) >= 32 and ord(char) != 127 for char in value
+                )
+        valid = not (
+            raw.get("domain") not in {"grok.com", ".grok.com"}
+            or raw.get("path") != "/"
+            or raw.get("secure") is not True
+            or raw.get("httpOnly") is not True
+            or expires is None
+            or not bounded_value
+        )
+        if not valid:
+            if name not in _REQUIRED_COOKIE_NAMES:
+                continue
+            raise _error("GROK_WEB_FAILED")
+        selected[name] = {
+            "name": name,
+            "domain": raw["domain"],
+            "path": "/",
+            "expires": expires,
+            "secure": True,
+            "http_only": True,
+            "value": value,
+        }
+    if not _REQUIRED_COOKIE_NAMES.issubset(selected):
+        raise _error("GROK_WEB_AUTH_MISSING")
+    return [selected[name] for name in sorted(selected)]
+
+
+async def import_browser_web_auth(
+    path: Path,
+    *,
+    chrome_profile: str = "Default",
+    runner: Runner = run_bounded_process,
+    resolver: Resolver = shutil.which,
+    session_factory: SessionFactory = _owned_session,
+) -> dict[str, Any]:
+    """Import only allowlisted Grok cookies from one uniquely owned session."""
+    command = resolver("browser-use")
+    if command is None:
+        raise _error("GROK_WEB_FAILED")
+    session = session_factory()
+    if not isinstance(session, str) or _SESSION_RE.fullmatch(session) is None:
+        raise _error("GROK_WEB_FAILED")
+    if (
+        not isinstance(chrome_profile, str)
+        or not chrome_profile
+        or len(chrome_profile) > 128
+        or any(ord(char) < 32 or ord(char) == 127 for char in chrome_profile)
+    ):
+        raise _error("GROK_WEB_FAILED")
+
+    base = [command, "--profile", chrome_profile, "--session", session]
+    failure: GrokError | None = None
+    final_status: dict[str, Any] | None = None
+    try:
+        opened = await _browser_call(
+            runner,
+            [
+                command,
+                "--headed",
+                "--profile",
+                chrome_profile,
+                "--session",
+                session,
+                "--json",
+                "open",
+                _GROK_URL,
+            ],
+        )
+        _response_data(opened)
+        cookie_result = await _browser_call(
+            runner,
+            [*base, "--json", "cookies", "get", "--url", _GROK_URL],
+        )
+        cookie_data = _response_data(cookie_result)
+        if not isinstance(cookie_data.get("cookies"), list):
+            raise _error("GROK_WEB_FAILED")
+        ua_result = await _browser_call(
+            runner,
+            [*base, "--json", "eval", "navigator.userAgent"],
+        )
+        user_agent = _response_data(ua_result).get("result")
+        compatible_profile = _chrome_profile_from_ua(user_agent)
+        cookies = _stored_browser_cookies(
+            cookie_data.get("cookies"),
+            compatible_profile=compatible_profile,
+        )
+        write_private_json(
+            path,
+            {
+                "schema_version": 1,
+                "source": "browser-use",
+                "browser_impersonation": compatible_profile
+                or _default_browser_profile(),
+                "cookies": cookies,
+            },
+        )
+        status = GrokWebAuthStore(path).status()
+        if status.get("authenticated") is not True:
+            failure = _error("GROK_WEB_AUTH_MISSING")
+        else:
+            final_status = status
+    except GrokError as exc:
+        failure = _error(exc.code)
+    except (BoundedProcessError, OSError, RuntimeError, ValueError):
+        failure = _error("GROK_WEB_FAILED")
+    finally:
+        try:
+            closed = await _browser_call(runner, [*base, "close"])
+            if closed.returncode != 0 and failure is None:
+                failure = _error("GROK_WEB_FAILED")
+        except (BoundedProcessError, OSError, RuntimeError, ValueError):
+            if failure is None:
+                failure = _error("GROK_WEB_FAILED")
+    if failure is not None:
+        raise failure from None
+    if final_status is None:  # pragma: no cover - control-flow guard
+        raise _error("GROK_WEB_FAILED")
+    return final_status
+
+
+def _manual_document(getpass_fn: Getpass) -> dict[str, Any]:
+    values: dict[str, str] = {}
+    failure: GrokError | None = None
+    try:
+        values["sso"] = getpass_fn("Grok sso cookie: ")
+        values["sso-rw"] = getpass_fn("Grok sso-rw cookie: ")
+    except (EOFError, KeyboardInterrupt, RuntimeError, StopIteration):
+        failure = _error("GROK_WEB_AUTH_MISSING")
+    if failure is not None:
+        raise failure from None
+    expires = int(time.time()) + _MANUAL_LIFETIME_SECONDS
+    cookies = [
+        {
+            "name": name,
+            "domain": ".grok.com",
+            "path": "/",
+            "expires": expires,
+            "secure": True,
+            "http_only": True,
+            "value": value,
+        }
+        for name, value in sorted(values.items())
+    ]
+    return {
+        "schema_version": 1,
+        "source": "manual",
+        "browser_impersonation": _default_browser_profile(),
+        "cookies": cookies,
+    }
+
+
+async def _manual_web_auth(path: Path, getpass_fn: Getpass) -> dict[str, Any]:
+    failure: GrokError | None = None
+    try:
+        write_private_json(path, _manual_document(getpass_fn))
+        status = GrokWebAuthStore(path).status()
+        if status.get("authenticated") is not True:
+            failure = _error("GROK_WEB_AUTH_MISSING")
+        else:
+            return status
+    except GrokError as exc:
+        failure = _error(exc.code)
+    except (OSError, RuntimeError, ValueError):
+        failure = _error("GROK_WEB_FAILED")
+    if failure is None:  # pragma: no cover - control-flow guard
+        failure = _error("GROK_WEB_FAILED")
+    raise failure from None
+
+
+async def setup_web_auth(
+    path: Path | None = None,
+    *,
+    manual: bool = False,
+    chrome_profile: str = "Default",
+    runner: Runner = run_bounded_process,
+    resolver: Resolver = shutil.which,
+    session_factory: SessionFactory = _owned_session,
+    getpass_fn: Getpass = getpass.getpass,
+) -> dict[str, Any]:
+    """Run browser-assisted setup, or hidden manual input when unavailable."""
+    auth_path = path or Path.home() / ".gpt2agent" / "grok-web-auth.json"
+    if manual:
+        return await _manual_web_auth(auth_path, getpass_fn)
+    command = resolver("browser-use")
+    if command is None:
+        return await _manual_web_auth(auth_path, getpass_fn)
+    return await import_browser_web_auth(
+        auth_path,
+        chrome_profile=chrome_profile,
+        runner=runner,
+        resolver=lambda _: command,
+        session_factory=session_factory,
+    )
+
+
+def _lane_success() -> dict[str, str]:
+    return {"status": "ok", "code": "OK"}
+
+
+def _lane_failure(code: str) -> dict[str, str]:
+    return {"status": "failed", "code": code}
+
+
+async def run_grok_setup(
+    *,
+    refresh: bool = False,
+    chrome_profile: str = "Default",
+    manual: bool = False,
+    auth_path: Path | None = None,
+    build_probe: Probe | None = None,
+    web_setup: Probe | None = None,
+) -> dict[str, Any]:
+    """Attempt Build and website setup independently and return a bounded receipt."""
+    del refresh  # The setup command always imports current auth; refresh is explicit intent.
+    if build_probe is None:
+        build_client = GrokBuildClient(
+            GrokBuildConfig.from_mapping({"roots": [str(Path.cwd())]})
+        )
+        build_probe = build_client.status
+    if web_setup is None:
+
+        async def default_web_setup() -> dict[str, Any]:
+            return await setup_web_auth(
+                auth_path,
+                manual=manual,
+                chrome_profile=chrome_profile,
+            )
+
+        web_setup = default_web_setup
+
+    try:
+        build_status = await build_probe()
+        if build_status.get("installed") is not True:
+            build = _lane_failure("GROK_BUILD_CLI_NOT_FOUND")
+        elif build_status.get("authenticated") is not True:
+            build = _lane_failure("GROK_BUILD_AUTH_MISSING")
+        else:
+            build = _lane_success()
+    except GrokError as exc:
+        build = _lane_failure(exc.code)
+    except InputValidationError:
+        build = _lane_failure("GROK_BUILD_FAILED")
+
+    try:
+        web_status = await web_setup()
+        if web_status.get("authenticated") is True:
+            web = _lane_success()
+        else:
+            web = _lane_failure("GROK_WEB_AUTH_MISSING")
+    except GrokError as exc:
+        web = _lane_failure(exc.code)
+    except InputValidationError:
+        web = _lane_failure("GROK_WEB_FAILED")
+
+    successes = sum(lane["status"] == "ok" for lane in (build, web))
+    status = "ok" if successes == 2 else "partial" if successes == 1 else "failed"
+    return {"status": status, "build": build, "web": web}

--- a/gpt2agent/grok_setup.py
+++ b/gpt2agent/grok_setup.py
@@ -26,6 +26,7 @@ from .grok_errors import GrokError
 from .grok_web_auth import (
     GrokWebAuthStore,
     browser_impersonation_by_major,
+    validate_grok_web_auth_document,
 )
 
 
@@ -231,16 +232,15 @@ async def import_browser_web_auth(
             cookie_data.get("cookies"),
             compatible_profile=compatible_profile,
         )
-        write_private_json(
-            path,
-            {
-                "schema_version": 1,
-                "source": "browser-use",
-                "browser_impersonation": compatible_profile
-                or _default_browser_profile(),
-                "cookies": cookies,
-            },
-        )
+        document = {
+            "schema_version": 1,
+            "source": "browser-use",
+            "browser_impersonation": compatible_profile
+            or _default_browser_profile(),
+            "cookies": cookies,
+        }
+        validate_grok_web_auth_document(document)
+        write_private_json(path, document)
         status = GrokWebAuthStore(path).status()
         if status.get("authenticated") is not True:
             failure = _error("GROK_WEB_AUTH_MISSING")
@@ -299,7 +299,9 @@ def _manual_document(getpass_fn: Getpass) -> dict[str, Any]:
 async def _manual_web_auth(path: Path, getpass_fn: Getpass) -> dict[str, Any]:
     failure: GrokError | None = None
     try:
-        write_private_json(path, _manual_document(getpass_fn))
+        document = _manual_document(getpass_fn)
+        validate_grok_web_auth_document(document)
+        write_private_json(path, document)
         status = GrokWebAuthStore(path).status()
         if status.get("authenticated") is not True:
             failure = _error("GROK_WEB_AUTH_MISSING")

--- a/gpt2agent/grok_upload.py
+++ b/gpt2agent/grok_upload.py
@@ -12,6 +12,7 @@ import stat
 from collections import OrderedDict
 from collections.abc import Sequence, Set
 from dataclasses import dataclass
+from itertools import islice
 from pathlib import Path
 from typing import AbstractSet, Any
 
@@ -44,6 +45,9 @@ _SUFFIX_MEDIA_TYPES = {
     ".webp": "image/webp",
 }
 _MAX_PATH_BYTES = 4_096
+_MAX_PATH_CHARS = 4_096
+_MAX_COMPONENT_CHARS = 255
+_MAX_COMPONENT_BYTES = 255
 _READ_CHUNK_BYTES = 64 * 1024
 _REGISTRY_CAPACITY = 256
 _MAX_ATTACHMENTS_PER_REQUEST = 20
@@ -95,24 +99,48 @@ def _validated_root_parts(roots: Sequence[Path]) -> tuple[tuple[str, ...], ...]:
         if not isinstance(root, Path) or not root.is_absolute():
             raise _blocked()
         raw = os.fspath(root)
-        if "\x00" in raw or len(os.fsencode(raw)) > _MAX_PATH_BYTES:
+        if len(raw) > _MAX_PATH_CHARS or "\x00" in raw:
             raise _blocked()
         parts = root.parts
         if not parts or parts[0] != os.sep or any(part in {"", ".", ".."} for part in parts[1:]):
+            raise _blocked()
+        for component in parts[1:]:
+            _validate_component_characters(component)
+        for component in parts[1:]:
+            _validate_component_bytes(component)
+        if len(os.fsencode(raw)) > _MAX_PATH_BYTES:
             raise _blocked()
         normalized.append(tuple(parts[1:]))
     return tuple(sorted(set(normalized), key=len, reverse=True))
 
 
-def _validated_target_parts(path: Any) -> tuple[str, ...]:
-    if not isinstance(path, str) or not path.strip() or "\x00" in path:
+def _validate_component_characters(component: str) -> None:
+    if len(component) > _MAX_COMPONENT_CHARS or not component.isprintable():
         raise _blocked()
-    if len(os.fsencode(path)) > _MAX_PATH_BYTES or not path.startswith(os.sep):
+
+
+def _validate_component_bytes(component: str) -> None:
+    if len(os.fsencode(component)) > _MAX_COMPONENT_BYTES:
+        raise _blocked()
+
+
+def _validated_target_parts(path: Any) -> tuple[str, ...]:
+    if not isinstance(path, str) or len(path) > _MAX_PATH_CHARS:
+        raise _blocked()
+    if not path.strip() or "\x00" in path:
+        raise _blocked()
+    if not path.startswith(os.sep):
         raise _blocked()
     if path.startswith(os.sep * 2):
         raise _blocked()
     components = path.split(os.sep)
     if any(component in {"", ".", ".."} for component in components[1:]):
+        raise _blocked()
+    for component in components[1:]:
+        _validate_component_characters(component)
+    for component in components[1:]:
+        _validate_component_bytes(component)
+    if len(os.fsencode(path)) > _MAX_PATH_BYTES:
         raise _blocked()
     return tuple(components[1:])
 
@@ -190,6 +218,48 @@ def _validate_descriptor(fd: int, maximum_bytes: int) -> int:
     return total
 
 
+def _validated_policy_configuration(
+    roots: Sequence[Path], maximum_bytes: int, allowed_types: AbstractSet[str]
+) -> tuple[tuple[tuple[str, ...], ...], int, frozenset[str]]:
+    if (
+        isinstance(maximum_bytes, bool)
+        or not isinstance(maximum_bytes, int)
+        or not 1 <= maximum_bytes <= DEFAULT_UPLOAD_MAX_BYTES
+    ):
+        raise _blocked()
+    if not isinstance(allowed_types, Set):
+        raise _blocked()
+    normalized_types = frozenset(allowed_types)
+    if (
+        not all(isinstance(value, str) for value in normalized_types)
+        or not normalized_types <= DEFAULT_UPLOAD_TYPES
+    ):
+        raise _blocked()
+    return _validated_root_parts(roots), maximum_bytes, normalized_types
+
+
+def _open_validated_upload(
+    roots: tuple[tuple[str, ...], ...],
+    maximum_bytes: int,
+    allowed_types: frozenset[str],
+    path: str,
+) -> ValidatedUpload:
+    target = _validated_target_parts(path)
+    root, relative = _relative_to_configured_root(target, roots)
+    name = relative[-1]
+    media_type = _media_type_for_name(name, allowed_types)
+    fd = _open_descriptor_relative(root, relative)
+    keep_fd = False
+    try:
+        size = _validate_descriptor(fd, maximum_bytes)
+        result = ValidatedUpload(fd=fd, name=name, media_type=media_type, size=size)
+        keep_fd = True
+        return result
+    finally:
+        if not keep_fd:
+            _close_quietly(fd)
+
+
 class GrokUploadPolicy:
     def __init__(
         self,
@@ -198,57 +268,41 @@ class GrokUploadPolicy:
         maximum_bytes: int = DEFAULT_UPLOAD_MAX_BYTES,
         allowed_types: AbstractSet[str] = DEFAULT_UPLOAD_TYPES,
     ) -> None:
-        failure: GrokError | None = None
-        normalized_roots: tuple[tuple[str, ...], ...] = ()
-        normalized_types: frozenset[str] = frozenset()
+        failed = False
+        configuration: tuple[tuple[tuple[str, ...], ...], int, frozenset[str]] | None = None
         try:
-            if (
-                isinstance(maximum_bytes, bool)
-                or not isinstance(maximum_bytes, int)
-                or not 1 <= maximum_bytes <= DEFAULT_UPLOAD_MAX_BYTES
-            ):
-                raise _blocked()
-            if not isinstance(allowed_types, Set):
-                raise _blocked()
-            normalized_types = frozenset(allowed_types)
-            if (
-                not all(isinstance(value, str) for value in normalized_types)
-                or not normalized_types <= DEFAULT_UPLOAD_TYPES
-            ):
-                raise _blocked()
-            normalized_roots = _validated_root_parts(roots)
+            configuration = _validated_policy_configuration(
+                roots, maximum_bytes, allowed_types
+            )
         except Exception:
-            failure = _blocked()
-        if failure is not None:
-            raise failure
+            failed = True
+        roots = ()
+        maximum_bytes = 0
+        allowed_types = frozenset()
+        if failed or configuration is None:
+            configuration = None
+            self = None  # type: ignore[assignment]
+            raise _blocked()
 
-        self._roots = normalized_roots
-        self._maximum_bytes = maximum_bytes
-        self._allowed_types = normalized_types
+        self._roots, self._maximum_bytes, self._allowed_types = configuration
 
     def open(self, path: str) -> ValidatedUpload:
         """Open one root-contained file; the caller owns the returned descriptor."""
-        failure: GrokError | None = None
+        failed = False
         result: ValidatedUpload | None = None
         try:
-            target = _validated_target_parts(path)
-            root, relative = _relative_to_configured_root(target, self._roots)
-            name = relative[-1]
-            media_type = _media_type_for_name(name, self._allowed_types)
-            fd = _open_descriptor_relative(root, relative)
-            keep_fd = False
-            try:
-                size = _validate_descriptor(fd, self._maximum_bytes)
-                result = ValidatedUpload(fd=fd, name=name, media_type=media_type, size=size)
-                keep_fd = True
-            finally:
-                if not keep_fd:
-                    _close_quietly(fd)
+            result = _open_validated_upload(
+                self._roots,
+                self._maximum_bytes,
+                self._allowed_types,
+                path,
+            )
         except Exception:
-            failure = _blocked()
-        if failure is not None:
-            raise failure
-        if result is None:  # pragma: no cover - defensive control-flow guard
+            failed = True
+        path = ""
+        if failed or result is None:
+            result = None
+            self = None  # type: ignore[assignment]
             raise _blocked()
         return result
 
@@ -265,53 +319,73 @@ def _validated_attachment_id(value: Any) -> str:
     return value
 
 
+def _record_attachment(
+    registry: AttachmentRegistry, auth_generation: int, attachment_id: str
+) -> None:
+    generation = _validated_generation(auth_generation)
+    identifier = _validated_attachment_id(attachment_id)
+    if registry._generation != generation:
+        if registry._generation is not None and generation < registry._generation:
+            raise _blocked()
+        registry._entries.clear()
+        registry._generation = generation
+    if identifier not in registry._entries:
+        registry._entries[identifier] = None
+        if len(registry._entries) > _REGISTRY_CAPACITY:
+            registry._entries.popitem(last=False)
+
+
+def _validated_attachments(
+    registry: AttachmentRegistry,
+    auth_generation: int,
+    attachment_ids: Sequence[str],
+) -> tuple[str, ...]:
+    generation = _validated_generation(auth_generation)
+    if isinstance(attachment_ids, (str, bytes, bytearray)) or not isinstance(
+        attachment_ids, Sequence
+    ):
+        raise _blocked()
+    values = tuple(islice(iter(attachment_ids), _MAX_ATTACHMENTS_PER_REQUEST + 1))
+    if len(values) > _MAX_ATTACHMENTS_PER_REQUEST:
+        raise _blocked()
+    values = tuple(_validated_attachment_id(value) for value in values)
+    if values and registry._generation != generation:
+        raise _blocked()
+    if len(set(values)) != len(values) or any(value not in registry._entries for value in values):
+        raise _blocked()
+    return values
+
+
 class AttachmentRegistry:
     def __init__(self) -> None:
         self._generation: int | None = None
         self._entries: OrderedDict[str, None] = OrderedDict()
 
     def record(self, auth_generation: int, attachment_id: str) -> None:
-        failure: GrokError | None = None
+        failed = False
         try:
-            generation = _validated_generation(auth_generation)
-            identifier = _validated_attachment_id(attachment_id)
-            if self._generation != generation:
-                if self._generation is not None and generation < self._generation:
-                    raise _blocked()
-                self._entries.clear()
-                self._generation = generation
-            if identifier not in self._entries:
-                self._entries[identifier] = None
-                if len(self._entries) > _REGISTRY_CAPACITY:
-                    self._entries.popitem(last=False)
+            _record_attachment(self, auth_generation, attachment_id)
         except Exception:
-            failure = _blocked()
-        if failure is not None:
-            raise failure
+            failed = True
+        auth_generation = 0
+        attachment_id = ""
+        if failed:
+            self = None  # type: ignore[assignment]
+            raise _blocked()
 
     def validate_many(
         self, auth_generation: int, attachment_ids: Sequence[str]
     ) -> tuple[str, ...]:
-        failure: GrokError | None = None
+        failed = False
         result: tuple[str, ...] | None = None
         try:
-            generation = _validated_generation(auth_generation)
-            if (
-                isinstance(attachment_ids, (str, bytes, bytearray))
-                or not isinstance(attachment_ids, Sequence)
-                or len(attachment_ids) > _MAX_ATTACHMENTS_PER_REQUEST
-            ):
-                raise _blocked()
-            values = tuple(_validated_attachment_id(value) for value in attachment_ids)
-            if values and self._generation != generation:
-                raise _blocked()
-            if len(set(values)) != len(values) or any(value not in self._entries for value in values):
-                raise _blocked()
-            result = values
+            result = _validated_attachments(self, auth_generation, attachment_ids)
         except Exception:
-            failure = _blocked()
-        if failure is not None:
-            raise failure
-        if result is None:  # pragma: no cover - defensive control-flow guard
+            failed = True
+        auth_generation = 0
+        attachment_ids = ()
+        if failed or result is None:
+            result = None
+            self = None  # type: ignore[assignment]
             raise _blocked()
         return result

--- a/gpt2agent/grok_upload.py
+++ b/gpt2agent/grok_upload.py
@@ -1,0 +1,317 @@
+"""Descriptor-safe local upload policy for Grok website attachments.
+
+``GrokUploadPolicy.open`` transfers ownership of the returned descriptor to its
+caller.  The caller must close ``ValidatedUpload.fd`` after the upload attempt.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from collections import OrderedDict
+from collections.abc import Sequence, Set
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AbstractSet, Any
+
+from .grok_errors import GrokError
+
+
+DEFAULT_UPLOAD_TYPES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "application/pdf",
+        "application/json",
+        "text/csv",
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+    }
+)
+DEFAULT_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
+
+_SUFFIX_MEDIA_TYPES = {
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".pdf": "application/pdf",
+    ".json": "application/json",
+    ".csv": "text/csv",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+}
+_MAX_PATH_BYTES = 4_096
+_READ_CHUNK_BYTES = 64 * 1024
+_REGISTRY_CAPACITY = 256
+_MAX_ATTACHMENTS_PER_REQUEST = 20
+_ATTACHMENT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+_OPEN_SUPPORTS_DIR_FD = os.open in os.supports_dir_fd
+
+
+@dataclass(frozen=True)
+class ValidatedUpload:
+    fd: int
+    name: str
+    media_type: str
+    size: int
+
+
+def _blocked() -> GrokError:
+    return GrokError("GROK_UPLOAD_BLOCKED", retryable=False)
+
+
+def _close_quietly(fd: int | None) -> None:
+    if fd is None:
+        return
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _required_open_flags() -> tuple[int, int]:
+    if (
+        os.name != "posix"
+        or not _OPEN_SUPPORTS_DIR_FD
+        or not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+        or not hasattr(os, "O_CLOEXEC")
+        or not hasattr(os, "O_NONBLOCK")
+    ):
+        raise _blocked()
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    leaf_flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+    return directory_flags, leaf_flags
+
+
+def _validated_root_parts(roots: Sequence[Path]) -> tuple[tuple[str, ...], ...]:
+    if isinstance(roots, (str, bytes, bytearray)) or not isinstance(roots, Sequence):
+        raise _blocked()
+    normalized: list[tuple[str, ...]] = []
+    for root in roots:
+        if not isinstance(root, Path) or not root.is_absolute():
+            raise _blocked()
+        raw = os.fspath(root)
+        if "\x00" in raw or len(os.fsencode(raw)) > _MAX_PATH_BYTES:
+            raise _blocked()
+        parts = root.parts
+        if not parts or parts[0] != os.sep or any(part in {"", ".", ".."} for part in parts[1:]):
+            raise _blocked()
+        normalized.append(tuple(parts[1:]))
+    return tuple(sorted(set(normalized), key=len, reverse=True))
+
+
+def _validated_target_parts(path: Any) -> tuple[str, ...]:
+    if not isinstance(path, str) or not path.strip() or "\x00" in path:
+        raise _blocked()
+    if len(os.fsencode(path)) > _MAX_PATH_BYTES or not path.startswith(os.sep):
+        raise _blocked()
+    if path.startswith(os.sep * 2):
+        raise _blocked()
+    components = path.split(os.sep)
+    if any(component in {"", ".", ".."} for component in components[1:]):
+        raise _blocked()
+    return tuple(components[1:])
+
+
+def _relative_to_configured_root(
+    target: tuple[str, ...], roots: tuple[tuple[str, ...], ...]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    for root in roots:
+        if len(target) > len(root) and target[: len(root)] == root:
+            return root, target[len(root) :]
+    raise _blocked()
+
+
+def _media_type_for_name(name: str, allowed_types: frozenset[str]) -> str:
+    suffixes = Path(name).suffixes
+    if len(suffixes) != 1:
+        raise _blocked()
+    media_type = _SUFFIX_MEDIA_TYPES.get(suffixes[0].lower())
+    if media_type is None or media_type not in allowed_types:
+        raise _blocked()
+    return media_type
+
+
+def _open_descriptor_relative(
+    root: tuple[str, ...], relative: tuple[str, ...]
+) -> int:
+    directory_flags, leaf_flags = _required_open_flags()
+    directory_fd: int | None = None
+    try:
+        directory_fd = os.open(os.sep, directory_flags)
+        for component in (*root, *relative[:-1]):
+            next_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+            previous_fd = directory_fd
+            directory_fd = next_fd
+            _close_quietly(previous_fd)
+        return os.open(relative[-1], leaf_flags, dir_fd=directory_fd)
+    finally:
+        _close_quietly(directory_fd)
+
+
+def _metadata_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        stat.S_IFMT(metadata.st_mode),
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _validate_descriptor(fd: int, maximum_bytes: int) -> int:
+    before = os.fstat(fd)
+    if not stat.S_ISREG(before.st_mode):
+        raise _blocked()
+
+    total = 0
+    limit = maximum_bytes + 1
+    while total < limit:
+        chunk = os.read(fd, min(_READ_CHUNK_BYTES, limit - total))
+        if not chunk:
+            break
+        total += len(chunk)
+
+    after = os.fstat(fd)
+    if (
+        _metadata_identity(before) != _metadata_identity(after)
+        or total != before.st_size
+        or total == 0
+        or total > maximum_bytes
+    ):
+        raise _blocked()
+    if os.lseek(fd, 0, os.SEEK_SET) != 0:
+        raise _blocked()
+    return total
+
+
+class GrokUploadPolicy:
+    def __init__(
+        self,
+        roots: Sequence[Path],
+        *,
+        maximum_bytes: int = DEFAULT_UPLOAD_MAX_BYTES,
+        allowed_types: AbstractSet[str] = DEFAULT_UPLOAD_TYPES,
+    ) -> None:
+        failure: GrokError | None = None
+        normalized_roots: tuple[tuple[str, ...], ...] = ()
+        normalized_types: frozenset[str] = frozenset()
+        try:
+            if (
+                isinstance(maximum_bytes, bool)
+                or not isinstance(maximum_bytes, int)
+                or not 1 <= maximum_bytes <= DEFAULT_UPLOAD_MAX_BYTES
+            ):
+                raise _blocked()
+            if not isinstance(allowed_types, Set):
+                raise _blocked()
+            normalized_types = frozenset(allowed_types)
+            if (
+                not all(isinstance(value, str) for value in normalized_types)
+                or not normalized_types <= DEFAULT_UPLOAD_TYPES
+            ):
+                raise _blocked()
+            normalized_roots = _validated_root_parts(roots)
+        except Exception:
+            failure = _blocked()
+        if failure is not None:
+            raise failure
+
+        self._roots = normalized_roots
+        self._maximum_bytes = maximum_bytes
+        self._allowed_types = normalized_types
+
+    def open(self, path: str) -> ValidatedUpload:
+        """Open one root-contained file; the caller owns the returned descriptor."""
+        failure: GrokError | None = None
+        result: ValidatedUpload | None = None
+        try:
+            target = _validated_target_parts(path)
+            root, relative = _relative_to_configured_root(target, self._roots)
+            name = relative[-1]
+            media_type = _media_type_for_name(name, self._allowed_types)
+            fd = _open_descriptor_relative(root, relative)
+            keep_fd = False
+            try:
+                size = _validate_descriptor(fd, self._maximum_bytes)
+                result = ValidatedUpload(fd=fd, name=name, media_type=media_type, size=size)
+                keep_fd = True
+            finally:
+                if not keep_fd:
+                    _close_quietly(fd)
+        except Exception:
+            failure = _blocked()
+        if failure is not None:
+            raise failure
+        if result is None:  # pragma: no cover - defensive control-flow guard
+            raise _blocked()
+        return result
+
+
+def _validated_generation(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise _blocked()
+    return value
+
+
+def _validated_attachment_id(value: Any) -> str:
+    if not isinstance(value, str) or _ATTACHMENT_ID_RE.fullmatch(value) is None:
+        raise _blocked()
+    return value
+
+
+class AttachmentRegistry:
+    def __init__(self) -> None:
+        self._generation: int | None = None
+        self._entries: OrderedDict[str, None] = OrderedDict()
+
+    def record(self, auth_generation: int, attachment_id: str) -> None:
+        failure: GrokError | None = None
+        try:
+            generation = _validated_generation(auth_generation)
+            identifier = _validated_attachment_id(attachment_id)
+            if self._generation != generation:
+                if self._generation is not None and generation < self._generation:
+                    raise _blocked()
+                self._entries.clear()
+                self._generation = generation
+            if identifier not in self._entries:
+                self._entries[identifier] = None
+                if len(self._entries) > _REGISTRY_CAPACITY:
+                    self._entries.popitem(last=False)
+        except Exception:
+            failure = _blocked()
+        if failure is not None:
+            raise failure
+
+    def validate_many(
+        self, auth_generation: int, attachment_ids: Sequence[str]
+    ) -> tuple[str, ...]:
+        failure: GrokError | None = None
+        result: tuple[str, ...] | None = None
+        try:
+            generation = _validated_generation(auth_generation)
+            if (
+                isinstance(attachment_ids, (str, bytes, bytearray))
+                or not isinstance(attachment_ids, Sequence)
+                or len(attachment_ids) > _MAX_ATTACHMENTS_PER_REQUEST
+            ):
+                raise _blocked()
+            values = tuple(_validated_attachment_id(value) for value in attachment_ids)
+            if values and self._generation != generation:
+                raise _blocked()
+            if len(set(values)) != len(values) or any(value not in self._entries for value in values):
+                raise _blocked()
+            result = values
+        except Exception:
+            failure = _blocked()
+        if failure is not None:
+            raise failure
+        if result is None:  # pragma: no cover - defensive control-flow guard
+            raise _blocked()
+        return result

--- a/gpt2agent/grok_web_auth.py
+++ b/gpt2agent/grok_web_auth.py
@@ -1,0 +1,211 @@
+"""Private, reloadable Grok website authentication storage."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from curl_cffi.requests.impersonate import BrowserType
+
+from ._secure_file import read_private_json
+from .grok_errors import GrokError
+
+
+_PROFILE_RE = re.compile(r"^chrome[0-9]+$")
+_COOKIE_NAMES = frozenset({"sso", "sso-rw", "grok_device_id", "cf_clearance"})
+_REQUIRED_COOKIE_NAMES = frozenset({"sso", "sso-rw"})
+_ROOT_FIELDS = frozenset(
+    {"schema_version", "source", "browser_impersonation", "cookies"}
+)
+_COOKIE_FIELDS = frozenset(
+    {"name", "domain", "path", "expires", "secure", "http_only", "value"}
+)
+_MAX_COOKIE_VALUE_BYTES = 16_384
+_MAX_AUTH_BYTES = 131_072
+_MAX_LOAD_ATTEMPTS = 3
+
+
+def supported_browser_impersonations() -> frozenset[str]:
+    """Return exact desktop Chrome profiles exposed by curl-cffi."""
+    return frozenset(
+        item.value
+        for item in BrowserType
+        if isinstance(item.value, str) and _PROFILE_RE.fullmatch(item.value)
+    )
+
+
+def browser_impersonation_by_major() -> Mapping[int, str]:
+    """Map each exact supported desktop Chrome major to its enum value."""
+    return MappingProxyType(
+        {
+            int(profile.removeprefix("chrome")): profile
+            for profile in supported_browser_impersonations()
+        }
+    )
+
+
+def _error(code: str) -> GrokError:
+    return GrokError(code, retryable=False)
+
+
+@dataclass(frozen=True)
+class GrokWebAuthSnapshot:
+    generation: int
+    cookies: Mapping[str, str]
+    browser_impersonation: str
+
+
+@dataclass(frozen=True)
+class _LoadedAuth:
+    fingerprint: tuple[int, int, int, int]
+    snapshot: GrokWebAuthSnapshot
+    expires_at: int
+
+
+def _fingerprint(path: Path) -> tuple[int, int, int, int]:
+    observed = path.lstat()
+    return (
+        observed.st_dev,
+        observed.st_ino,
+        observed.st_size,
+        observed.st_mtime_ns,
+    )
+
+
+def _bounded_cookie_value(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return (
+        len(encoded) <= _MAX_COOKIE_VALUE_BYTES
+        and all(ord(char) >= 32 and ord(char) != 127 for char in value)
+    )
+
+
+def _validate_payload(payload: Any, *, now: int) -> tuple[dict[str, str], str, int]:
+    if not isinstance(payload, dict) or frozenset(payload) != _ROOT_FIELDS:
+        raise _error("GROK_WEB_AUTH_MISSING")
+    if payload.get("schema_version") != 1 or payload.get("source") not in {
+        "browser-use",
+        "manual",
+    }:
+        raise _error("GROK_WEB_AUTH_MISSING")
+
+    profile = payload.get("browser_impersonation")
+    if not isinstance(profile, str) or profile not in supported_browser_impersonations():
+        raise _error("GROK_WEB_AUTH_MISSING")
+
+    raw_cookies = payload.get("cookies")
+    if not isinstance(raw_cookies, list) or not 2 <= len(raw_cookies) <= len(
+        _COOKIE_NAMES
+    ):
+        raise _error("GROK_WEB_AUTH_MISSING")
+
+    cookies: dict[str, str] = {}
+    expirations: list[int] = []
+    for raw_cookie in raw_cookies:
+        if not isinstance(raw_cookie, dict) or frozenset(raw_cookie) != _COOKIE_FIELDS:
+            raise _error("GROK_WEB_AUTH_MISSING")
+        name = raw_cookie.get("name")
+        expires = raw_cookie.get("expires")
+        if (
+            not isinstance(name, str)
+            or name not in _COOKIE_NAMES
+            or name in cookies
+            or raw_cookie.get("domain") not in {"grok.com", ".grok.com"}
+            or raw_cookie.get("path") != "/"
+            or raw_cookie.get("secure") is not True
+            or raw_cookie.get("http_only") is not True
+            or isinstance(expires, bool)
+            or not isinstance(expires, int)
+            or not 1 <= expires <= 2**53 - 1
+            or not _bounded_cookie_value(raw_cookie.get("value"))
+        ):
+            raise _error("GROK_WEB_AUTH_MISSING")
+        if expires <= now:
+            raise _error("GROK_WEB_AUTH_EXPIRED")
+        cookies[name] = raw_cookie["value"]
+        expirations.append(expires)
+
+    if not _REQUIRED_COOKIE_NAMES.issubset(cookies):
+        raise _error("GROK_WEB_AUTH_MISSING")
+    return cookies, profile, min(expirations)
+
+
+class GrokWebAuthStore:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or Path.home() / ".gpt2agent" / "grok-web-auth.json"
+        self._loaded: _LoadedAuth | None = None
+
+    @property
+    def auth_generation(self) -> int:
+        return self.snapshot().generation
+
+    def _load(self) -> _LoadedAuth:
+        failure: GrokError | None = None
+        for _ in range(_MAX_LOAD_ATTEMPTS):
+            try:
+                before = _fingerprint(self.path)
+                if self._loaded is not None and self._loaded.fingerprint == before:
+                    if self._loaded.expires_at <= int(time.time()):
+                        raise _error("GROK_WEB_AUTH_EXPIRED")
+                    return self._loaded
+                payload = read_private_json(self.path, maximum_bytes=_MAX_AUTH_BYTES)
+                after = _fingerprint(self.path)
+            except GrokError as exc:
+                failure = _error(exc.code)
+                break
+            except (OSError, RuntimeError, ValueError):
+                failure = _error("GROK_WEB_AUTH_MISSING")
+                break
+            if before != after:
+                continue
+            try:
+                cookies, profile, expires_at = _validate_payload(
+                    payload,
+                    now=int(time.time()),
+                )
+            except GrokError as exc:
+                failure = _error(exc.code)
+                break
+            generation = 0 if self._loaded is None else self._loaded.snapshot.generation + 1
+            snapshot = GrokWebAuthSnapshot(
+                generation=generation,
+                cookies=MappingProxyType(dict(cookies)),
+                browser_impersonation=profile,
+            )
+            self._loaded = _LoadedAuth(after, snapshot, expires_at)
+            return self._loaded
+        if failure is None:
+            failure = _error("GROK_WEB_AUTH_MISSING")
+        raise failure from None
+
+    def snapshot(self) -> GrokWebAuthSnapshot:
+        """Return immutable cookies plus one validated impersonation profile."""
+        return self._load().snapshot
+
+    def status(self) -> dict[str, Any]:
+        """Return configured/authenticated/expires_at/cookie_names only."""
+        try:
+            loaded = self._load()
+        except GrokError:
+            return {
+                "configured": self.path.is_file(),
+                "authenticated": False,
+                "expires_at": None,
+                "cookie_names": [],
+            }
+        return {
+            "configured": True,
+            "authenticated": True,
+            "expires_at": loaded.expires_at,
+            "cookie_names": sorted(loaded.snapshot.cookies),
+        }

--- a/gpt2agent/grok_web_auth.py
+++ b/gpt2agent/grok_web_auth.py
@@ -78,7 +78,7 @@ def _fingerprint(path: Path) -> tuple[int, int, int, int]:
 
 
 def _bounded_cookie_value(value: Any) -> bool:
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str) or not value.strip():
         return False
     try:
         encoded = value.encode("utf-8")
@@ -90,7 +90,13 @@ def _bounded_cookie_value(value: Any) -> bool:
     )
 
 
-def _validate_payload(payload: Any, *, now: int) -> tuple[dict[str, str], str, int]:
+def validate_grok_web_auth_document(
+    payload: Any,
+    *,
+    now: int | None = None,
+) -> tuple[dict[str, str], str, int]:
+    """Validate one complete closed auth document without reading or writing."""
+    current_time = int(time.time()) if now is None else now
     if not isinstance(payload, dict) or frozenset(payload) != _ROOT_FIELDS:
         raise _error("GROK_WEB_AUTH_MISSING")
     if payload.get("schema_version") != 1 or payload.get("source") not in {
@@ -130,7 +136,7 @@ def _validate_payload(payload: Any, *, now: int) -> tuple[dict[str, str], str, i
             or not _bounded_cookie_value(raw_cookie.get("value"))
         ):
             raise _error("GROK_WEB_AUTH_MISSING")
-        if expires <= now:
+        if expires <= current_time:
             raise _error("GROK_WEB_AUTH_EXPIRED")
         cookies[name] = raw_cookie["value"]
         expirations.append(expires)
@@ -169,7 +175,7 @@ class GrokWebAuthStore:
             if before != after:
                 continue
             try:
-                cookies, profile, expires_at = _validate_payload(
+                cookies, profile, expires_at = validate_grok_web_auth_document(
                     payload,
                     now=int(time.time()),
                 )

--- a/gpt2agent/install.py
+++ b/gpt2agent/install.py
@@ -713,7 +713,7 @@ def install_claude_skill(
     The deep-research skill calls gpt2agent's ConversationClient directly
     (bypasses MCP) so it works even before restarting Claude Code.
     The gpt2agent skill provides full account access instructions and
-    pre-approves all 32 MCP tools.
+    pre-approves all registered MCP tools.
 
     The historical top-level result describes the final skill; ``skills``
     reports every attempted bundle without breaking existing callers.

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -370,12 +370,16 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         raise ValueError("server.host must be a loopback address")
 
     from gpt2agent.backend import BackendClient
+    from gpt2agent.grok_build import GrokBuildClient, GrokBuildConfig
     from gpt2agent.model_catalog import ModelCatalog
     from gpt2agent.sse import ConversationClient
 
     _backend = BackendClient()
     model_catalog = ModelCatalog(_backend)
     conv = ConversationClient(_backend)
+    grok_build_client = GrokBuildClient(
+        GrokBuildConfig.from_mapping(cfg.get("grok_build", {}))
+    )
 
     mcp = FastMCP(
         "gpt2agent",
@@ -570,7 +574,13 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
     from gpt2agent.tools import register_all
 
-    register_all(mcp, _backend, conv, model_catalog=model_catalog)
+    register_all(
+        mcp,
+        _backend,
+        conv,
+        model_catalog=model_catalog,
+        grok_build_client=grok_build_client,
+    )
 
     return mcp
 

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -593,6 +593,26 @@ def main() -> None:
     # setup subcommand
     sub.add_parser("setup", help="First-time setup wizard (login + register)")
 
+    grok_setup_p = sub.add_parser(
+        "grok-setup",
+        help="Configure independent Grok Build and website authentication",
+    )
+    grok_setup_p.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Refresh the stored website authentication",
+    )
+    grok_setup_p.add_argument(
+        "--chrome-profile",
+        default="Default",
+        help="Chrome profile selected for browser-assisted website setup",
+    )
+    grok_setup_p.add_argument(
+        "--manual",
+        action="store_true",
+        help="Use hidden manual cookie input instead of browser assistance",
+    )
+
     # install subcommand — register gpt2agent with one or more MCP clients
     from gpt2agent.install import SUPPORTED_CLIENTS
 
@@ -666,6 +686,22 @@ def main() -> None:
 
         run_setup()
         return
+
+    if args.command == "grok-setup":
+        import asyncio
+        import json
+
+        from gpt2agent.grok_setup import run_grok_setup
+
+        receipt = asyncio.run(
+            run_grok_setup(
+                refresh=args.refresh,
+                chrome_profile=args.chrome_profile,
+                manual=args.manual,
+            )
+        )
+        print(json.dumps(receipt, sort_keys=True))
+        raise SystemExit(0 if receipt["status"] == "ok" else 1)
 
     if args.command == "install":
         from gpt2agent.install import run_install

--- a/gpt2agent/skills/gpt2agent/SKILL.md
+++ b/gpt2agent/skills/gpt2agent/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gpt2agent
 description: |
-  ChatGPT Plus/Pro account access via 32 MCP tools and 2 static resources covering chat,
+  ChatGPT Plus/Pro account access plus an independent official Grok Build CLI
+  lane via all registered MCP tools and 2 static resources covering chat,
   agent mode, deep research, image generation, code execution, canvas,
   memory, custom instructions, conversations, Custom GPTs, Codex, Apps,
   Plugins, Work models, automations, Sites, and capability truth.
@@ -45,6 +46,9 @@ allowed-tools:
   - mcp__gpt2agent__sites_access
   - mcp__gpt2agent__list_sites
   - mcp__gpt2agent__account_capabilities
+  - mcp__gpt2agent__grok_build_agent
+  - mcp__gpt2agent__grok_build_models
+  - mcp__gpt2agent__grok_build_status
 ---
 
 # gpt2agent — ChatGPT Account Access via MCP
@@ -85,6 +89,7 @@ If any precondition fails, stop and tell the user the exact fix command.
 | Memory | `memory_list`, `memory_search`, `memory_create_via_chat` |
 | Instructions | `custom_instructions_get`, `custom_instructions_set` |
 | Codex | `list_codex_envs`, `list_codex_tasks`, `codex_task_create` |
+| Grok Build | `grok_build_agent`, `grok_build_models`, `grok_build_status` |
 
 ## When to Use Which Tool
 
@@ -164,6 +169,20 @@ account. Use `account_capabilities` for live state.
 3. codex_task_create(repo, desc)  -- spin up a coding task
 ```
 
+### Grok Build repository coding
+
+1. Configure at least one explicit `[grok_build].roots` entry. Empty roots
+   disable every Build probe and action.
+2. Run the MCP server from a current working directory within a configured root.
+3. Use `grok_build_models` and `grok_build_status` for the official CLI lane only.
+4. Use `grok_build_agent` for repository coding work.
+5. Use `mode="plan"` unless the user explicitly authorizes source changes.
+
+Grok Build uses its own official CLI subscription/OAuth state. It never falls
+back to ChatGPT auth, an ambient API key, or a website session. The CLI retains
+history; gpt2agent returns a sanitized session ID but does not copy transcripts
+or expose resume/deletion operations.
+
 ## Quota Management
 
 Deep Research limits and reset timing are reported by the current account and
@@ -190,7 +209,24 @@ port = 9000          # retained for compatibility; stdio does not bind
 chat = "gpt-5-3"
 # agent = "agent-mode"
 # heavy_dr = "gpt-5-5-pro"
+
+[grok_build]
+command = "grok"
+# home = "~/.grok"
+# auth_path = "~/.grok/auth.json"
+roots = []
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20
 ```
+
+The Build defaults and CLI mapping are documented by xAI's
+[enterprise/authentication guidance](https://docs.x.ai/build/enterprise), [CLI
+reference](https://docs.x.ai/build/cli/reference), [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands). gpt2agent strips
+`XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` from the child environment; optional
+`home`/`auth_path` set explicit `GROK_HOME`/`GROK_AUTH_PATH` paths.
 
 Ordinary REST/JSON backend calls share a process-wide limit of 4. Set
 `GPT2AGENT_MAX_IN_FLIGHT` only to an integer from 1 through 8. A 429 activates a
@@ -212,6 +248,15 @@ should run serially.
 | `contract_changed` | Private response no longer satisfies the bounded adapter; update and inspect sanitized evidence |
 | HTTP transport disabled | Expected in 0.0.12: use stdio |
 | Invalid `thinking_effort` | Call `list_models`; use an effort advertised by that exact general model or leave it unset |
+| `GROK_BUILD_CLI_NOT_FOUND` | Install the official CLI or set a reviewed `grok_build.command`, then restart the server |
+| `GROK_BUILD_AUTH_MISSING` | Complete the official CLI OAuth flow locally, then call `grok_build_status` |
+| `GROK_BUILD_QUOTA` | Stop retrying and wait for the account-reported quota window |
+| `GROK_BUILD_TIMEOUT` | Reduce scope or increase the configured timeout within 1–600 seconds, then retry once |
+| `GROK_BUILD_OUTPUT_TOO_LARGE` | Reduce output or increase the configured output bound, then retry once |
+| `GROK_BUILD_FAILED` | Check secret-free status, root, and CLI version; retry one smaller plan request |
+
+Never paste or log a Grok credential, auth file, or raw CLI failure while
+troubleshooting.
 
 ## Detailed Reference
 

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -1,6 +1,6 @@
 # gpt2agent MCP Tools Reference
 
-Complete parameter reference for all 32 MCP tools and 2 static resources exposed by the gpt2agent server.
+Complete parameter reference for all registered MCP tools and 2 static resources exposed by the gpt2agent server.
 Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 
 Every tool declares all four standard MCP annotations: read-only, destructive,
@@ -17,6 +17,7 @@ they are not an authorization boundary.
 - [Account Discovery (14)](#account-discovery)
 - [Memory & Instructions (5)](#memory--instructions)
 - [Codex (3)](#codex)
+- [Grok Build (3)](#grok-build)
 - [Static Resources (2)](#static-resources)
 
 ---
@@ -841,6 +842,56 @@ they are not an authorization boundary.
 
 ---
 
+## Grok Build
+
+These tools call the official Grok Build CLI through its independent
+subscription/OAuth lane. They do not reuse ChatGPT auth or ambient xAI API
+keys. Configure at least one repository root and run the MCP server from within
+a configured root before using any of them.
+
+### grok_build_agent
+
+- **Purpose**: Run one bounded official-CLI repository coding session.
+- **Parameters**:
+  - `prompt` (str, required) -- nonempty UTF-8 task, at most 65,536 bytes.
+  - `cwd` (str or None, default: `None`) -- existing directory under a configured root; `None` uses the server current working directory.
+  - `mode` (`"plan"` or `"apply"`, default: `"plan"`) -- plan maps to the CLI plan permission mode and read-only sandbox; apply maps to bypass-permissions and the strict sandbox.
+  - `model` (str or None, default: `None`) -- authenticated account-catalog model; when omitted, use the configured or catalog default.
+  - `max_turns` (int or None, default: `None`) -- 1–100; when omitted, use `default_max_turns`.
+  - `subagents` (bool, default: `False`) -- opt in to official CLI subagents.
+- **Returns**: A bounded dict containing `surface`, `status`, sanitized
+  `session_id`, selected `model`, response `text`, bounded `stop_reason`, safe
+  aggregate `usage`, and validated relative `changed_files`.
+- **Notes**: The MCP tool remains annotated destructive for every invocation
+  because annotations cannot vary with `mode`. Use plan unless the user
+  explicitly authorizes source changes. The official CLI retains session
+  history; gpt2agent does not copy transcripts or expose resume/deletion tools.
+
+### grok_build_models
+
+- **Purpose**: Read the authenticated official CLI account model catalog.
+- **Parameters**: None. The server current working directory must be in a configured root.
+- **Returns**: `authenticated`, `default_model`, ordered `models`, and `count`.
+- **Annotations**: Read-only, idempotent, closed-world.
+
+### grok_build_status
+
+- **Purpose**: Read secret-free official CLI installation, version,
+  authentication, default-model, and catalog-count status.
+- **Parameters**: None. The server current working directory must be in a configured root.
+- **Returns**: `installed`, bounded `version`, `authenticated`, `default_model`,
+  and `models_count`; no identity or credential fields.
+- **Annotations**: Read-only, idempotent, closed-world.
+
+`roots = []` disables all three calls. gpt2agent strips `XAI_API_KEY` and
+`GROK_CODE_XAI_API_KEY`; optional configuration paths set `GROK_HOME` and
+`GROK_AUTH_PATH`. No fallback exists between ChatGPT auth, Grok Build OAuth, or
+a website session. See xAI's [enterprise/authentication
+guidance](https://docs.x.ai/build/enterprise), [CLI
+reference](https://docs.x.ai/build/cli/reference), [headless scripting
+guide](https://docs.x.ai/build/cli/headless-scripting), and [modes and
+commands](https://docs.x.ai/build/modes-and-commands).
+
 ## Static Resources
 
 Resource reads are deterministic package reads. They perform no account or
@@ -850,8 +901,8 @@ responses, or private URLs.
 ### chatgpt://feature-coverage
 
 - **MIME type**: `application/json`
-- **Purpose**: Versioned 0.0.12 contract snapshot containing the exact 32-tool
-  manifest plus bounded feature status. Voice catalog/transcript/GPT-Live are
+- **Purpose**: Versioned 0.0.12 contract snapshot containing the exact ChatGPT
+  provider manifest plus bounded feature status. Voice catalog/transcript/GPT-Live are
   deferred and Projects is unsupported; those records do not claim live reachability.
 - **Use instead of**: Hard-coding a tool count or inferring that every ChatGPT
   product is exposed by this adapter.
@@ -970,7 +1021,7 @@ requested `report.md` and shape-only `status.txt`, never raw SSE/server metadata
 
 14. **No Voice/audio surface in 0.0.12**: Voice catalog work starts in 0.0.13.
 GPT-Live audio, microphone capture, WebRTC sessions, and an API fallback are not
-among the 32 tools or 2 resources.
+among the registered tools or 2 resources.
 
 15. **Final receipts are authoritative**: every `chat`, `agent`, and `gpt_chat`
 completion ends with a server-appended receipt, including `none`. Ignore any

--- a/gpt2agent/tool_contracts.py
+++ b/gpt2agent/tool_contracts.py
@@ -196,6 +196,24 @@ TOOL_ANNOTATION_MANIFEST: dict[str, dict[str, bool]] = {
         "idempotentHint": True,
         "openWorldHint": False,
     },
+    "grok_build_agent": {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+    "grok_build_models": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "grok_build_status": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
 }
 
 

--- a/gpt2agent/tool_manifest.py
+++ b/gpt2agent/tool_manifest.py
@@ -6,6 +6,12 @@ from gpt2agent.tool_contracts import TOOL_ANNOTATION_MANIFEST
 
 
 TOOL_NAMES: tuple[str, ...] = tuple(TOOL_ANNOTATION_MANIFEST)
+GROK_TOOL_NAMES: tuple[str, ...] = tuple(
+    name for name in TOOL_NAMES if name.startswith("grok_")
+)
+CHATGPT_TOOL_NAMES: tuple[str, ...] = tuple(
+    name for name in TOOL_NAMES if not name.startswith("grok_")
+)
 
 
 def exposes(tool_name: str) -> bool:

--- a/gpt2agent/tools/__init__.py
+++ b/gpt2agent/tools/__init__.py
@@ -4,9 +4,17 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from gpt2agent.backend import BackendClient
+    from gpt2agent.grok_build import GrokBuildClient
 
 
-def register_all(mcp, client: BackendClient, conv=None, *, model_catalog=None) -> None:
+def register_all(
+    mcp,
+    client: BackendClient,
+    conv=None,
+    *,
+    model_catalog=None,
+    grok_build_client: GrokBuildClient | None = None,
+) -> None:
     """Register every backend tool on *mcp*."""
     # Keep package initialization dependency-free. Domain modules such as
     # model_catalog import focused helpers below this package; eager imports here
@@ -45,6 +53,10 @@ def register_all(mcp, client: BackendClient, conv=None, *, model_catalog=None) -
     writes.register(mcp, client)
     images.register(mcp, client, conv)
     tools_features.register(mcp, client, conv)
+    if grok_build_client is not None:
+        from gpt2agent.tools import grok_build
+
+        grok_build.register(mcp, grok_build_client)
     from gpt2agent.resources import register as register_resources
 
     register_resources(mcp)

--- a/gpt2agent/tools/_errors.py
+++ b/gpt2agent/tools/_errors.py
@@ -15,6 +15,7 @@ from gpt2agent.errors import (
     BackendHTTPError,
     InputValidationError,
 )
+from gpt2agent.grok_errors import GrokError
 
 
 def serialize_tool_error(error: BaseException) -> str:
@@ -31,7 +32,8 @@ def serialize_tool_error(error: BaseException) -> str:
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         if isinstance(
-            current, (BackendHTTPError, BackendContractError, InputValidationError)
+            current,
+            (BackendHTTPError, BackendContractError, InputValidationError, GrokError),
         ):
             return str(current)
         current = current.__cause__

--- a/gpt2agent/tools/_redact.py
+++ b/gpt2agent/tools/_redact.py
@@ -9,10 +9,16 @@ _PHONE_RE = re.compile(r"\+?\d[\d ()\-]{8,}\d")
 # leading date. Only the date itself is preserved; the rest of the match is
 # re-scanned so "2026-05-26 617-555-0123" still masks the phone.
 _DATE_PREFIX_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}|\d{1,2}-\d{1,2}-\d{4})(?=$|[^\d])")
+_UUID_LIKE_RE = re.compile(
+    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}\b"
+)
 
 
 def _phone_repl(m: re.Match) -> str:
     text = m.group(0)
+    if _UUID_LIKE_RE.fullmatch(text):
+        return text
     parts = []
     position = 0
     while position < len(text):
@@ -61,6 +67,22 @@ _DB_CREDENTIAL_URL_RE = re.compile(
     r"(?P<scheme>\b(?:cockroachdb|mariadb|mongodb(?:\+srv)?|"
     r"mysql(?:\+[A-Za-z0-9_.-]+)?|postgres(?:ql)?|rediss?)://)"
     r"[^:@/\s]+:[^@\s]+@",
+    re.IGNORECASE,
+)
+_COOKIE_HEADER_RE = re.compile(r"\b(Cookie|Set-Cookie)\s*:\s*[^\r\n]+", re.IGNORECASE)
+_GROK_COOKIE_RE = re.compile(
+    r'''\b(sso-rw|sso|cf_clearance|grok_device_id)=(?:"[^"\r\n]*"|'[^'\r\n]*'|[^;\s"&]+)''',
+    re.IGNORECASE,
+)
+_XAI_TOKEN_RE = re.compile(r"\bxai-[A-Za-z0-9._~+/\-]{12,}=*", re.IGNORECASE)
+_SIGNED_QUERY_RE = re.compile(
+    r"([?&](?:credential|googleaccessid|signature|x-amz-credential|x-amz-security-token"
+    r"|x-amz-signature|x-goog-credential|x-goog-signature)=)[^&\s\"]+",
+    re.IGNORECASE,
+)
+_IDENTITY_FIELD_RE = re.compile(
+    r"(?P<prefix>\b(?:account|identity|profile|user|workspace|organization|org)"
+    r"(?:[_-]?id|Id)\s*(?:=|:)\s*[\"']?)[^\s,;}\]\"']+",
     re.IGNORECASE,
 )
 
@@ -120,6 +142,11 @@ def redact(s: object) -> object:
     s = _GOOGLE_API_KEY_RE.sub("<APIKEY>", s)
     s = _PEM_PRIVATE_KEY_RE.sub("<PRIVATE_KEY>", s)
     s = _DB_CREDENTIAL_URL_RE.sub(r"\g<scheme><REDACTED>@", s)
+    s = _COOKIE_HEADER_RE.sub(r"\1: <REDACTED>", s)
+    s = _GROK_COOKIE_RE.sub(r"\1=<REDACTED>", s)
+    s = _XAI_TOKEN_RE.sub("<TOKEN>", s)
+    s = _SIGNED_QUERY_RE.sub(r"\1<REDACTED>", s)
+    s = _IDENTITY_FIELD_RE.sub(r"\g<prefix><REDACTED>", s)
     s = _SECRET_ASSIGNMENT_RE.sub(_secret_assignment_repl, s)
     s = _BARE_KEY_ASSIGNMENT_RE.sub(_secret_assignment_repl, s)
     s = _EMAIL_RE.sub("<EMAIL>", s)

--- a/gpt2agent/tools/grok_build.py
+++ b/gpt2agent/tools/grok_build.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from gpt2agent.errors import InputValidationError
+from gpt2agent.grok_build import GrokBuildClient
+from gpt2agent.tool_contracts import tool_annotations
+
+
+_PROMPT_MAX_BYTES = 65_536
+
+
+def _validate_agent_inputs(
+    prompt: str,
+    *,
+    cwd: str | None,
+    mode: Literal["plan", "apply"],
+    model: str | None,
+    max_turns: int | None,
+    subagents: bool,
+) -> None:
+    encoded_size = 0
+    encoding_failed = False
+    if isinstance(prompt, str):
+        try:
+            encoded_size = len(prompt.encode("utf-8"))
+        except UnicodeEncodeError:
+            encoding_failed = True
+    if (
+        not isinstance(prompt, str)
+        or not prompt.strip()
+        or "\x00" in prompt
+        or encoding_failed
+        or encoded_size > _PROMPT_MAX_BYTES
+    ):
+        raise InputValidationError(
+            "grok_build.prompt must be 1..65536 UTF-8 bytes"
+        )
+    if cwd is not None and not isinstance(cwd, str):
+        raise InputValidationError("grok_build.cwd must be a string or null")
+    if mode not in ("plan", "apply"):
+        raise InputValidationError("grok_build.mode must be plan or apply")
+    if model is not None and not isinstance(model, str):
+        raise InputValidationError("grok_build.model must be a string or null")
+    if max_turns is not None and (
+        isinstance(max_turns, bool)
+        or not isinstance(max_turns, int)
+        or not 1 <= max_turns <= 100
+    ):
+        raise InputValidationError("grok_build.max_turns must be 1..100")
+    if not isinstance(subagents, bool):
+        raise InputValidationError("grok_build.subagents must be boolean")
+
+
+def register(mcp, client: GrokBuildClient) -> None:
+    @mcp.tool(annotations=tool_annotations("grok_build_agent"))
+    async def grok_build_agent(
+        prompt: str,
+        cwd: str | None = None,
+        mode: Literal["plan", "apply"] = "plan",
+        model: str | None = None,
+        max_turns: int | None = None,
+        subagents: bool = False,
+    ) -> dict[str, Any]:
+        """Run one bounded official Grok Build CLI agent session."""
+        _validate_agent_inputs(
+            prompt,
+            cwd=cwd,
+            mode=mode,
+            model=model,
+            max_turns=max_turns,
+            subagents=subagents,
+        )
+        return await client.agent(
+            prompt,
+            cwd=cwd,
+            mode=mode,
+            model=model,
+            max_turns=max_turns,
+            subagents=subagents,
+        )
+
+    @mcp.tool(annotations=tool_annotations("grok_build_models"))
+    async def grok_build_models() -> dict[str, Any]:
+        """Return the authenticated Grok Build CLI model catalog."""
+        return await client.models()
+
+    @mcp.tool(annotations=tool_annotations("grok_build_status"))
+    async def grok_build_status() -> dict[str, Any]:
+        """Return secret-free Grok Build CLI installation and auth status."""
+        return await client.status()

--- a/scripts/package_smoke.sh
+++ b/scripts/package_smoke.sh
@@ -39,6 +39,15 @@ if [ "${#DIST_ENTRIES[@]}" -ne 2 ] \
 fi
 WHEEL=${WHEELS[0]}
 SDIST=${SDISTS[0]}
+SOURCE_TOOL_NAMES_JSON=$(
+  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$SCRIPT_ROOT/.." python - <<'PY'
+import json
+
+from gpt2agent.tool_manifest import TOOL_NAMES
+
+print(json.dumps(list(TOOL_NAMES), separators=(",", ":")))
+PY
+)
 
 hash_dist() {
   python - "$WHEEL" "$SDIST" <<'PY'
@@ -92,7 +101,7 @@ check_installed_package() {
     test "$(run_scrubbed "$PRIVATE_HOME" "$VENV_ROOT/bin/python" -m gpt2agent --version)" = \
       "gpt2agent $PROJECT_VERSION"
     run_scrubbed "$PRIVATE_HOME" "$VENV_ROOT/bin/python" - \
-      "$DIST_VERSION" "$FORBIDDEN_SOURCE" <<'PY'
+      "$DIST_VERSION" "$FORBIDDEN_SOURCE" "$SOURCE_TOOL_NAMES_JSON" <<'PY'
 from importlib import import_module
 from importlib.metadata import version
 from importlib.resources import files
@@ -103,6 +112,7 @@ import re
 import sys
 
 expected_distribution = sys.argv[1]
+source_tool_names = json.loads(sys.argv[3])
 assert version("gpt2agent") == expected_distribution
 
 module_file = import_module("gpt2agent").__file__
@@ -134,10 +144,15 @@ manifest_spec = find_spec("gpt2agent.tool_manifest")
 if requires_account_manifest:
     assert manifest_spec is not None
 if manifest_spec is not None:
-    from gpt2agent.tool_manifest import TOOL_NAMES
+    from gpt2agent.tool_manifest import CHATGPT_TOOL_NAMES, GROK_TOOL_NAMES, TOOL_NAMES
 
-    assert len(TOOL_NAMES) == 32
+    assert TOOL_NAMES
     assert len(set(TOOL_NAMES)) == len(TOOL_NAMES)
+    assert CHATGPT_TOOL_NAMES
+    assert GROK_TOOL_NAMES
+    assert set(CHATGPT_TOOL_NAMES).isdisjoint(GROK_TOOL_NAMES)
+    assert CHATGPT_TOOL_NAMES + GROK_TOOL_NAMES == TOOL_NAMES
+    assert list(TOOL_NAMES) == source_tool_names
 
 resources_dir = root.joinpath("resources")
 if requires_account_manifest:
@@ -146,6 +161,10 @@ if resources_dir.is_dir():
     for name in ("feature-coverage.v1.json", "update-evidence.v1.json"):
         payload = json.loads(resources_dir.joinpath(name).read_text(encoding="utf-8"))
         assert payload["schema_version"] == "1"
+    coverage = json.loads(
+        resources_dir.joinpath("feature-coverage.v1.json").read_text(encoding="utf-8")
+    )
+    assert coverage["tools"] == list(CHATGPT_TOOL_NAMES)
 PY
   )
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
-  "description": "ChatGPT Plus/Pro account access as 32 MCP tools and 2 static resources.",
+  "description": "ChatGPT tools plus Grok Build tools and 2 static resources.",
   "version": "0.0.12",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",

--- a/tests/test_bounded_process.py
+++ b/tests/test_bounded_process.py
@@ -156,6 +156,44 @@ async def test_run_bounded_process_timeout_kills_sigterm_resistant_grandchild(
                 os.kill(grandchild_pid, signal.SIGKILL)
 
 
+@pytest.mark.parametrize("returncode", [0, 7])
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+@pytest.mark.asyncio
+async def test_run_bounded_process_normal_return_cleans_up_detached_descendant(
+    tmp_path: Path, returncode: int
+) -> None:
+    descendant_pid_file = tmp_path / f"descendant-{returncode}.pid"
+    descendant_code = "import time; time.sleep(30)"
+    parent_code = (
+        "import pathlib, subprocess, sys; "
+        f"child = subprocess.Popen([sys.executable, '-c', {descendant_code!r}], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, "
+        "stderr=subprocess.DEVNULL); "
+        f"pathlib.Path({str(descendant_pid_file)!r}).write_text(str(child.pid)); "
+        "print('out'); print('err', file=sys.stderr); "
+        f"sys.exit({returncode})"
+    )
+
+    try:
+        result = await run_bounded_process(
+            [sys.executable, "-c", parent_code],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=5.0,
+            max_output_bytes=1024,
+        )
+        await _wait_for_file(descendant_pid_file)
+        descendant_pid = int(descendant_pid_file.read_text())
+
+        assert result == ProcessResult(returncode, b"out\n", b"err\n")
+        assert not _pid_is_running(descendant_pid)
+    finally:
+        if descendant_pid_file.exists():
+            descendant_pid = int(descendant_pid_file.read_text())
+            if _pid_is_running(descendant_pid):
+                os.kill(descendant_pid, signal.SIGKILL)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX leak check")
 @pytest.mark.asyncio
 async def test_run_bounded_process_output_cap_stops_live_producer(

--- a/tests/test_bounded_process.py
+++ b/tests/test_bounded_process.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from gpt2agent._bounded_process import (
+    BoundedProcessError,
+    ProcessResult,
+    run_bounded_process,
+)
+
+
+def _pid_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    stat_path = Path(f"/proc/{pid}/stat")
+    if stat_path.exists():
+        try:
+            if stat_path.read_text().split()[2] == "Z":
+                return False
+        except (FileNotFoundError, ProcessLookupError):
+            return False
+    return True
+
+
+async def _wait_for_file(path: Path, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"timed out waiting for {path}")
+
+
+async def _wait_for_pid_to_stop(pid: int, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_is_running(pid):
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"process {pid} was still running")
+
+
+def _assert_code_only(
+    error: BoundedProcessError, expected_code: str
+) -> None:
+    assert error.code == expected_code
+    assert error.__dict__ == {"code": expected_code}
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_captures_separate_streams(tmp_path: Path) -> None:
+    result = await run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('out'); print('err', file=sys.stderr)",
+        ],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=5.0,
+        max_output_bytes=1024,
+    )
+
+    assert result == ProcessResult(0, b"out\n", b"err\n")
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_disconnects_stdin(tmp_path: Path) -> None:
+    result = await run_bounded_process(
+        [sys.executable, "-c", "import sys; print(sys.stdin.read() == '')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=5.0,
+        max_output_bytes=1024,
+    )
+
+    assert result.stdout == b"True\n"
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_caps_output_while_reading(tmp_path: Path) -> None:
+    with pytest.raises(BoundedProcessError) as caught:
+        await run_bounded_process(
+            [sys.executable, "-c", "print('x' * 4096)"],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=5.0,
+            max_output_bytes=1024,
+        )
+
+    _assert_code_only(caught.value, "output_too_large")
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_times_out_without_waiting_for_child(
+    tmp_path: Path,
+) -> None:
+    started = time.monotonic()
+    with pytest.raises(BoundedProcessError) as caught:
+        await run_bounded_process(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=0.2,
+            max_output_bytes=1024,
+        )
+
+    _assert_code_only(caught.value, "timeout")
+    assert time.monotonic() - started < 5
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+@pytest.mark.asyncio
+async def test_run_bounded_process_timeout_kills_sigterm_resistant_grandchild(
+    tmp_path: Path,
+) -> None:
+    grandchild_pid_file = tmp_path / "grandchild.pid"
+    grandchild_code = (
+        "import os, pathlib, signal, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"pathlib.Path({str(grandchild_pid_file)!r}).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    parent_code = (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {grandchild_code!r}]); "
+        "time.sleep(30)"
+    )
+
+    try:
+        with pytest.raises(BoundedProcessError) as caught:
+            await run_bounded_process(
+                [sys.executable, "-c", parent_code],
+                cwd=tmp_path,
+                env=os.environ.copy(),
+                timeout_seconds=0.5,
+                max_output_bytes=1024,
+            )
+        assert caught.value.code == "timeout"
+        await _wait_for_file(grandchild_pid_file)
+        grandchild_pid = int(grandchild_pid_file.read_text())
+        await _wait_for_pid_to_stop(grandchild_pid)
+    finally:
+        if grandchild_pid_file.exists():
+            grandchild_pid = int(grandchild_pid_file.read_text())
+            if _pid_is_running(grandchild_pid):
+                os.kill(grandchild_pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX leak check")
+@pytest.mark.asyncio
+async def test_run_bounded_process_output_cap_stops_live_producer(
+    tmp_path: Path,
+) -> None:
+    producer_pid_file = tmp_path / "producer.pid"
+    producer_code = (
+        "import os, pathlib, sys; "
+        f"pathlib.Path({str(producer_pid_file)!r}).write_text(str(os.getpid())); "
+        "chunk = b'x' * 4096; "
+        "[(sys.stdout.buffer.write(chunk), sys.stdout.buffer.flush()) "
+        "for _ in iter(int, 1)]"
+    )
+
+    try:
+        with pytest.raises(BoundedProcessError) as caught:
+            await run_bounded_process(
+                [sys.executable, "-c", producer_code],
+                cwd=tmp_path,
+                env=os.environ.copy(),
+                timeout_seconds=5.0,
+                max_output_bytes=1024,
+            )
+        assert caught.value.code == "output_too_large"
+        await _wait_for_file(producer_pid_file)
+        producer_pid = int(producer_pid_file.read_text())
+        await _wait_for_pid_to_stop(producer_pid)
+    finally:
+        if producer_pid_file.exists():
+            producer_pid = int(producer_pid_file.read_text())
+            if _pid_is_running(producer_pid):
+                os.kill(producer_pid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX leak check")
+@pytest.mark.asyncio
+async def test_run_bounded_process_caller_cancellation_cleans_up_child(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "cancelled-child.pid"
+    child_code = (
+        "import os, pathlib, time; "
+        f"pathlib.Path({str(child_pid_file)!r}).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    task = asyncio.create_task(
+        run_bounded_process(
+            [sys.executable, "-c", child_code],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=20.0,
+            max_output_bytes=1024,
+        )
+    )
+
+    await _wait_for_file(child_pid_file)
+    child_pid = int(child_pid_file.read_text())
+    try:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await _wait_for_pid_to_stop(child_pid)
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        if _pid_is_running(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_drains_large_streams_concurrently(
+    tmp_path: Path,
+) -> None:
+    stream_size = 256 * 1024
+    child_code = (
+        "import sys, threading; "
+        f"size = {stream_size}; "
+        "threads = ["
+        "threading.Thread(target=lambda: (sys.stdout.buffer.write(b'o' * size), "
+        "sys.stdout.buffer.flush())), "
+        "threading.Thread(target=lambda: (sys.stderr.buffer.write(b'e' * size), "
+        "sys.stderr.buffer.flush()))]; "
+        "[thread.start() for thread in threads]; "
+        "[thread.join() for thread in threads]"
+    )
+
+    result = await run_bounded_process(
+        [sys.executable, "-c", child_code],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=5.0,
+        max_output_bytes=stream_size,
+    )
+
+    assert result.stdout == b"o" * stream_size
+    assert result.stderr == b"e" * stream_size
+
+
+@pytest.mark.asyncio
+async def test_run_bounded_process_applies_cap_independently_to_stderr(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(BoundedProcessError) as caught:
+        await run_bounded_process(
+            [
+                sys.executable,
+                "-c",
+                "import sys; print('small'); sys.stderr.write('e' * 4096)",
+            ],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=5.0,
+            max_output_bytes=1024,
+        )
+
+    _assert_code_only(caught.value, "output_too_large")

--- a/tests/test_grok_build.py
+++ b/tests/test_grok_build.py
@@ -108,6 +108,12 @@ def _assert_grok_code(caught: pytest.ExceptionInfo[GrokError], code: str) -> Non
     }
 
 
+def _assert_detached_closed_error(error: GrokError, code: str) -> None:
+    assert error.code == code
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
 def test_build_config_defaults_and_resolves_paths(tmp_path: Path) -> None:
     default = GrokBuildConfig.from_mapping(None)
     assert default == GrokBuildConfig(
@@ -185,7 +191,7 @@ async def test_models_resolves_path_command_and_returns_current_catalog(
     monkeypatch.setenv("XAI_API_KEY", "xai-planted-secret")
     monkeypatch.setenv("GROK_CODE_XAI_API_KEY", "xai-planted-code-secret")
     client = _client(
-        None,
+        Path.cwd(),
         runner,
         resolver=lambda command: str(executable) if command == "grok" else None,
         home=str(profile),
@@ -216,6 +222,82 @@ async def test_models_resolves_path_command_and_returns_current_catalog(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["models", "status"])
+async def test_build_probes_reject_disabled_roots_without_subprocess_launch(
+    operation: str,
+) -> None:
+    runner = RecordingRunner(
+        [
+            _result("grok 7.4.3 (build) [stable]\n"),
+            _result(_models_output("grok-4.5")),
+        ]
+    )
+    client = _client(None, runner)
+
+    with pytest.raises(InputValidationError) as caught:
+        await getattr(client, operation)()
+
+    assert caught.value.invariant == (
+        "grok_build.cwd must be an existing directory under a configured root"
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["models", "status"])
+async def test_build_probes_reject_ambient_cwd_outside_roots_without_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+    runner = RecordingRunner(
+        [
+            _result("grok 7.4.3 (build) [stable]\n"),
+            _result(_models_output("grok-4.5")),
+        ]
+    )
+    client = _client(allowed_root, runner)
+
+    with pytest.raises(InputValidationError) as caught:
+        await getattr(client, operation)()
+
+    assert caught.value.invariant == (
+        "grok_build.cwd must be an existing directory under a configured root"
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["models", "status"])
+async def test_build_probes_use_canonical_allowed_ambient_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    root = tmp_path / "root"
+    ambient_cwd = root / "repo"
+    ambient_cwd.mkdir(parents=True)
+    monkeypatch.chdir(ambient_cwd)
+    results = [_result(_models_output("grok-4.5"))]
+    if operation == "status":
+        results.insert(0, _result("grok 7.4.3 (build) [stable]\n"))
+    runner = RecordingRunner(results)
+    client = _client(root, runner)
+
+    result = await getattr(client, operation)()
+
+    assert result["authenticated"] is True
+    assert result["default_model"] == "grok-4.5"
+    assert len(runner.calls) == (2 if operation == "status" else 1)
+    assert all(call["cwd"] == ambient_cwd.resolve() for call in runner.calls)
+
+
+@pytest.mark.asyncio
 async def test_models_accepts_explicit_executable_without_path_resolver(
     tmp_path: Path,
 ) -> None:
@@ -226,7 +308,7 @@ async def test_models_accepts_explicit_executable_without_path_resolver(
         pytest.fail("explicit executable paths must not use PATH resolution")
 
     result = await _client(
-        None,
+        Path.cwd(),
         runner,
         command=str(executable),
         resolver=unexpected_resolver,
@@ -247,7 +329,7 @@ async def test_models_reports_unauthenticated_without_returning_cli_prose() -> N
         ]
     )
 
-    result = await _client(None, runner).models()
+    result = await _client(Path.cwd(), runner).models()
 
     assert result == {
         "authenticated": False,
@@ -272,7 +354,7 @@ async def test_models_accepts_unbulleted_catalog_without_version_pinning() -> No
         ]
     )
 
-    result = await _client(None, runner).models()
+    result = await _client(Path.cwd(), runner).models()
 
     assert result == {
         "authenticated": True,
@@ -294,7 +376,7 @@ async def test_models_ignores_unallowlisted_footer_and_identity() -> None:
         ]
     )
 
-    result = await _client(None, runner).models()
+    result = await _client(Path.cwd(), runner).models()
 
     rendered = json.dumps(result)
     assert result["models"] == ["grok-4.5", "grok-composer-2.5-fast"]
@@ -314,7 +396,7 @@ async def test_status_parses_drifted_version_without_identity_or_paths(
     )
 
     status = await _client(
-        None,
+        Path.cwd(),
         runner,
         home=str(tmp_path / "private-profile"),
         auth_path=str(tmp_path / "private-profile" / "oauth.json"),
@@ -336,17 +418,18 @@ async def test_status_parses_drifted_version_without_identity_or_paths(
 @pytest.mark.asyncio
 async def test_status_is_the_only_missing_binary_soft_failure() -> None:
     runner = RecordingRunner([])
-    client = _client(None, runner, resolver=lambda _: None)
+    status_client = _client(None, runner, resolver=lambda _: None)
 
-    assert await client.status() == {
+    assert await status_client.status() == {
         "installed": False,
         "version": None,
         "authenticated": False,
         "default_model": None,
         "models_count": 0,
     }
+    action_client = _client(Path.cwd(), runner, resolver=lambda _: None)
     with pytest.raises(GrokError) as caught:
-        await client.models()
+        await action_client.models()
 
     _assert_grok_code(caught, "GROK_BUILD_CLI_NOT_FOUND")
     assert runner.calls == []
@@ -369,7 +452,7 @@ async def test_models_maps_process_failures_to_closed_errors(
     runner = RecordingRunner([failure])
 
     with pytest.raises(GrokError) as caught:
-        await _client(None, runner).models()
+        await _client(Path.cwd(), runner).models()
 
     _assert_grok_code(caught, code)
     rendered = str(caught.value)
@@ -385,9 +468,45 @@ async def test_models_maps_malformed_utf8_and_contract_to_failed() -> None:
         _result(_models_output("grok-4.5", default="other-model")),
     ):
         with pytest.raises(GrokError) as caught:
-            await _client(None, RecordingRunner([result])).models()
+            await _client(Path.cwd(), RecordingRunner([result])).models()
 
         _assert_grok_code(caught, "GROK_BUILD_FAILED")
+
+
+@pytest.mark.asyncio
+async def test_malformed_utf8_grok_error_has_no_raw_exception_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+    planted = b"xai-planted-raw-decode-secret"
+    runner = RecordingRunner([ProcessResult(0, b"\xff" + planted, b"")])
+
+    with pytest.raises(GrokError) as caught:
+        await _client(root, runner).models()
+
+    _assert_detached_closed_error(caught.value, "GROK_BUILD_FAILED")
+    assert planted.decode() not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_missing_executable_race_grok_error_has_no_os_exception_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+    planted = "xai-planted-file-not-found-secret"
+    runner = RecordingRunner([FileNotFoundError(planted)])
+
+    with pytest.raises(GrokError) as caught:
+        await _client(root, runner).models()
+
+    _assert_detached_closed_error(caught.value, "GROK_BUILD_CLI_NOT_FOUND")
+    assert planted not in str(caught.value)
 
 
 @pytest.mark.asyncio
@@ -463,6 +582,8 @@ async def test_agent_plan_uses_exact_argv_and_projects_only_allowlisted_result(
     assert "--no-memory" in argv
     assert "--no-subagents" in argv
     assert runner.calls[1]["cwd"] == cwd.resolve()
+    assert runner.calls[0]["cwd"] == cwd.resolve()
+    assert all(call["cwd"] == cwd.resolve() for call in runner.calls)
     assert "XAI_API_KEY" not in runner.calls[1]["env"]
     assert "GROK_CODE_XAI_API_KEY" not in runner.calls[1]["env"]
     rendered = json.dumps(result)
@@ -648,6 +769,28 @@ async def test_agent_maps_malformed_and_error_payloads_to_closed_errors(
 
 
 @pytest.mark.asyncio
+async def test_malformed_json_grok_error_has_no_raw_exception_chain(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    planted = "xai-planted-raw-json-secret"
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5")),
+            _result(f'{{"text":"unterminated {planted}'),
+        ]
+    )
+
+    with pytest.raises(GrokError) as caught:
+        await _client(root, runner).agent("plan", cwd=str(cwd))
+
+    _assert_detached_closed_error(caught.value, "GROK_BUILD_FAILED")
+    assert planted not in str(caught.value)
+
+
+@pytest.mark.asyncio
 async def test_agent_drops_malformed_optional_fields_fail_closed(
     tmp_path: Path,
 ) -> None:
@@ -712,10 +855,11 @@ async def test_agent_returns_empty_optional_structures_when_sources_are_not_mapp
 
 @pytest.mark.asyncio
 async def test_agent_maps_executable_disappearance_race_to_cli_not_found(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "root"
     root.mkdir()
+    monkeypatch.chdir(root)
     executable = _make_executable(tmp_path / "bin" / "grok")
 
     class DisappearingExecutableRunner(RecordingRunner):

--- a/tests/test_grok_build.py
+++ b/tests/test_grok_build.py
@@ -1,0 +1,761 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt2agent._bounded_process import BoundedProcessError, ProcessResult
+from gpt2agent.errors import InputValidationError
+from gpt2agent.grok_build import GrokBuildClient, GrokBuildConfig
+from gpt2agent.grok_errors import GrokError
+
+
+def _result(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> ProcessResult:
+    return ProcessResult(returncode, stdout.encode(), stderr.encode())
+
+
+def _models_output(
+    *models: str,
+    default: str = "grok-4.5",
+    logged_in: bool = True,
+) -> str:
+    login = (
+        "You are logged in with grok.com.\n\n"
+        if logged_in
+        else "You are not authenticated.\n\n"
+    )
+    entries = "".join(
+        f"  {'*' if model == default else '-'} {model}"
+        f"{' (default)' if model == default else ''}\n"
+        for model in models
+    )
+    return f"{login}Default model: {default}\n\nAvailable models:\n{entries}"
+
+
+class RecordingRunner:
+    def __init__(self, results: Sequence[ProcessResult | BaseException]) -> None:
+        self.results = list(results)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        timeout_seconds: float,
+        max_output_bytes: int,
+    ) -> ProcessResult:
+        self.calls.append(
+            {
+                "argv": list(argv),
+                "cwd": cwd,
+                "env": dict(env),
+                "timeout_seconds": timeout_seconds,
+                "max_output_bytes": max_output_bytes,
+            }
+        )
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _make_executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+    return path.resolve()
+
+
+def _config(root: Path | None = None, **overrides: Any) -> GrokBuildConfig:
+    values: dict[str, Any] = {"roots": [str(root)] if root is not None else []}
+    values.update(overrides)
+    return GrokBuildConfig.from_mapping(values)
+
+
+def _client(
+    root: Path | None,
+    runner: RecordingRunner,
+    *,
+    command: str = "grok",
+    resolver: Any = None,
+    **config_overrides: Any,
+) -> GrokBuildClient:
+    return GrokBuildClient(
+        _config(root, command=command, **config_overrides),
+        runner=runner,
+        resolver=resolver or (lambda _: command),
+    )
+
+
+def _assert_grok_code(caught: pytest.ExceptionInfo[GrokError], code: str) -> None:
+    assert caught.value.code == code
+    assert caught.value.__dict__ == {
+        "code": code,
+        "method": None,
+        "route": None,
+        "status_code": None,
+        "retryable": caught.value.retryable,
+        "retry_after": None,
+    }
+
+
+def test_build_config_defaults_and_resolves_paths(tmp_path: Path) -> None:
+    default = GrokBuildConfig.from_mapping(None)
+    assert default == GrokBuildConfig(
+        command="grok",
+        home=None,
+        auth_path=None,
+        roots=(),
+        default_model=None,
+        timeout_seconds=120.0,
+        max_output_bytes=1_048_576,
+        default_max_turns=20,
+    )
+
+    configured = GrokBuildConfig.from_mapping(
+        {
+            "command": str(tmp_path / "bin" / "grok"),
+            "home": str(tmp_path / "profile"),
+            "auth_path": str(tmp_path / "profile" / "oauth.json"),
+            "roots": [str(tmp_path / "repo")],
+            "default_model": "grok-4.5:fast",
+            "timeout_seconds": "30",
+            "max_output_bytes": "4096",
+            "default_max_turns": "7",
+        }
+    )
+
+    assert configured.home == (tmp_path / "profile").resolve()
+    assert configured.auth_path == (tmp_path / "profile" / "oauth.json").resolve()
+    assert configured.roots == ((tmp_path / "repo").resolve(),)
+    assert configured.timeout_seconds == 30.0
+    assert configured.max_output_bytes == 4096
+    assert configured.default_max_turns == 7
+
+
+@pytest.mark.parametrize(
+    ("mapping", "invariant"),
+    [
+        ({"command": ""}, "grok_build.command must not be empty"),
+        ({"roots": ("/repo",)}, "grok_build.roots must be a string list"),
+        ({"roots": [""]}, "grok_build.roots must be a string list"),
+        ({"roots": [7]}, "grok_build.roots must be a string list"),
+        ({"default_model": "bad model"}, "grok_build.default_model is invalid"),
+        ({"timeout_seconds": True}, "grok_build.timeout_seconds must be 1..600"),
+        ({"timeout_seconds": float("nan")}, "grok_build.timeout_seconds must be 1..600"),
+        ({"timeout_seconds": "inf"}, "grok_build.timeout_seconds must be 1..600"),
+        ({"timeout_seconds": 10**10_000}, "grok_build.timeout_seconds must be 1..600"),
+        ({"timeout_seconds": 0}, "grok_build.timeout_seconds must be 1..600"),
+        ({"max_output_bytes": False}, "grok_build.max_output_bytes is out of range"),
+        ({"max_output_bytes": 1024.5}, "grok_build.max_output_bytes is out of range"),
+        ({"max_output_bytes": 1023}, "grok_build.max_output_bytes is out of range"),
+        ({"default_max_turns": True}, "grok_build.default_max_turns must be 1..100"),
+        ({"default_max_turns": 1.5}, "grok_build.default_max_turns must be 1..100"),
+        ({"default_max_turns": 101}, "grok_build.default_max_turns must be 1..100"),
+    ],
+)
+def test_build_config_rejects_invalid_values(
+    mapping: dict[str, Any], invariant: str
+) -> None:
+    with pytest.raises(InputValidationError) as caught:
+        GrokBuildConfig.from_mapping(mapping)
+
+    assert caught.value.invariant == invariant
+
+
+@pytest.mark.asyncio
+async def test_models_resolves_path_command_and_returns_current_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = _make_executable(tmp_path / "bin" / "grok")
+    profile = tmp_path / "profile"
+    auth_path = profile / "oauth.json"
+    runner = RecordingRunner(
+        [_result(_models_output("grok-4.5", "grok-composer-2.5-fast"))]
+    )
+    monkeypatch.setenv("XAI_API_KEY", "xai-planted-secret")
+    monkeypatch.setenv("GROK_CODE_XAI_API_KEY", "xai-planted-code-secret")
+    client = _client(
+        None,
+        runner,
+        resolver=lambda command: str(executable) if command == "grok" else None,
+        home=str(profile),
+        auth_path=str(auth_path),
+        timeout_seconds=45,
+        max_output_bytes=8192,
+    )
+
+    catalog = await client.models()
+
+    assert catalog == {
+        "authenticated": True,
+        "default_model": "grok-4.5",
+        "models": ["grok-4.5", "grok-composer-2.5-fast"],
+        "count": 2,
+    }
+    call = runner.calls[0]
+    assert call["argv"] == [str(executable), "--no-auto-update", "models"]
+    assert call["cwd"] == Path.cwd().resolve()
+    assert call["env"]["GROK_HOME"] == str(profile.resolve())
+    assert call["env"]["GROK_AUTH_PATH"] == str(auth_path.resolve())
+    assert "XAI_API_KEY" not in call["env"]
+    assert "GROK_CODE_XAI_API_KEY" not in call["env"]
+    assert os.environ["XAI_API_KEY"] == "xai-planted-secret"
+    assert os.environ["GROK_CODE_XAI_API_KEY"] == "xai-planted-code-secret"
+    assert call["timeout_seconds"] == 45.0
+    assert call["max_output_bytes"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_models_accepts_explicit_executable_without_path_resolver(
+    tmp_path: Path,
+) -> None:
+    executable = _make_executable(tmp_path / "grok explicit")
+    runner = RecordingRunner([_result(_models_output("grok-4.5"))])
+
+    def unexpected_resolver(_: str) -> str | None:
+        pytest.fail("explicit executable paths must not use PATH resolution")
+
+    result = await _client(
+        None,
+        runner,
+        command=str(executable),
+        resolver=unexpected_resolver,
+    ).models()
+
+    assert result["models"] == ["grok-4.5"]
+    assert runner.calls[0]["argv"][0] == str(executable)
+
+
+@pytest.mark.asyncio
+async def test_models_reports_unauthenticated_without_returning_cli_prose() -> None:
+    runner = RecordingRunner(
+        [
+            _result(
+                "You are not authenticated.\n\n"
+                "Default model: grok-4.5\n\nAvailable models:\n"
+            )
+        ]
+    )
+
+    result = await _client(None, runner).models()
+
+    assert result == {
+        "authenticated": False,
+        "default_model": "grok-4.5",
+        "models": [],
+        "count": 0,
+    }
+    assert "identity" not in result
+
+
+@pytest.mark.asyncio
+async def test_models_accepts_unbulleted_catalog_without_version_pinning() -> None:
+    runner = RecordingRunner(
+        [
+            _result(
+                "Default model: grok-build\n\n"
+                "Available models:\n"
+                "  grok-build  Grok Build\n"
+                "  grok-4.5: Grok 4.5\n"
+                "  composer/next  Composer Next\n"
+            )
+        ]
+    )
+
+    result = await _client(None, runner).models()
+
+    assert result == {
+        "authenticated": True,
+        "default_model": "grok-build",
+        "models": ["grok-build", "grok-4.5", "composer/next"],
+        "count": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_models_ignores_unallowlisted_footer_and_identity() -> None:
+    runner = RecordingRunner(
+        [
+            _result(
+                _models_output("grok-4.5", "grok-composer-2.5-fast")
+                + "Account: private.member@example.test\n"
+                + "  after-footer-must-not-parse\n"
+            )
+        ]
+    )
+
+    result = await _client(None, runner).models()
+
+    rendered = json.dumps(result)
+    assert result["models"] == ["grok-4.5", "grok-composer-2.5-fast"]
+    assert "private.member@example.test" not in rendered
+    assert "after-footer" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_parses_drifted_version_without_identity_or_paths(
+    tmp_path: Path,
+) -> None:
+    runner = RecordingRunner(
+        [
+            _result("grok 9.17.3-next.4 (drifted-build) [stable]\n"),
+            _result(_models_output("grok-4.5", "grok-composer-2.5-fast")),
+        ]
+    )
+
+    status = await _client(
+        None,
+        runner,
+        home=str(tmp_path / "private-profile"),
+        auth_path=str(tmp_path / "private-profile" / "oauth.json"),
+    ).status()
+
+    assert status == {
+        "installed": True,
+        "version": "9.17.3-next.4",
+        "authenticated": True,
+        "default_model": "grok-4.5",
+        "models_count": 2,
+    }
+    assert runner.calls[0]["argv"][-1] == "--version"
+    assert runner.calls[1]["argv"][-1] == "models"
+    assert "profile" not in status
+    assert "identity" not in status
+
+
+@pytest.mark.asyncio
+async def test_status_is_the_only_missing_binary_soft_failure() -> None:
+    runner = RecordingRunner([])
+    client = _client(None, runner, resolver=lambda _: None)
+
+    assert await client.status() == {
+        "installed": False,
+        "version": None,
+        "authenticated": False,
+        "default_model": None,
+        "models_count": 0,
+    }
+    with pytest.raises(GrokError) as caught:
+        await client.models()
+
+    _assert_grok_code(caught, "GROK_BUILD_CLI_NOT_FOUND")
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "code"),
+    [
+        (_result(stderr="You are not authenticated.", returncode=1), "GROK_BUILD_AUTH_MISSING"),
+        (_result(stderr="Usage quota exceeded.", returncode=1), "GROK_BUILD_QUOTA"),
+        (_result(stderr="private.member@example.test xai-secret", returncode=2), "GROK_BUILD_FAILED"),
+        (BoundedProcessError("timeout"), "GROK_BUILD_TIMEOUT"),
+        (BoundedProcessError("output_too_large"), "GROK_BUILD_OUTPUT_TOO_LARGE"),
+    ],
+)
+async def test_models_maps_process_failures_to_closed_errors(
+    failure: ProcessResult | BaseException, code: str
+) -> None:
+    runner = RecordingRunner([failure])
+
+    with pytest.raises(GrokError) as caught:
+        await _client(None, runner).models()
+
+    _assert_grok_code(caught, code)
+    rendered = str(caught.value)
+    assert "private.member@example.test" not in rendered
+    assert "xai-secret" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_models_maps_malformed_utf8_and_contract_to_failed() -> None:
+    for result in (
+        ProcessResult(0, b"\xff", b""),
+        _result("model service ready\n"),
+        _result(_models_output("grok-4.5", default="other-model")),
+    ):
+        with pytest.raises(GrokError) as caught:
+            await _client(None, RecordingRunner([result])).models()
+
+        _assert_grok_code(caught, "GROK_BUILD_FAILED")
+
+
+@pytest.mark.asyncio
+async def test_agent_plan_uses_exact_argv_and_projects_only_allowlisted_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    prompt = "quote ' $(touch /tmp/never-run) ; literal\nsecond line"
+    payload = {
+        "text": "Completed the planted task.",
+        "stopReason": "end_turn",
+        "sessionId": "123e4567-e89b-12d3-a456-426614174000",
+        "usage": {
+            "inputTokens": 12,
+            "outputTokens": 5,
+            "totalTokens": 17,
+            "cacheReadTokens": 3,
+            "cacheCreationTokens": 1,
+            "costUsd": 999,
+            "negative": -1,
+            "boolTokens": True,
+        },
+        "changedFiles": [
+            "src/main.py",
+            "new/module.py",
+            "src/main.py",
+            "../outside.txt",
+            str(tmp_path / "absolute-secret.txt"),
+            42,
+        ],
+        "requestId": "req-planted-secret",
+        "identity": "private.member@example.test",
+        "metadata": {"access_token": "xai-planted-secret"},
+    }
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5", "grok-composer-2.5-fast")),
+            _result(json.dumps(payload), stderr="stderr-planted-secret"),
+        ]
+    )
+    monkeypatch.setenv("XAI_API_KEY", "xai-parent-secret")
+    monkeypatch.setenv("GROK_CODE_XAI_API_KEY", "xai-parent-code-secret")
+
+    result = await _client(root, runner).agent(prompt, cwd=str(cwd))
+
+    assert result == {
+        "surface": "build",
+        "status": "completed",
+        "session_id": "123e4567-e89b-12d3-a456-426614174000",
+        "model": "grok-4.5",
+        "text": "Completed the planted task.",
+        "stop_reason": "end_turn",
+        "usage": {
+            "inputTokens": 12,
+            "outputTokens": 5,
+            "totalTokens": 17,
+            "cacheReadTokens": 3,
+            "cacheCreationTokens": 1,
+        },
+        "changed_files": ["src/main.py", "new/module.py"],
+    }
+    argv = runner.calls[1]["argv"]
+    assert argv[:4] == ["grok", "--no-auto-update", "--cwd", str(cwd.resolve())]
+    assert argv[argv.index("-p") + 1] == prompt
+    assert argv.count(prompt) == 1
+    assert argv[argv.index("--output-format") + 1] == "json"
+    assert argv[argv.index("--max-turns") + 1] == "20"
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+    assert argv[argv.index("--sandbox") + 1] == "read-only"
+    assert argv[argv.index("--model") + 1] == "grok-4.5"
+    assert "--no-memory" in argv
+    assert "--no-subagents" in argv
+    assert runner.calls[1]["cwd"] == cwd.resolve()
+    assert "XAI_API_KEY" not in runner.calls[1]["env"]
+    assert "GROK_CODE_XAI_API_KEY" not in runner.calls[1]["env"]
+    rendered = json.dumps(result)
+    for planted in (
+        prompt,
+        "stderr-planted-secret",
+        "req-planted-secret",
+        "private.member@example.test",
+        "xai-planted-secret",
+        str(tmp_path / "absolute-secret.txt"),
+    ):
+        assert planted not in rendered
+
+
+@pytest.mark.asyncio
+async def test_agent_apply_and_subagent_flags_are_exact(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    complete = _result('{"text":"done"}')
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5")),
+            complete,
+            _result(_models_output("grok-4.5")),
+            complete,
+        ]
+    )
+    client = _client(root, runner)
+
+    apply_result = await client.agent("apply", cwd=str(cwd), mode="apply")
+    subagent_result = await client.agent("delegate", cwd=str(cwd), subagents=True)
+
+    apply_argv = runner.calls[1]["argv"]
+    subagent_argv = runner.calls[3]["argv"]
+    assert apply_result["status"] == "completed"
+    assert subagent_result["status"] == "completed"
+    assert apply_argv[apply_argv.index("--permission-mode") + 1] == "bypassPermissions"
+    assert apply_argv[apply_argv.index("--sandbox") + 1] == "strict"
+    assert "--no-subagents" in apply_argv
+    assert subagent_argv[subagent_argv.index("--permission-mode") + 1] == "plan"
+    assert subagent_argv[subagent_argv.index("--sandbox") + 1] == "read-only"
+    assert "--no-subagents" not in subagent_argv
+
+
+@pytest.mark.asyncio
+async def test_agent_none_cwd_uses_contained_process_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+    runner = RecordingRunner(
+        [_result(_models_output("grok-4.5")), _result('{"text":"done"}')]
+    )
+
+    result = await _client(root, runner).agent("plan")
+
+    assert result["text"] == "done"
+    assert runner.calls[1]["cwd"] == cwd.resolve()
+    assert runner.calls[1]["argv"][3] == str(cwd.resolve())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prompt",
+    ["", "   ", "a" * 65_537, "\ud800"],
+)
+async def test_agent_rejects_invalid_prompt_without_process(
+    tmp_path: Path, prompt: str
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner([])
+
+    with pytest.raises(InputValidationError, match="grok_build.prompt"):
+        await _client(root, runner).agent(prompt, cwd=str(root))
+
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "invariant"),
+    [
+        ({"mode": "workspace"}, "grok_build.mode must be plan or apply"),
+        ({"max_turns": True}, "grok_build.max_turns must be 1..100"),
+        ({"max_turns": 0}, "grok_build.max_turns must be 1..100"),
+        ({"max_turns": 101}, "grok_build.max_turns must be 1..100"),
+        ({"subagents": 1}, "grok_build.subagents must be boolean"),
+    ],
+)
+async def test_agent_rejects_invalid_controls_without_process(
+    tmp_path: Path, kwargs: dict[str, Any], invariant: str
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner([])
+
+    with pytest.raises(InputValidationError) as caught:
+        await _client(root, runner).agent("plan", cwd=str(root), **kwargs)
+
+    assert caught.value.invariant == invariant
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_agent_accepts_prompt_at_utf8_limit_and_explicit_catalog_model(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    prompt = "é" * 32_768
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5", "grok-composer-2.5-fast")),
+            _result('{"text":"done"}'),
+        ]
+    )
+
+    result = await _client(root, runner).agent(
+        prompt,
+        cwd=str(root),
+        model="grok-composer-2.5-fast",
+        max_turns=100,
+    )
+
+    assert result["model"] == "grok-composer-2.5-fast"
+    argv = runner.calls[1]["argv"]
+    assert argv[argv.index("-p") + 1] == prompt
+    assert argv[argv.index("--max-turns") + 1] == "100"
+
+
+@pytest.mark.asyncio
+async def test_agent_rejects_unauthenticated_or_unlisted_model_before_session(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+
+    unauth_runner = RecordingRunner([_result("You are not authenticated.\n")])
+    with pytest.raises(GrokError) as auth_error:
+        await _client(root, unauth_runner).agent("plan", cwd=str(root))
+    _assert_grok_code(auth_error, "GROK_BUILD_AUTH_MISSING")
+
+    model_runner = RecordingRunner([_result(_models_output("grok-4.5"))])
+    with pytest.raises(InputValidationError, match="grok_build.model"):
+        await _client(root, model_runner).agent(
+            "plan", cwd=str(root), model="grok-unlisted"
+        )
+
+    assert len(unauth_runner.calls) == 1
+    assert len(model_runner.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        ("not-json", "GROK_BUILD_FAILED"),
+        ("[]", "GROK_BUILD_FAILED"),
+        ('{"text":""}', "GROK_BUILD_FAILED"),
+        ('{"type":"error","message":"quota exceeded"}', "GROK_BUILD_QUOTA"),
+        ('{"type":"error","message":"not authenticated"}', "GROK_BUILD_AUTH_MISSING"),
+        ('{"type":"error","message":"private.member@example.test"}', "GROK_BUILD_FAILED"),
+    ],
+)
+async def test_agent_maps_malformed_and_error_payloads_to_closed_errors(
+    tmp_path: Path, payload: str, code: str
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner(
+        [_result(_models_output("grok-4.5")), _result(payload)]
+    )
+
+    with pytest.raises(GrokError) as caught:
+        await _client(root, runner).agent("plan", cwd=str(root))
+
+    _assert_grok_code(caught, code)
+    assert "private.member@example.test" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_agent_drops_malformed_optional_fields_fail_closed(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    too_large = 2**63
+    payload = {
+        "text": "done",
+        "sessionId": "x" * 129,
+        "stopReason": {"private": "value"},
+        "usage": {
+            "inputTokens": True,
+            "outputTokens": -1,
+            "totalTokens": too_large,
+            "cacheReadTokens": 4,
+            "cacheCreationTokens": "5",
+            "arbitrary": 9,
+        },
+        "changedFiles": [
+            "safe/file.py",
+            "nested/../escape.py",
+            "/absolute/file.py",
+            "C:drive-relative.py",
+            "line\nbreak.py",
+            "x" * 1025,
+            None,
+        ],
+    }
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5")),
+            _result(json.dumps(payload)),
+        ]
+    )
+
+    result = await _client(root, runner).agent("plan", cwd=str(root))
+
+    assert result["session_id"] is None
+    assert result["stop_reason"] is None
+    assert result["usage"] == {"cacheReadTokens": 4}
+    assert result["changed_files"] == ["safe/file.py"]
+
+
+@pytest.mark.asyncio
+async def test_agent_returns_empty_optional_structures_when_sources_are_not_mappings(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner(
+        [
+            _result(_models_output("grok-4.5")),
+            _result('{"text":"done","usage":[],"changedFiles":"src/main.py"}'),
+        ]
+    )
+
+    result = await _client(root, runner).agent("plan", cwd=str(root))
+
+    assert result["usage"] is None
+    assert result["changed_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_agent_maps_executable_disappearance_race_to_cli_not_found(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    executable = _make_executable(tmp_path / "bin" / "grok")
+
+    class DisappearingExecutableRunner(RecordingRunner):
+        async def __call__(self, *args: Any, **kwargs: Any) -> ProcessResult:
+            executable.unlink(missing_ok=True)
+            return await super().__call__(*args, **kwargs)
+
+    runner = DisappearingExecutableRunner([FileNotFoundError("planted")])
+
+    with pytest.raises(GrokError) as caught:
+        await _client(
+            root,
+            runner,
+            resolver=lambda _: str(executable),
+        ).models()
+
+    _assert_grok_code(caught, "GROK_BUILD_CLI_NOT_FOUND")
+
+
+@pytest.mark.asyncio
+async def test_agent_maps_cwd_disappearance_race_to_input_validation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    cwd = root / "repo"
+    cwd.mkdir(parents=True)
+
+    class DisappearingCwdRunner(RecordingRunner):
+        async def __call__(
+            self, argv: Sequence[str], **kwargs: Any
+        ) -> ProcessResult:
+            if len(self.calls) == 1:
+                shutil.rmtree(cwd)
+            return await super().__call__(argv, **kwargs)
+
+    runner = DisappearingCwdRunner(
+        [_result(_models_output("grok-4.5")), FileNotFoundError("planted")]
+    )
+
+    with pytest.raises(InputValidationError, match="grok_build.cwd"):
+        await _client(root, runner).agent("plan", cwd=str(cwd))
+
+    assert len(runner.calls) == 2

--- a/tests/test_grok_build.py
+++ b/tests/test_grok_build.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -92,7 +93,7 @@ def _client(
     return GrokBuildClient(
         _config(root, command=command, **config_overrides),
         runner=runner,
-        resolver=resolver or (lambda _: command),
+        resolver=resolver or (lambda _: sys.executable),
     )
 
 
@@ -112,6 +113,15 @@ def _assert_detached_closed_error(error: GrokError, code: str) -> None:
     assert error.code == code
     assert error.__cause__ is None
     assert error.__context__ is None
+
+
+def _assert_detached_input_error(
+    error: InputValidationError, invariant: str, planted: str
+) -> None:
+    assert error.invariant == invariant
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert planted not in str(error)
 
 
 def test_build_config_defaults_and_resolves_paths(tmp_path: Path) -> None:
@@ -178,6 +188,35 @@ def test_build_config_rejects_invalid_values(
     assert caught.value.invariant == invariant
 
 
+@pytest.mark.parametrize(
+    ("key", "planted", "invariant"),
+    [
+        (
+            "timeout_seconds",
+            "xai-planted-float-secret",
+            "grok_build.timeout_seconds must be 1..600",
+        ),
+        (
+            "max_output_bytes",
+            "xai-planted-output-secret",
+            "grok_build.max_output_bytes is out of range",
+        ),
+        (
+            "default_max_turns",
+            "xai-planted-turns-secret",
+            "grok_build.default_max_turns must be 1..100",
+        ),
+    ],
+)
+def test_build_config_conversion_errors_have_no_raw_exception_chain(
+    key: str, planted: str, invariant: str
+) -> None:
+    with pytest.raises(InputValidationError) as caught:
+        GrokBuildConfig.from_mapping({key: planted})
+
+    _assert_detached_input_error(caught.value, invariant, planted)
+
+
 @pytest.mark.asyncio
 async def test_models_resolves_path_command_and_returns_current_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -233,6 +272,23 @@ async def test_build_probes_reject_disabled_roots_without_subprocess_launch(
         ]
     )
     client = _client(None, runner)
+
+    with pytest.raises(InputValidationError) as caught:
+        await getattr(client, operation)()
+
+    assert caught.value.invariant == (
+        "grok_build.cwd must be an existing directory under a configured root"
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["models", "status"])
+async def test_build_probes_validate_roots_before_missing_binary_soft_failure(
+    operation: str,
+) -> None:
+    runner = RecordingRunner([])
+    client = _client(None, runner, resolver=lambda _: None)
 
     with pytest.raises(InputValidationError) as caught:
         await getattr(client, operation)()
@@ -316,6 +372,100 @@ async def test_models_accepts_explicit_executable_without_path_resolver(
 
     assert result["models"] == ["grok-4.5"]
     assert runner.calls[0]["argv"][0] == str(executable)
+
+
+@pytest.mark.asyncio
+async def test_bare_resolver_result_is_pinned_before_repository_cwd_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    discovery_cwd = tmp_path / "discovery"
+    root = tmp_path / "root"
+    repository = root / "repo"
+    discovery_cwd.mkdir()
+    repository.mkdir(parents=True)
+    trusted = _make_executable(discovery_cwd / "grok")
+    substituted = _make_executable(repository / "grok")
+    runner = RecordingRunner([_result(_models_output("grok-4.5"))])
+    resolver_calls: list[str] = []
+
+    def resolver(command: str) -> str:
+        resolver_calls.append(command)
+        return "grok"
+
+    monkeypatch.chdir(discovery_cwd)
+    client = _client(root, runner, resolver=resolver)
+    monkeypatch.chdir(repository)
+
+    result = await client.models()
+
+    assert result["models"] == ["grok-4.5"]
+    assert resolver_calls == ["grok"]
+    assert runner.calls[0]["argv"][0] == str(trusted)
+    assert runner.calls[0]["argv"][0] != str(substituted)
+
+
+@pytest.mark.asyncio
+async def test_relative_explicit_command_is_pinned_before_repository_cwd_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    discovery_cwd = tmp_path / "discovery"
+    root = tmp_path / "root"
+    repository = root / "repo"
+    discovery_cwd.mkdir()
+    repository.mkdir(parents=True)
+    trusted = _make_executable(discovery_cwd / "bin" / "grok")
+    substituted = _make_executable(repository / "bin" / "grok")
+    runner = RecordingRunner([_result(_models_output("grok-4.5"))])
+
+    def unexpected_resolver(_: str) -> str | None:
+        pytest.fail("explicit executable paths must not use PATH resolution")
+
+    monkeypatch.chdir(discovery_cwd)
+    client = _client(
+        root,
+        runner,
+        command="bin/grok",
+        resolver=unexpected_resolver,
+    )
+    monkeypatch.chdir(repository)
+
+    result = await client.models()
+
+    assert result["models"] == ["grok-4.5"]
+    assert runner.calls[0]["argv"][0] == str(trusted)
+    assert runner.calls[0]["argv"][0] != str(substituted)
+
+
+@pytest.mark.asyncio
+async def test_discovered_executable_disappearance_does_not_rediscover_in_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    discovery_cwd = tmp_path / "discovery"
+    root = tmp_path / "root"
+    repository = root / "repo"
+    discovery_cwd.mkdir()
+    repository.mkdir(parents=True)
+    trusted = _make_executable(discovery_cwd / "grok")
+    _make_executable(repository / "grok")
+    runner = RecordingRunner([_result(_models_output("grok-4.5"))])
+    resolver_calls: list[Path] = []
+
+    def resolver(_: str) -> str:
+        candidate = Path.cwd() / "grok"
+        resolver_calls.append(candidate)
+        return str(candidate)
+
+    monkeypatch.chdir(discovery_cwd)
+    client = _client(root, runner, resolver=resolver)
+    trusted.unlink()
+    monkeypatch.chdir(repository)
+
+    with pytest.raises(GrokError) as caught:
+        await client.models()
+
+    _assert_grok_code(caught, "GROK_BUILD_CLI_NOT_FOUND")
+    assert resolver_calls == [discovery_cwd / "grok"]
+    assert runner.calls == []
 
 
 @pytest.mark.asyncio
@@ -416,9 +566,14 @@ async def test_status_parses_drifted_version_without_identity_or_paths(
 
 
 @pytest.mark.asyncio
-async def test_status_is_the_only_missing_binary_soft_failure() -> None:
+async def test_status_is_the_only_missing_binary_soft_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.chdir(root)
     runner = RecordingRunner([])
-    status_client = _client(None, runner, resolver=lambda _: None)
+    status_client = _client(root, runner, resolver=lambda _: None)
 
     assert await status_client.status() == {
         "installed": False,
@@ -427,7 +582,7 @@ async def test_status_is_the_only_missing_binary_soft_failure() -> None:
         "default_model": None,
         "models_count": 0,
     }
-    action_client = _client(Path.cwd(), runner, resolver=lambda _: None)
+    action_client = _client(root, runner, resolver=lambda _: None)
     with pytest.raises(GrokError) as caught:
         await action_client.models()
 
@@ -571,7 +726,12 @@ async def test_agent_plan_uses_exact_argv_and_projects_only_allowlisted_result(
         "changed_files": ["src/main.py", "new/module.py"],
     }
     argv = runner.calls[1]["argv"]
-    assert argv[:4] == ["grok", "--no-auto-update", "--cwd", str(cwd.resolve())]
+    assert argv[:4] == [
+        str(Path(sys.executable).resolve()),
+        "--no-auto-update",
+        "--cwd",
+        str(cwd.resolve()),
+    ]
     assert argv[argv.index("-p") + 1] == prompt
     assert argv.count(prompt) == 1
     assert argv[argv.index("--output-format") + 1] == "json"
@@ -660,9 +820,53 @@ async def test_agent_rejects_invalid_prompt_without_process(
     root.mkdir()
     runner = RecordingRunner([])
 
-    with pytest.raises(InputValidationError, match="grok_build.prompt"):
+    with pytest.raises(InputValidationError) as caught:
         await _client(root, runner).agent(prompt, cwd=str(root))
 
+    assert caught.value.invariant == (
+        "grok_build.prompt must be 1..65536 UTF-8 bytes"
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_agent_prompt_encoding_error_has_no_raw_exception_chain(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner([])
+    planted = "xai-planted-prompt-secret"
+    prompt = f"{planted}\ud800"
+
+    with pytest.raises(InputValidationError) as caught:
+        await _client(root, runner).agent(prompt, cwd=str(root))
+
+    _assert_detached_input_error(
+        caught.value,
+        "grok_build.prompt must be 1..65536 UTF-8 bytes",
+        planted,
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prompt", ["\x00", "safe\x00unsafe"])
+async def test_agent_rejects_embedded_nul_before_catalog_or_session(
+    tmp_path: Path, prompt: str
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    runner = RecordingRunner(
+        [_result(_models_output("grok-4.5")), _result('{"text":"done"}')]
+    )
+
+    with pytest.raises(InputValidationError) as caught:
+        await _client(root, runner).agent(prompt, cwd=str(root))
+
+    assert caught.value.invariant == (
+        "grok_build.prompt must be 1..65536 UTF-8 bytes"
+    )
     assert runner.calls == []
 
 

--- a/tests/test_grok_build_live.py
+++ b/tests/test_grok_build_live.py
@@ -1,0 +1,414 @@
+"""Opt-in live gate for the official Grok Build subscription lane."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from gpt2agent.errors import InputValidationError
+from gpt2agent.grok_build import GrokBuildClient, GrokBuildConfig
+from gpt2agent.grok_errors import GrokError
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_RUN_LIVE = os.environ.get("RUN_GROK_BUILD_LIVE") == "1"
+_LIVE_MODE = "plan"
+_LIVE_PROMPT = "Reply with exactly GROK_BUILD_LIVE_OK. Do not inspect files or use tools."
+_LIVE_SENTINEL = "GROK_BUILD_LIVE_OK"
+_MAX_LIVE_MODELS = 256
+
+
+@dataclass(frozen=True)
+class _SelectedLiveEnvironment:
+    home: Path
+    auth_path: Path | None
+    build_root: Path
+    repository_root: Path
+    mode: str
+
+
+class LiveGateConfigurationError(RuntimeError):
+    """Fixed-code configuration failure that never retains a private value."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _absolute_directory(value: object) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved if resolved.is_dir() else None
+
+
+def _absolute_file(value: object) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved if resolved.is_file() else None
+
+
+def _configuration_failure(code: str) -> LiveGateConfigurationError:
+    return LiveGateConfigurationError(code)
+
+
+def _validate_live_environment(
+    environment: Mapping[str, str],
+    *,
+    repository_root: Path,
+    mode: str,
+) -> _SelectedLiveEnvironment:
+    if mode != "plan":
+        raise _configuration_failure("GROK_BUILD_LIVE_MODE_FORBIDDEN")
+    if "XAI_API_KEY" in environment or "GROK_CODE_XAI_API_KEY" in environment:
+        raise _configuration_failure("GROK_BUILD_LIVE_API_KEY_FORBIDDEN")
+
+    home = _absolute_directory(environment.get("GROK_HOME"))
+    if home is None:
+        raise _configuration_failure("GROK_BUILD_LIVE_HOME_REQUIRED")
+
+    auth_path: Path | None = None
+    if "GROK_AUTH_PATH" in environment:
+        auth_path = _absolute_file(environment.get("GROK_AUTH_PATH"))
+        if auth_path is None:
+            raise _configuration_failure("GROK_BUILD_LIVE_AUTH_PATH_INVALID")
+
+    build_root = _absolute_directory(environment.get("GROK_BUILD_ROOT"))
+    if build_root is None:
+        raise _configuration_failure("GROK_BUILD_LIVE_ROOT_REQUIRED")
+    try:
+        resolved_repository_root = repository_root.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        resolved_repository_root = None
+    if (
+        resolved_repository_root is None
+        or not resolved_repository_root.is_dir()
+        or (
+            resolved_repository_root != build_root
+            and build_root not in resolved_repository_root.parents
+        )
+    ):
+        raise _configuration_failure("GROK_BUILD_LIVE_ROOT_MISMATCH")
+
+    return _SelectedLiveEnvironment(
+        home=home,
+        auth_path=auth_path,
+        build_root=build_root,
+        repository_root=resolved_repository_root,
+        mode=mode,
+    )
+
+
+def _require(condition: bool, code: str) -> None:
+    if not condition:
+        pytest.fail(code, pytrace=False)
+
+
+def _valid_environment(
+    tmp_path: Path,
+) -> tuple[dict[str, str], Path, Path, Path]:
+    home = tmp_path / "reviewed-profile"
+    build_root = tmp_path / "build-root"
+    repository_root = build_root / "repository"
+    home.mkdir()
+    repository_root.mkdir(parents=True)
+    return (
+        {
+            "GROK_HOME": str(home.resolve()),
+            "GROK_BUILD_ROOT": str(build_root.resolve()),
+        },
+        home.resolve(),
+        build_root.resolve(),
+        repository_root.resolve(),
+    )
+
+
+def _assert_configuration_error(
+    environment: Mapping[str, str],
+    repository_root: Path,
+    code: str,
+    *,
+    mode: str = _LIVE_MODE,
+) -> None:
+    with pytest.raises(LiveGateConfigurationError) as caught:
+        _validate_live_environment(
+            environment,
+            repository_root=repository_root,
+            mode=mode,
+        )
+
+    assert caught.value.code == code
+    assert str(caught.value) == code
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    for raw_value in environment.values():
+        if raw_value:
+            assert raw_value not in str(caught.value)
+
+
+def test_live_requirement_uses_only_fixed_bounded_code() -> None:
+    with pytest.raises(pytest.fail.Exception) as caught:
+        _require(False, "GROK_BUILD_LIVE_FIXED_FAILURE")
+
+    assert str(caught.value) == "GROK_BUILD_LIVE_FIXED_FAILURE"
+
+
+def test_live_requirement_accepts_true_condition() -> None:
+    _require(True, "GROK_BUILD_LIVE_UNUSED_FAILURE")
+
+
+def test_live_environment_accepts_absolute_reviewed_paths(tmp_path: Path) -> None:
+    environment, home, build_root, repository_root = _valid_environment(tmp_path)
+    auth_path = home / "oauth.json"
+    auth_path.touch(mode=0o600)
+    environment["GROK_AUTH_PATH"] = str(auth_path.resolve())
+
+    selected = _validate_live_environment(
+        environment,
+        repository_root=repository_root,
+        mode="plan",
+    )
+
+    assert selected.home == home
+    assert selected.auth_path == auth_path.resolve()
+    assert selected.build_root == build_root
+    assert selected.repository_root == repository_root
+    assert selected.mode == "plan"
+
+
+def test_live_environment_accepts_missing_optional_auth_path(tmp_path: Path) -> None:
+    environment, home, build_root, repository_root = _valid_environment(tmp_path)
+
+    selected = _validate_live_environment(
+        environment,
+        repository_root=repository_root,
+        mode="plan",
+    )
+
+    assert selected.home == home
+    assert selected.auth_path is None
+    assert selected.build_root == build_root
+
+
+@pytest.mark.parametrize("variable", ["GROK_HOME", "GROK_BUILD_ROOT"])
+def test_live_environment_rejects_missing_required_paths(
+    tmp_path: Path,
+    variable: str,
+) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    environment.pop(variable)
+    expected = {
+        "GROK_HOME": "GROK_BUILD_LIVE_HOME_REQUIRED",
+        "GROK_BUILD_ROOT": "GROK_BUILD_LIVE_ROOT_REQUIRED",
+    }[variable]
+
+    _assert_configuration_error(environment, repository_root, expected)
+
+
+@pytest.mark.parametrize("variable", ["GROK_HOME", "GROK_BUILD_ROOT"])
+def test_live_environment_rejects_relative_required_paths(
+    tmp_path: Path,
+    variable: str,
+) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    environment[variable] = "relative-planted-private-path"
+    expected = {
+        "GROK_HOME": "GROK_BUILD_LIVE_HOME_REQUIRED",
+        "GROK_BUILD_ROOT": "GROK_BUILD_LIVE_ROOT_REQUIRED",
+    }[variable]
+
+    _assert_configuration_error(environment, repository_root, expected)
+
+
+def test_live_environment_rejects_non_directory_home(tmp_path: Path) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    not_directory = tmp_path / "not-a-profile-directory"
+    not_directory.touch()
+    environment["GROK_HOME"] = str(not_directory.resolve())
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_HOME_REQUIRED",
+    )
+
+
+def test_live_environment_rejects_non_directory_build_root(tmp_path: Path) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    not_directory = tmp_path / "not-a-build-directory"
+    not_directory.touch()
+    environment["GROK_BUILD_ROOT"] = str(not_directory.resolve())
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_ROOT_REQUIRED",
+    )
+
+
+@pytest.mark.parametrize("value_kind", ["relative", "missing", "directory"])
+def test_live_environment_rejects_invalid_optional_auth_path(
+    tmp_path: Path,
+    value_kind: str,
+) -> None:
+    environment, home, _, repository_root = _valid_environment(tmp_path)
+    values = {
+        "relative": "relative-planted-private-auth",
+        "missing": str((home / "missing-auth.json").resolve()),
+        "directory": str(home.resolve()),
+    }
+    environment["GROK_AUTH_PATH"] = values[value_kind]
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_AUTH_PATH_INVALID",
+    )
+
+
+@pytest.mark.parametrize("variable", ["XAI_API_KEY", "GROK_CODE_XAI_API_KEY"])
+def test_live_environment_rejects_api_key_presence_even_when_empty(
+    tmp_path: Path,
+    variable: str,
+) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    environment[variable] = ""
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_API_KEY_FORBIDDEN",
+    )
+
+
+def test_live_environment_rejects_root_outside_current_repository(
+    tmp_path: Path,
+) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+    outside = tmp_path / "outside-root"
+    outside.mkdir()
+    environment["GROK_BUILD_ROOT"] = str(outside.resolve())
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_ROOT_MISMATCH",
+    )
+
+
+def test_live_environment_rejects_non_plan_mode(tmp_path: Path) -> None:
+    environment, _, _, repository_root = _valid_environment(tmp_path)
+
+    _assert_configuration_error(
+        environment,
+        repository_root,
+        "GROK_BUILD_LIVE_MODE_FORBIDDEN",
+        mode="apply",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _RUN_LIVE,
+    reason="set RUN_GROK_BUILD_LIVE=1 with explicit reviewed paths",
+)
+async def test_grok_build_live_account() -> None:
+    selected = _validate_live_environment(
+        os.environ,
+        repository_root=_PROJECT_ROOT,
+        mode=_LIVE_MODE,
+    )
+    config = GrokBuildConfig.from_mapping(
+        {
+            "command": "grok",
+            "home": str(selected.home),
+            "auth_path": (
+                str(selected.auth_path) if selected.auth_path is not None else None
+            ),
+            "roots": [str(selected.build_root)],
+            "timeout_seconds": 120,
+            "max_output_bytes": 1_048_576,
+            "default_max_turns": 2,
+        }
+    )
+    client = GrokBuildClient(config)
+
+    try:
+        status = await client.status()
+        catalog = await client.models()
+        _require(status.get("installed") is True, "GROK_BUILD_LIVE_CLI_NOT_INSTALLED")
+        _require(
+            status.get("authenticated") is True,
+            "GROK_BUILD_LIVE_AUTH_NOT_READY",
+        )
+        version = status.get("version")
+        _require(
+            isinstance(version, str) and 1 <= len(version) <= 64,
+            "GROK_BUILD_LIVE_VERSION_INVALID",
+        )
+        models = catalog.get("models")
+        _require(
+            catalog.get("authenticated") is True
+            and isinstance(models, list)
+            and 1 <= len(models) <= _MAX_LIVE_MODELS,
+            "GROK_BUILD_LIVE_CATALOG_INVALID",
+        )
+        default_model = catalog.get("default_model")
+        _require(
+            isinstance(default_model, str) and default_model in models,
+            "GROK_BUILD_LIVE_DEFAULT_MODEL_INVALID",
+        )
+        _require(
+            status.get("default_model") == default_model
+            and status.get("models_count") == len(models),
+            "GROK_BUILD_LIVE_PROBE_MISMATCH",
+        )
+
+        result = await client.agent(
+            _LIVE_PROMPT,
+            cwd=str(selected.repository_root),
+            mode=_LIVE_MODE,
+            max_turns=2,
+            subagents=False,
+        )
+    except GrokError as exc:
+        pytest.fail(f"GROK_BUILD_LIVE_CLIENT_ERROR:{exc.code}", pytrace=False)
+    except InputValidationError:
+        pytest.fail("GROK_BUILD_LIVE_CLIENT_ERROR:INPUT_VALIDATION", pytrace=False)
+
+    _require(
+        result.get("surface") == "build" and result.get("status") == "completed",
+        "GROK_BUILD_LIVE_COMPLETION_INVALID",
+    )
+    text = result.get("text")
+    _require(
+        isinstance(text, str) and " ".join(text.split()) == _LIVE_SENTINEL,
+        "GROK_BUILD_LIVE_SENTINEL_MISMATCH",
+    )
+    _require(result.get("model") in models, "GROK_BUILD_LIVE_MODEL_INVALID")
+    session_id = result.get("session_id")
+    _require(
+        isinstance(session_id, str) and bool(session_id),
+        "GROK_BUILD_LIVE_SESSION_ID_MISSING",
+    )
+    _require(
+        result.get("changed_files") == [],
+        "GROK_BUILD_LIVE_CHANGED_FILES_NONEMPTY",
+    )

--- a/tests/test_grok_build_tools.py
+++ b/tests/test_grok_build_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -11,6 +12,7 @@ import gpt2agent.backend as backend_module
 import gpt2agent.server as server_module
 import gpt2agent.sse as sse_module
 from gpt2agent.errors import InputValidationError
+from gpt2agent.grok_build import GrokBuildClient
 from gpt2agent.tool_manifest import CHATGPT_TOOL_NAMES, GROK_TOOL_NAMES, TOOL_NAMES
 from gpt2agent.tools import grok_build
 
@@ -218,7 +220,28 @@ def test_provider_manifests_partition_the_exact_global_manifest() -> None:
     assert len(CHATGPT_TOOL_NAMES) + len(GROK_TOOL_NAMES) == len(TOOL_NAMES)
 
 
-def test_server_registers_build_tools_without_binary_roots_or_auth(monkeypatch) -> None:
+def test_server_registers_build_tools_without_binary_roots_or_auth(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    for name in (
+        "GROK_AUTH_PATH",
+        "GROK_CODE_XAI_API_KEY",
+        "GROK_HOME",
+        "XAI_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    def unexpected_startup_probe(*args: Any, **kwargs: Any) -> None:
+        pytest.fail("Grok Build account or execution probe ran during startup")
+
+    for method_name in ("_run", "status", "models", "agent"):
+        monkeypatch.setattr(
+            GrokBuildClient,
+            method_name,
+            unexpected_startup_probe,
+        )
     monkeypatch.setattr(server_module, "FastMCP", _RecordingMCP)
     monkeypatch.setattr(backend_module, "BackendClient", _Backend)
     monkeypatch.setattr(sse_module, "ConversationClient", _Conversation)
@@ -227,7 +250,7 @@ def test_server_registers_build_tools_without_binary_roots_or_auth(monkeypatch) 
         {
             "server": {"host": "127.0.0.1", "port": 9000},
             "models": {"chat": "gpt-5-3"},
-            "grok_build": {"command": "/definitely/missing/grok", "roots": []},
+            "grok_build": {"command": str(tmp_path / "missing-grok"), "roots": []},
         }
     )
 

--- a/tests/test_grok_build_tools.py
+++ b/tests/test_grok_build_tools.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+from mcp.types import ToolAnnotations
+
+import gpt2agent.backend as backend_module
+import gpt2agent.server as server_module
+import gpt2agent.sse as sse_module
+from gpt2agent.errors import InputValidationError
+from gpt2agent.tool_manifest import CHATGPT_TOOL_NAMES, GROK_TOOL_NAMES, TOOL_NAMES
+from gpt2agent.tools import grok_build
+
+
+_FIELDS = (
+    "readOnlyHint",
+    "destructiveHint",
+    "idempotentHint",
+    "openWorldHint",
+)
+
+GROK_BUILD_ANNOTATIONS = {
+    "grok_build_agent": (False, True, False, True),
+    "grok_build_models": (True, False, True, False),
+    "grok_build_status": (True, False, True, False),
+}
+
+
+class _RecordingMCP:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.registrations: dict[str, tuple[Any, dict[str, Any]]] = {}
+        self.resources: dict[str, tuple[Any, dict[str, Any]]] = {}
+
+    def tool(self, *args: Any, **kwargs: Any):
+        def decorator(fn):
+            self.registrations[fn.__name__] = (fn, kwargs)
+            return fn
+
+        return decorator
+
+    def resource(self, uri: str, *args: Any, **kwargs: Any):
+        def decorator(fn):
+            self.resources[uri] = (fn, kwargs)
+            return fn
+
+        return decorator
+
+
+class _FakeBuildClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.results = {
+            "agent": {"surface": "build", "status": "completed", "text": "done"},
+            "models": {"authenticated": True, "models": ["grok-4.5"]},
+            "status": {"installed": True, "authenticated": True},
+        }
+
+    async def agent(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("agent", args, kwargs))
+        return self.results["agent"]
+
+    async def models(self) -> dict[str, Any]:
+        self.calls.append(("models", (), {}))
+        return self.results["models"]
+
+    async def status(self) -> dict[str, Any]:
+        self.calls.append(("status", (), {}))
+        return self.results["status"]
+
+
+class _Backend:
+    pass
+
+
+class _Conversation:
+    def __init__(self, backend: _Backend) -> None:
+        self.backend = backend
+
+
+def _registered(client: _FakeBuildClient | None = None):
+    mcp = _RecordingMCP()
+    build_client = client or _FakeBuildClient()
+    grok_build.register(mcp, build_client)
+    return mcp.registrations, build_client
+
+
+def _annotation_tuple(value: ToolAnnotations) -> tuple[bool | None, ...]:
+    return tuple(getattr(value, field) for field in _FIELDS)
+
+
+def test_grok_build_registry_is_exact_and_fully_annotated() -> None:
+    registrations, _ = _registered()
+
+    assert set(registrations) == set(GROK_BUILD_ANNOTATIONS)
+    for name, (fn, kwargs) in registrations.items():
+        assert fn.__name__ == name
+        assert "structured_output" not in kwargs
+        annotation = kwargs.get("annotations")
+        assert isinstance(annotation, ToolAnnotations), name
+        assert _annotation_tuple(annotation) == GROK_BUILD_ANNOTATIONS[name]
+        assert all(value is not None for value in _annotation_tuple(annotation))
+
+
+def test_grok_build_public_signatures_are_exact_and_secret_free() -> None:
+    registrations, _ = _registered()
+    agent = inspect.signature(registrations["grok_build_agent"][0])
+
+    assert tuple(agent.parameters) == (
+        "prompt",
+        "cwd",
+        "mode",
+        "model",
+        "max_turns",
+        "subagents",
+    )
+    assert agent.parameters["prompt"].annotation == "str"
+    assert agent.parameters["cwd"].annotation == "str | None"
+    assert agent.parameters["cwd"].default is None
+    assert agent.parameters["mode"].annotation == "Literal['plan', 'apply']"
+    assert agent.parameters["mode"].default == "plan"
+    assert agent.parameters["model"].annotation == "str | None"
+    assert agent.parameters["model"].default is None
+    assert agent.parameters["max_turns"].annotation == "int | None"
+    assert agent.parameters["max_turns"].default is None
+    assert agent.parameters["subagents"].annotation == "bool"
+    assert agent.parameters["subagents"].default is False
+    assert tuple(inspect.signature(registrations["grok_build_models"][0]).parameters) == ()
+    assert tuple(inspect.signature(registrations["grok_build_status"][0]).parameters) == ()
+
+    all_parameters = {
+        parameter
+        for fn, _kwargs in registrations.values()
+        for parameter in inspect.signature(fn).parameters
+    }
+    assert all_parameters.isdisjoint(
+        {"auth", "authorization", "cookie", "credential", "key", "secret", "token"}
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"prompt": ""},
+        {"prompt": 7},
+        {"prompt": "ok", "cwd": 7},
+        {"prompt": "ok", "mode": "workspace"},
+        {"prompt": "ok", "model": 7},
+        {"prompt": "ok", "max_turns": True},
+        {"prompt": "ok", "max_turns": 0},
+        {"prompt": "ok", "max_turns": 101},
+        {"prompt": "ok", "subagents": 1},
+    ],
+)
+def test_grok_build_agent_validates_public_inputs_before_dispatch(
+    kwargs: dict[str, Any],
+) -> None:
+    registrations, client = _registered()
+
+    with pytest.raises(InputValidationError):
+        asyncio.run(registrations["grok_build_agent"][0](**kwargs))
+
+    assert client.calls == []
+
+
+def test_grok_build_agent_calls_client_once_and_returns_exact_object() -> None:
+    registrations, client = _registered()
+
+    result = asyncio.run(
+        registrations["grok_build_agent"][0](
+            "inspect only",
+            cwd="/repo",
+            mode="apply",
+            model="grok-4.5",
+            max_turns=8,
+            subagents=True,
+        )
+    )
+
+    assert result is client.results["agent"]
+    assert client.calls == [
+        (
+            "agent",
+            ("inspect only",),
+            {
+                "cwd": "/repo",
+                "mode": "apply",
+                "model": "grok-4.5",
+                "max_turns": 8,
+                "subagents": True,
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize("tool_name, method_name", [("grok_build_models", "models"), ("grok_build_status", "status")])
+def test_grok_build_read_handlers_call_client_once_and_return_exact_object(
+    tool_name: str,
+    method_name: str,
+) -> None:
+    registrations, client = _registered()
+
+    result = asyncio.run(registrations[tool_name][0]())
+
+    assert result is client.results[method_name]
+    assert client.calls == [(method_name, (), {})]
+
+
+def test_provider_manifests_partition_the_exact_global_manifest() -> None:
+    assert GROK_TOOL_NAMES == tuple(name for name in TOOL_NAMES if name.startswith("grok_"))
+    assert CHATGPT_TOOL_NAMES == tuple(
+        name for name in TOOL_NAMES if not name.startswith("grok_")
+    )
+    assert GROK_TOOL_NAMES == tuple(GROK_BUILD_ANNOTATIONS)
+    assert set(CHATGPT_TOOL_NAMES).isdisjoint(GROK_TOOL_NAMES)
+    assert len(CHATGPT_TOOL_NAMES) + len(GROK_TOOL_NAMES) == len(TOOL_NAMES)
+
+
+def test_server_registers_build_tools_without_binary_roots_or_auth(monkeypatch) -> None:
+    monkeypatch.setattr(server_module, "FastMCP", _RecordingMCP)
+    monkeypatch.setattr(backend_module, "BackendClient", _Backend)
+    monkeypatch.setattr(sse_module, "ConversationClient", _Conversation)
+
+    mcp = server_module.build_server(
+        {
+            "server": {"host": "127.0.0.1", "port": 9000},
+            "models": {"chat": "gpt-5-3"},
+            "grok_build": {"command": "/definitely/missing/grok", "roots": []},
+        }
+    )
+
+    assert set(GROK_BUILD_ANNOTATIONS) <= set(mcp.registrations)

--- a/tests/test_grok_errors.py
+++ b/tests/test_grok_errors.py
@@ -57,6 +57,15 @@ def test_grok_routes_remove_identity_and_credential_segments(
     assert planted not in normalized
 
 
+def test_unknown_grok_route_fails_closed_without_opaque_identifier() -> None:
+    planted = "account-private-8"
+
+    normalized = normalize_grok_route(f"/rest/sessions/{planted}")
+
+    assert normalized == "<route>"
+    assert planted not in normalized
+
+
 def test_grok_error_is_typed_bounded_and_secret_free() -> None:
     error = GrokError(
         "GROK_WEB_AUTH_EXPIRED",

--- a/tests/test_grok_errors.py
+++ b/tests/test_grok_errors.py
@@ -1,0 +1,177 @@
+"""Secret-safe Grok error and route-normalization contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gpt2agent._log_redact import redact_error
+from gpt2agent.grok_errors import GROK_ERROR_CODES, GrokError, normalize_grok_route
+from gpt2agent.tools._errors import serialize_tool_error
+
+
+CONVERSATION_ID = "conv-private-42"
+RESPONSE_ID = "resp-private-99"
+ATTACHMENT_ID = "attach-private-17"
+UUID_ID = "8cb6f8ef-b988-4f5a-a721-926c7e52e770"
+UUID_LIKE_ID = "00000000-0000-0000-0000-000000000042"
+
+
+def test_grok_routes_remove_conversation_and_response_ids() -> None:
+    assert normalize_grok_route(
+        f"/rest/app-chat/conversations/{CONVERSATION_ID}"
+    ) == "/rest/app-chat/conversations/{id}"
+    assert normalize_grok_route(
+        f"/rest/app-chat/conversations/reconnect-response-v2/{RESPONSE_ID}"
+    ) == "/rest/app-chat/conversations/reconnect-response-v2/{id}"
+
+
+def test_grok_routes_remove_queries_attachment_ids_and_uuids() -> None:
+    assert normalize_grok_route(
+        f"/rest/app-chat/attachments/{ATTACHMENT_ID}?X-Amz-Signature=planted-secret"
+    ) == "/rest/app-chat/attachments/{id}"
+    assert normalize_grok_route(f"/rest/app-chat/responses/{UUID_ID}") == (
+        "/rest/app-chat/responses/{id}"
+    )
+    assert normalize_grok_route(f"/rest/app-chat/events/{UUID_LIKE_ID}") == (
+        "/rest/app-chat/events/{id}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("route", "planted"),
+    [
+        ("/rest/users/user@example.test", "user@example.test"),
+        ("/rest/identities/account-private-8", "account-private-8"),
+        ("/rest/sessions/xai-planted-route-secret-123456", "xai-planted-route-secret"),
+    ],
+)
+def test_grok_routes_remove_identity_and_credential_segments(
+    route: str,
+    planted: str,
+) -> None:
+    normalized = normalize_grok_route(route)
+
+    assert normalized is not None
+    assert planted not in normalized
+
+
+def test_grok_error_is_typed_bounded_and_secret_free() -> None:
+    error = GrokError(
+        "GROK_WEB_AUTH_EXPIRED",
+        method="POST",
+        route=(
+            f"/rest/app-chat/conversations/{CONVERSATION_ID}?token=planted-secret"
+        ),
+        status_code=401,
+        retryable=False,
+    )
+    rendered = serialize_tool_error(error)
+    assert rendered == (
+        "GROK_WEB_AUTH_EXPIRED: POST "
+        "/rest/app-chat/conversations/{id} failed (401)"
+    )
+    assert "planted-secret" not in rendered
+    assert CONVERSATION_ID not in rendered
+
+
+def test_grok_error_validates_code_and_bounds_metadata() -> None:
+    assert len(GROK_ERROR_CODES) == 14
+    with pytest.raises(ValueError, match="Grok error code"):
+        GrokError("PLANTED_SECRET", retryable=False)
+    with pytest.raises(ValueError, match="Grok error method"):
+        GrokError("GROK_WEB_FAILED", method="X" * 17, retryable=False)
+
+    error = GrokError(
+        "GROK_WEB_RATE_LIMITED",
+        method="post",
+        route="/rest/models",
+        status_code=429,
+        retryable=True,
+        retry_after=3600,
+    )
+
+    assert error.method == "POST"
+    assert error.route == "/rest/models"
+    assert error.status_code == 429
+    assert error.retryable is True
+    assert error.retry_after == 60.0
+    assert len(str(error)) < 256
+
+
+def test_only_typed_grok_errors_cross_the_tool_boundary() -> None:
+    typed = GrokError("GROK_BUILD_TIMEOUT", retryable=True, retry_after=2)
+    assert serialize_tool_error(typed) == str(typed)
+
+    planted = f"unexpected Grok failure for {CONVERSATION_ID} at user@example.test"
+    assert serialize_tool_error(RuntimeError(planted)) == (
+        "unavailable: tool execution failed"
+    )
+
+
+@pytest.mark.parametrize(
+    "planted",
+    [
+        "sso=planted-sso-secret",
+        "sso-rw=planted-sso-rw-secret",
+        'sso="planted-quoted-cookie-secret"',
+        "cf_clearance=planted-clearance-secret",
+        "grok_device_id=planted-device-secret",
+        "Cookie: sso=planted-cookie-secret; theme=dark",
+        "Set-Cookie: sso-rw=planted-set-cookie-secret; Secure",
+        "Authorization: Bearer xai-planted-auth-secret-123456",
+        "/asset?X-Amz-Credential=planted-credential&X-Amz-Signature=planted-signature"
+        "&X-Amz-Security-Token=planted-security-token",
+        "email=user@example.test account_id=account-private-8",
+        f"conversation failed for {CONVERSATION_ID}",
+        f"response failed for {RESPONSE_ID}",
+        f"attachment failed for {ATTACHMENT_ID}",
+        f"upstream identity {UUID_ID}",
+        f"upstream identity {UUID_LIKE_ID}",
+    ],
+)
+def test_grok_log_redaction_removes_credentials_identity_and_opaque_ids(
+    planted: str,
+) -> None:
+    rendered = redact_error(planted, max_len=500)
+
+    for secret in (
+        "planted-sso-secret",
+        "planted-sso-rw-secret",
+        "planted-quoted-cookie-secret",
+        "planted-clearance-secret",
+        "planted-device-secret",
+        "planted-cookie-secret",
+        "planted-set-cookie-secret",
+        "xai-planted-auth-secret-123456",
+        "planted-credential",
+        "planted-signature",
+        "planted-security-token",
+        "user@example.test",
+        "account-private-8",
+        CONVERSATION_ID,
+        RESPONSE_ID,
+        ATTACHMENT_ID,
+        UUID_ID,
+        UUID_LIKE_ID,
+    ):
+        assert secret not in rendered
+
+
+def test_validated_grok_ids_survive_dedicated_structured_result_fields() -> None:
+    result = {
+        "conversation_id": CONVERSATION_ID,
+        "response_id": RESPONSE_ID,
+        "attachment_id": ATTACHMENT_ID,
+        "request_id": UUID_ID,
+        "trace_id": UUID_LIKE_ID,
+    }
+
+    rendered = json.dumps(result, sort_keys=True)
+
+    assert CONVERSATION_ID in rendered
+    assert RESPONSE_ID in rendered
+    assert ATTACHMENT_ID in rendered
+    assert UUID_ID in rendered
+    assert UUID_LIKE_ID in rendered

--- a/tests/test_grok_paths.py
+++ b/tests/test_grok_paths.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from gpt2agent.errors import InputValidationError
+from gpt2agent.grok_paths import RootPolicy
+
+
+_CWD_INVARIANT = (
+    "grok_build.cwd must be an existing directory under a configured root"
+)
+
+
+def _assert_cwd_rejected(policy: RootPolicy, value: str | Path | None) -> None:
+    with pytest.raises(InputValidationError) as caught:
+        policy.directory(value)
+
+    assert caught.value.invariant == _CWD_INVARIANT
+
+
+def test_root_policy_defaults_to_disabled(tmp_path: Path) -> None:
+    _assert_cwd_rejected(RootPolicy(()), tmp_path)
+
+
+def test_root_policy_rejects_non_path_values_with_the_fixed_invariant(
+    tmp_path: Path,
+) -> None:
+    _assert_cwd_rejected(RootPolicy((tmp_path,)), 42)  # type: ignore[arg-type]
+
+
+def test_root_policy_returns_canonical_contained_directory(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    nested = root / "source" / "package"
+    nested.mkdir(parents=True)
+
+    result = RootPolicy((root,)).directory(root / "source" / ".." / "source" / "package")
+
+    assert result == nested.resolve()
+    assert result.is_absolute()
+
+
+def test_root_policy_uses_process_cwd_only_when_contained(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "repo"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    assert RootPolicy((root,)).directory(None) == nested.resolve()
+
+    monkeypatch.chdir(tmp_path)
+    _assert_cwd_rejected(RootPolicy((root,)), None)
+
+
+@pytest.mark.parametrize("kind", ["missing", "file", "parent_traversal"])
+def test_root_policy_rejects_non_directories_and_escaped_paths(
+    tmp_path: Path, kind: str
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    if kind == "missing":
+        candidate = root / "missing"
+    elif kind == "file":
+        candidate = root / "file.txt"
+        candidate.write_text("planted")
+    else:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        candidate = root / ".." / "outside"
+
+    _assert_cwd_rejected(RootPolicy((root,)), candidate)
+
+
+@pytest.mark.parametrize("symlink_location", ["parent", "leaf"])
+def test_root_policy_rejects_parent_and_leaf_symlink_escapes(
+    tmp_path: Path, symlink_location: str
+) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    if symlink_location == "parent":
+        link = root / "linked-parent"
+        link.symlink_to(outside, target_is_directory=True)
+        candidate = link / "child"
+        (outside / "child").mkdir()
+    else:
+        link = root / "linked-leaf"
+        link.symlink_to(outside, target_is_directory=True)
+        candidate = link
+
+    _assert_cwd_rejected(RootPolicy((root,)), candidate)
+
+
+def test_root_policy_fails_closed_when_root_disappears_after_configuration(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "repo"
+    nested.mkdir(parents=True)
+    policy = RootPolicy((root,))
+    shutil.rmtree(root)
+
+    _assert_cwd_rejected(policy, nested)

--- a/tests/test_grok_paths.py
+++ b/tests/test_grok_paths.py
@@ -31,6 +31,23 @@ def test_root_policy_rejects_non_path_values_with_the_fixed_invariant(
     _assert_cwd_rejected(RootPolicy((tmp_path,)), 42)  # type: ignore[arg-type]
 
 
+def test_root_policy_resolution_error_has_no_raw_exception_chain(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    planted = "xai-planted-absolute-cwd-secret"
+    missing = (root / planted / "missing").absolute()
+
+    with pytest.raises(InputValidationError) as caught:
+        RootPolicy((root,)).directory(missing)
+
+    assert caught.value.invariant == _CWD_INVARIANT
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert str(missing) not in str(caught.value)
+
+
 def test_root_policy_returns_canonical_contained_directory(tmp_path: Path) -> None:
     root = tmp_path / "root"
     nested = root / "source" / "package"

--- a/tests/test_grok_setup.py
+++ b/tests/test_grok_setup.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt2agent._bounded_process import ProcessResult
+from gpt2agent.grok_errors import GrokError
+from gpt2agent.grok_setup import (
+    import_browser_web_auth,
+    run_grok_setup,
+    setup_web_auth,
+)
+from gpt2agent.grok_web_auth import GrokWebAuthStore
+
+
+def _process(payload: Any = None, *, returncode: int = 0) -> ProcessResult:
+    stdout = b"" if payload is None else json.dumps(payload).encode("utf-8")
+    return ProcessResult(returncode, stdout, b"")
+
+
+def _response(data: dict[str, Any]) -> dict[str, Any]:
+    return {"id": "planted-request", "success": True, "data": data}
+
+
+def _browser_cookie(
+    name: str,
+    value: str,
+    *,
+    expires: int,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "value": value,
+        "domain": ".grok.com",
+        "path": "/",
+        "secure": True,
+        "httpOnly": True,
+        "sameSite": "Lax",
+        "expires": expires,
+    }
+
+
+class RecordingRunner:
+    def __init__(self, results: Sequence[ProcessResult | BaseException]) -> None:
+        self.results = list(results)
+        self.calls: list[list[str]] = []
+        self.options: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        timeout_seconds: float,
+        max_output_bytes: int,
+    ) -> ProcessResult:
+        self.calls.append(list(argv))
+        self.options.append(
+            {
+                "cwd": cwd,
+                "env": dict(env),
+                "timeout_seconds": timeout_seconds,
+                "max_output_bytes": max_output_bytes,
+            }
+        )
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _successful_results(
+    *,
+    now: int,
+    user_agent: str = "Mozilla/5.0 Chrome/131.0.0.0 Safari/537.36",
+) -> list[ProcessResult]:
+    cookies = [
+        _browser_cookie("sso", "planted-sso-secret", expires=now + 3_600),
+        _browser_cookie("sso-rw", "planted-rw-secret", expires=now + 3_600),
+        _browser_cookie(
+            "cf_clearance", "planted-clearance-secret", expires=now + 3_600
+        ),
+        _browser_cookie("unrelated", "planted-unrelated", expires=now + 3_600),
+    ]
+    return [
+        _process(_response({"url": "https://grok.com/"})),
+        _process(_response({"cookies": cookies})),
+        _process(_response({"result": user_agent})),
+        _process(_response({"shutdown": True})),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_browser_import_uses_one_owned_session_and_exact_argv_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = int(time.time())
+    runner = RecordingRunner(_successful_results(now=now))
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    owned_session = "gpt2agent-grok-planted-session"
+    monkeypatch.setenv("XAI_API_KEY", "xai-planted-cross-lane-secret")
+    monkeypatch.setenv("GROK_CODE_XAI_API_KEY", "xai-planted-build-secret")
+
+    status = await import_browser_web_auth(
+        auth_path,
+        chrome_profile="Default",
+        runner=runner,
+        resolver=lambda name: name if name == "browser-use" else None,
+        session_factory=lambda: owned_session,
+    )
+
+    assert runner.calls[0] == [
+        "browser-use",
+        "--headed",
+        "--profile",
+        "Default",
+        "--session",
+        owned_session,
+        "--json",
+        "open",
+        "https://grok.com/",
+    ]
+    assert runner.calls[1] == [
+        "browser-use",
+        "--profile",
+        "Default",
+        "--session",
+        owned_session,
+        "--json",
+        "cookies",
+        "get",
+        "--url",
+        "https://grok.com/",
+    ]
+    assert runner.calls[2] == [
+        "browser-use",
+        "--profile",
+        "Default",
+        "--session",
+        owned_session,
+        "--json",
+        "eval",
+        "navigator.userAgent",
+    ]
+    assert runner.calls[-1] == [
+        "browser-use",
+        "--profile",
+        "Default",
+        "--session",
+        owned_session,
+        "close",
+    ]
+    assert all(call.count(owned_session) == 1 for call in runner.calls)
+    assert not any(call[-2:] == ["close", "--all"] for call in runner.calls)
+    assert not any("export" in call for call in runner.calls)
+    assert all(options["max_output_bytes"] == 131_072 for options in runner.options)
+    assert all("XAI_API_KEY" not in options["env"] for options in runner.options)
+    assert all(
+        "GROK_CODE_XAI_API_KEY" not in options["env"] for options in runner.options
+    )
+    assert status["cookie_names"] == ["cf_clearance", "sso", "sso-rw"]
+
+    stored = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert stored["browser_impersonation"] == "chrome131"
+    assert "userAgent" not in repr(stored)
+    assert "Mozilla" not in repr(stored)
+    assert {cookie["name"] for cookie in stored["cookies"]} == {
+        "sso",
+        "sso-rw",
+        "cf_clearance",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "Mozilla/5.0 Chrome/130.0.0.0 Safari/537.36",
+        "Mozilla/5.0 Chromium/131.0.0.0 Safari/537.36",
+        "planted-unparseable-agent",
+    ],
+)
+async def test_browser_import_discards_clearance_without_exact_supported_major(
+    tmp_path: Path,
+    user_agent: str,
+) -> None:
+    now = int(time.time())
+    runner = RecordingRunner(_successful_results(now=now, user_agent=user_agent))
+    auth_path = tmp_path / "private" / f"{len(user_agent)}-auth.json"
+
+    status = await import_browser_web_auth(
+        auth_path,
+        runner=runner,
+        resolver=lambda _: "browser-use",
+        session_factory=lambda: "gpt2agent-grok-unsupported-ua",
+    )
+
+    assert "cf_clearance" not in status["cookie_names"]
+    stored = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert "cf_clearance" not in {cookie["name"] for cookie in stored["cookies"]}
+    assert user_agent not in repr(stored)
+
+
+@pytest.mark.asyncio
+async def test_browser_import_drops_invalid_optional_cookie_metadata(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    cookies = [
+        _browser_cookie("sso", "planted-sso-secret", expires=now + 3_600),
+        _browser_cookie("sso-rw", "planted-rw-secret", expires=now + 3_600),
+        _browser_cookie("grok_device_id", "planted-device", expires=now + 3_600)
+        | {"secure": False},
+    ]
+    runner = RecordingRunner(
+        [
+            _process(_response({"url": "https://grok.com/"})),
+            _process(_response({"cookies": cookies})),
+            _process(
+                _response(
+                    {
+                        "result": (
+                            "Mozilla/5.0 Chrome/131.0.0.0 Safari/537.36"
+                        )
+                    }
+                )
+            ),
+            _process(_response({"shutdown": True})),
+        ]
+    )
+
+    status = await import_browser_web_auth(
+        tmp_path / "private" / "auth.json",
+        runner=runner,
+        resolver=lambda _: "browser-use",
+        session_factory=lambda: "gpt2agent-grok-drop-optional",
+    )
+
+    assert status["cookie_names"] == ["sso", "sso-rw"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["open", "cookies", "write"])
+async def test_browser_import_closes_only_owned_session_on_every_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    now = int(time.time())
+    owned_session = f"gpt2agent-grok-{failure_point}"
+    if failure_point == "open":
+        results: list[ProcessResult | BaseException] = [
+            RuntimeError("planted-open-secret"),
+            _process(_response({"shutdown": True})),
+        ]
+    elif failure_point == "cookies":
+        results = [
+            _process(_response({"url": "https://grok.com/"})),
+            _process({"success": True, "data": {"cookies": "not-a-list"}}),
+            _process(_response({"shutdown": True})),
+        ]
+    else:
+        results = _successful_results(now=now)
+        from gpt2agent import grok_setup
+
+        def fail_write(path: Path, value: Any) -> None:
+            raise RuntimeError("planted-write-secret")
+
+        monkeypatch.setattr(grok_setup, "write_private_json", fail_write)
+    runner = RecordingRunner(results)
+
+    with pytest.raises(GrokError) as caught:
+        await import_browser_web_auth(
+            tmp_path / "private" / "auth.json",
+            runner=runner,
+            resolver=lambda _: "browser-use",
+            session_factory=lambda: owned_session,
+        )
+
+    assert caught.value.code == "GROK_WEB_FAILED"
+    assert "planted" not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert runner.calls[-1] == [
+        "browser-use",
+        "--profile",
+        "Default",
+        "--session",
+        owned_session,
+        "close",
+    ]
+    assert not any("--all" in call or "export" in call for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_browser_import_reports_owned_session_close_failure(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    results: list[ProcessResult | BaseException] = _successful_results(now=now)[:-1]
+    results.append(RuntimeError("planted-close-secret"))
+    runner = RecordingRunner(results)
+
+    with pytest.raises(GrokError) as caught:
+        await import_browser_web_auth(
+            tmp_path / "private" / "auth.json",
+            runner=runner,
+            resolver=lambda _: "browser-use",
+            session_factory=lambda: "gpt2agent-grok-close-failure",
+        )
+
+    assert caught.value.code == "GROK_WEB_FAILED"
+    assert "planted-close-secret" not in str(caught.value)
+    assert runner.calls[-1][-1] == "close"
+
+
+@pytest.mark.asyncio
+async def test_manual_fallback_uses_hidden_injected_input_and_prints_nothing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    prompts: list[str] = []
+    answers = iter(["planted-manual-sso", "planted-manual-rw"])
+
+    def hidden_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(answers)
+
+    status = await setup_web_auth(
+        tmp_path / "private" / "auth.json",
+        manual=True,
+        resolver=lambda _: pytest.fail("manual setup must not discover a browser"),
+        getpass_fn=hidden_input,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert len(prompts) == 2
+    assert all("planted" not in prompt for prompt in prompts)
+    assert status["cookie_names"] == ["sso", "sso-rw"]
+    assert "planted" not in repr(status)
+
+
+@pytest.mark.asyncio
+async def test_missing_browser_automatically_uses_hidden_manual_fallback(
+    tmp_path: Path,
+) -> None:
+    answers = iter(["planted-auto-sso", "planted-auto-rw"])
+    status = await setup_web_auth(
+        tmp_path / "private" / "auth.json",
+        resolver=lambda _: None,
+        getpass_fn=lambda _: next(answers),
+    )
+
+    assert status["authenticated"] is True
+    assert status["cookie_names"] == ["sso", "sso-rw"]
+
+
+class _TypedBuildFailure:
+    async def __call__(self) -> dict[str, Any]:
+        raise GrokError("GROK_BUILD_AUTH_MISSING", retryable=False)
+
+
+class _TypedWebFailure:
+    async def __call__(self) -> dict[str, Any]:
+        raise GrokError("GROK_WEB_AUTH_MISSING", retryable=False)
+
+
+@pytest.mark.asyncio
+async def test_build_failure_does_not_prevent_web_setup() -> None:
+    calls: list[str] = []
+
+    async def web_setup() -> dict[str, Any]:
+        calls.append("web")
+        return {
+            "configured": True,
+            "authenticated": True,
+            "expires_at": 1_800_000_000,
+            "cookie_names": ["sso", "sso-rw"],
+        }
+
+    receipt = await run_grok_setup(
+        build_probe=_TypedBuildFailure(),
+        web_setup=web_setup,
+    )
+
+    assert calls == ["web"]
+    assert receipt == {
+        "status": "partial",
+        "build": {"status": "failed", "code": "GROK_BUILD_AUTH_MISSING"},
+        "web": {"status": "ok", "code": "OK"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_failure_does_not_erase_successful_build_probe() -> None:
+    calls: list[str] = []
+
+    async def build_probe() -> dict[str, Any]:
+        calls.append("build")
+        return {
+            "installed": True,
+            "version": "planted-version",
+            "authenticated": True,
+            "default_model": "planted-model",
+            "models_count": 2,
+        }
+
+    receipt = await run_grok_setup(
+        build_probe=build_probe,
+        web_setup=_TypedWebFailure(),
+    )
+
+    assert calls == ["build"]
+    assert receipt == {
+        "status": "partial",
+        "build": {"status": "ok", "code": "OK"},
+        "web": {"status": "failed", "code": "GROK_WEB_AUTH_MISSING"},
+    }
+    assert "planted-version" not in repr(receipt)
+    assert "planted-model" not in repr(receipt)
+
+
+@pytest.mark.asyncio
+async def test_both_lanes_are_attempted_and_receipt_never_contains_failures() -> None:
+    calls: list[str] = []
+
+    async def build_failure() -> dict[str, Any]:
+        calls.append("build")
+        raise GrokError("GROK_BUILD_FAILED", retryable=False)
+
+    async def web_failure() -> dict[str, Any]:
+        calls.append("web")
+        raise GrokError("GROK_WEB_FAILED", retryable=False)
+
+    receipt = await run_grok_setup(
+        build_probe=build_failure,
+        web_setup=web_failure,
+    )
+
+    assert calls == ["build", "web"]
+    assert receipt == {
+        "status": "failed",
+        "build": {"status": "failed", "code": "GROK_BUILD_FAILED"},
+        "web": {"status": "failed", "code": "GROK_WEB_FAILED"},
+    }
+    rendered = repr(receipt)
+    assert "exception" not in rendered.lower()
+    assert "cookie" not in rendered.lower()
+    assert "identity" not in rendered.lower()
+
+
+def test_grok_setup_help_has_no_account_or_browser_side_effects(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    completed = subprocess.run(
+        [sys.executable, "-m", "gpt2agent", "grok-setup", "--help"],
+        cwd=Path(__file__).parents[1],
+        env={"HOME": str(home), "PATH": ""},
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert "--refresh" in completed.stdout
+    assert "--chrome-profile" in completed.stdout
+    assert "--manual" in completed.stdout
+    assert not (home / ".gpt2agent").exists()
+
+
+def test_imported_auth_round_trips_through_store(tmp_path: Path) -> None:
+    now = int(time.time())
+    runner = RecordingRunner(_successful_results(now=now))
+    path = tmp_path / "private" / "auth.json"
+
+    async def exercise() -> None:
+        await import_browser_web_auth(
+            path,
+            runner=runner,
+            resolver=lambda _: "browser-use",
+            session_factory=lambda: "gpt2agent-grok-round-trip",
+        )
+
+    import asyncio
+
+    asyncio.run(exercise())
+    assert GrokWebAuthStore(path).status()["authenticated"] is True

--- a/tests/test_grok_setup.py
+++ b/tests/test_grok_setup.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from gpt2agent._bounded_process import ProcessResult
+from gpt2agent._secure_file import write_private_json
 from gpt2agent.grok_errors import GrokError
 from gpt2agent.grok_setup import (
     import_browser_web_auth,
@@ -364,6 +365,84 @@ async def test_missing_browser_automatically_uses_hidden_manual_fallback(
 
     assert status["authenticated"] is True
     assert status["cookie_names"] == ["sso", "sso-rw"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_name", ["sso", "sso-rw"])
+@pytest.mark.parametrize(
+    ("case", "invalid_value"),
+    [
+        ("blank", ""),
+        ("blank-whitespace", "   "),
+        ("control", "planted-control\nsecret"),
+        ("oversized", "planted-" + "x" * (16_385 - len("planted-"))),
+    ],
+    ids=("blank", "blank-whitespace", "control", "oversized"),
+)
+async def test_invalid_manual_cookie_preserves_existing_private_auth(
+    tmp_path: Path,
+    invalid_name: str,
+    case: str,
+    invalid_value: str,
+) -> None:
+    now = int(time.time())
+    path = tmp_path / "private" / "grok-web-auth.json"
+    existing = {
+        "schema_version": 1,
+        "source": "manual",
+        "browser_impersonation": "chrome131",
+        "cookies": [
+            {
+                "name": name,
+                "domain": ".grok.com",
+                "path": "/",
+                "expires": now + 3_600,
+                "secure": True,
+                "http_only": True,
+                "value": f"planted-existing-{name}-secret",
+            }
+            for name in ("sso", "sso-rw")
+        ],
+    }
+    write_private_json(path, existing)
+    original_bytes = path.read_bytes()
+    original_stat = path.stat()
+    original_fingerprint = (
+        original_stat.st_dev,
+        original_stat.st_ino,
+        original_stat.st_size,
+        original_stat.st_mtime_ns,
+    )
+    answers = {
+        "sso": invalid_value
+        if invalid_name == "sso"
+        else "planted-replacement-sso-secret",
+        "sso-rw": invalid_value
+        if invalid_name == "sso-rw"
+        else "planted-replacement-rw-secret",
+    }
+    supplied = iter((answers["sso"], answers["sso-rw"]))
+
+    with pytest.raises(GrokError) as caught:
+        await setup_web_auth(
+            path,
+            manual=True,
+            getpass_fn=lambda _: next(supplied),
+        )
+
+    assert caught.value.code == "GROK_WEB_AUTH_MISSING"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    if invalid_value:
+        assert invalid_value not in str(caught.value)
+    assert path.read_bytes() == original_bytes
+    current_stat = path.stat()
+    assert (
+        current_stat.st_dev,
+        current_stat.st_ino,
+        current_stat.st_size,
+        current_stat.st_mtime_ns,
+    ) == original_fingerprint, case
 
 
 class _TypedBuildFailure:

--- a/tests/test_grok_upload.py
+++ b/tests/test_grok_upload.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import errno
+import os
+import socket
+import stat
+from pathlib import Path
+
+import pytest
+
+from gpt2agent.grok_errors import GrokError
+from gpt2agent.grok_upload import (
+    DEFAULT_UPLOAD_MAX_BYTES,
+    DEFAULT_UPLOAD_TYPES,
+    AttachmentRegistry,
+    GrokUploadPolicy,
+    ValidatedUpload,
+)
+
+
+def _assert_blocked(error: GrokError, *planted: str) -> None:
+    assert error.code == "GROK_UPLOAD_BLOCKED"
+    assert error.retryable is False
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert error.__dict__ == {
+        "code": "GROK_UPLOAD_BLOCKED",
+        "method": None,
+        "route": None,
+        "status_code": None,
+        "retryable": False,
+        "retry_after": None,
+    }
+    for value in planted:
+        if value.strip():
+            assert value not in str(error)
+
+
+def _rejected_open(policy: GrokUploadPolicy, value: object) -> GrokError:
+    with pytest.raises(GrokError) as caught:
+        policy.open(value)  # type: ignore[arg-type]
+    _assert_blocked(caught.value, str(value))
+    return caught.value
+
+
+def _assert_fd_closed(fd: int) -> None:
+    with pytest.raises(OSError) as caught:
+        os.fstat(fd)
+    assert caught.value.errno == errno.EBADF
+
+
+def test_upload_contract_constants_are_fixed() -> None:
+    assert DEFAULT_UPLOAD_MAX_BYTES == 25 * 1024 * 1024
+    assert DEFAULT_UPLOAD_TYPES == frozenset(
+        {
+            "text/plain",
+            "text/markdown",
+            "application/pdf",
+            "application/json",
+            "text/csv",
+            "image/png",
+            "image/jpeg",
+            "image/webp",
+        }
+    )
+
+
+def test_policy_returns_owned_rewound_descriptor_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "NOTE.TXT"
+    source.write_bytes(b"descriptor source")
+
+    upload = GrokUploadPolicy((root,)).open(str(source.absolute()))
+
+    try:
+        assert upload == ValidatedUpload(
+            fd=upload.fd,
+            name="NOTE.TXT",
+            media_type="text/plain",
+            size=17,
+        )
+        assert os.get_inheritable(upload.fd) is False
+        assert os.lseek(upload.fd, 0, os.SEEK_CUR) == 0
+        assert os.read(upload.fd, 17) == b"descriptor source"
+    finally:
+        os.close(upload.fd)
+    _assert_fd_closed(upload.fd)
+
+
+def test_returned_descriptor_is_not_a_later_path_reopen(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_bytes(b"original")
+    upload = GrokUploadPolicy((root,), maximum_bytes=64).open(str(source))
+    source.unlink()
+    source.write_bytes(b"replacement")
+
+    try:
+        assert upload.size == len(b"original")
+        assert os.read(upload.fd, 64) == b"original"
+        assert source.read_bytes() == b"replacement"
+    finally:
+        os.close(upload.fd)
+
+
+def test_parent_replacement_after_descriptor_open_cannot_redirect_leaf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    parent = root / "parent"
+    outside = tmp_path / "outside"
+    parent.mkdir(parents=True)
+    outside.mkdir()
+    (parent / "source.txt").write_bytes(b"contained")
+    (outside / "source.txt").write_bytes(b"outside")
+    parked = root / "parked"
+    real_open = os.open
+    replaced = False
+
+    def replacing_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        nonlocal replaced
+        fd = real_open(path, flags, *args, **kwargs)
+        if path == "parent" and not replaced:
+            replaced = True
+            parent.rename(parked)
+            parent.symlink_to(outside, target_is_directory=True)
+        return fd
+
+    monkeypatch.setattr(upload_module.os, "open", replacing_open)
+    upload = GrokUploadPolicy((root,)).open(str(parent / "source.txt"))
+
+    try:
+        assert os.read(upload.fd, 64) == b"contained"
+    finally:
+        os.close(upload.fd)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, 3, b"/tmp/file.txt", "", "   ", "bad\x00path.txt", "x" * 4_097],
+)
+def test_policy_rejects_invalid_and_overlong_paths(
+    tmp_path: Path, value: object
+) -> None:
+    _rejected_open(GrokUploadPolicy((tmp_path,)), value)
+
+
+def test_policy_rejects_disabled_relative_parent_and_outside_paths(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    relative = "source.txt"
+    parent_escape = str(root / "nested" / ".." / "source.txt")
+    outside_path = outside / "source.txt"
+    outside_path.write_text("outside")
+
+    _rejected_open(GrokUploadPolicy(()), str(outside_path))
+    policy = GrokUploadPolicy((root,))
+    _rejected_open(policy, relative)
+    _rejected_open(policy, parent_escape)
+    _rejected_open(policy, str(outside_path))
+
+
+@pytest.mark.parametrize("location", ["parent", "leaf"])
+def test_policy_rejects_symlinked_parents_and_leaves(
+    tmp_path: Path, location: str
+) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    target = outside / "secret.txt"
+    target.write_text("outside")
+    if location == "parent":
+        link = root / "linked"
+        link.symlink_to(outside, target_is_directory=True)
+        candidate = link / target.name
+    else:
+        candidate = root / "secret.txt"
+        candidate.symlink_to(target)
+
+    _rejected_open(GrokUploadPolicy((root,)), str(candidate))
+
+
+@pytest.mark.parametrize(
+    ("name", "content"),
+    [
+        ("unknown.exe", b"data"),
+        ("double.txt.exe", b"data"),
+        ("credential.env.txt", b"data"),
+        ("secret.pem", b"data"),
+        ("empty.txt", b""),
+        ("oversized.txt", b"12345"),
+    ],
+)
+def test_policy_rejects_unsafe_suffixes_empty_and_oversized_files(
+    tmp_path: Path,
+    name: str,
+    content: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / name
+    source.write_bytes(content)
+    real_open = os.open
+    acquired: list[int] = []
+
+    def recording_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        fd = real_open(path, flags, *args, **kwargs)
+        acquired.append(fd)
+        return fd
+
+    monkeypatch.setattr(upload_module.os, "open", recording_open)
+
+    _rejected_open(GrokUploadPolicy((root,), maximum_bytes=4), str(source))
+    for fd in acquired:
+        _assert_fd_closed(fd)
+
+
+def test_policy_rejects_a_mapped_type_removed_by_configuration(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_text("data")
+
+    _rejected_open(
+        GrokUploadPolicy((root,), allowed_types={"application/pdf"}),
+        str(source),
+    )
+
+
+@pytest.mark.parametrize(
+    ("maximum_bytes", "allowed_types"),
+    [
+        (True, DEFAULT_UPLOAD_TYPES),
+        (0, DEFAULT_UPLOAD_TYPES),
+        (-1, DEFAULT_UPLOAD_TYPES),
+        (DEFAULT_UPLOAD_MAX_BYTES + 1, DEFAULT_UPLOAD_TYPES),
+        (DEFAULT_UPLOAD_MAX_BYTES, ["text/plain"]),
+        (DEFAULT_UPLOAD_MAX_BYTES, {"application/x-secret"}),
+        (DEFAULT_UPLOAD_MAX_BYTES, {"text/plain", 3}),
+    ],
+)
+def test_policy_configuration_can_only_lower_limits_and_narrow_types(
+    tmp_path: Path, maximum_bytes: object, allowed_types: object
+) -> None:
+    with pytest.raises(GrokError) as caught:
+        GrokUploadPolicy(
+            (tmp_path,),
+            maximum_bytes=maximum_bytes,  # type: ignore[arg-type]
+            allowed_types=allowed_types,  # type: ignore[arg-type]
+        )
+    _assert_blocked(caught.value)
+
+
+def test_policy_rejects_non_regular_nodes_without_blocking_and_closes_descriptors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    directory = root / "directory.txt"
+    directory.mkdir()
+    fifo = root / "pipe.txt"
+    os.mkfifo(fifo)
+    unix_socket = root / "socket.txt"
+    listener = socket.socket(socket.AF_UNIX)
+    listener.bind(str(unix_socket))
+    real_open = os.open
+    acquired: list[int] = []
+
+    def recording_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        fd = real_open(path, flags, *args, **kwargs)
+        acquired.append(fd)
+        return fd
+
+    monkeypatch.setattr(upload_module.os, "open", recording_open)
+    try:
+        policy = GrokUploadPolicy((root,))
+        for candidate in (directory, fifo, unix_socket):
+            _rejected_open(policy, str(candidate))
+            for fd in acquired:
+                _assert_fd_closed(fd)
+            acquired.clear()
+    finally:
+        listener.close()
+
+
+@pytest.mark.skipif(not Path("/dev/null").exists(), reason="POSIX device unavailable")
+def test_policy_rejects_device_nodes() -> None:
+    _rejected_open(GrokUploadPolicy((Path("/dev"),)), "/dev/null")
+
+
+def test_policy_closes_leaf_descriptor_when_metadata_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_bytes(b"stable")
+    real_open = os.open
+    real_fstat = os.fstat
+    leaf_fd: int | None = None
+    regular_stats = 0
+
+    def recording_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        nonlocal leaf_fd
+        fd = real_open(path, flags, *args, **kwargs)
+        if path == source.name and not flags & os.O_DIRECTORY:
+            leaf_fd = fd
+        return fd
+
+    def mismatching_fstat(fd: int) -> os.stat_result:
+        nonlocal regular_stats
+        result = real_fstat(fd)
+        if stat.S_ISREG(result.st_mode):
+            regular_stats += 1
+            if regular_stats == 2:
+                values = list(result)
+                values[6] = result.st_size + 1
+                return os.stat_result(values)
+        return result
+
+    monkeypatch.setattr(upload_module.os, "open", recording_open)
+    monkeypatch.setattr(upload_module.os, "fstat", mismatching_fstat)
+
+    _rejected_open(GrokUploadPolicy((root,)), str(source))
+    assert leaf_fd is not None
+    _assert_fd_closed(leaf_fd)
+
+
+def test_policy_rejects_same_size_content_change_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_bytes(b"stable")
+    real_fstat = os.fstat
+    regular_stats = 0
+
+    def changed_fstat(fd: int) -> os.stat_result:
+        nonlocal regular_stats
+        result = real_fstat(fd)
+        if stat.S_ISREG(result.st_mode):
+            regular_stats += 1
+            if regular_stats == 2:
+                values = list(result)
+                values[8] = result.st_mtime + 1
+                return os.stat_result(values)
+        return result
+
+    monkeypatch.setattr(upload_module.os, "fstat", changed_fstat)
+
+    _rejected_open(GrokUploadPolicy((root,)), str(source))
+
+
+def test_policy_closes_leaf_descriptor_and_detaches_read_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_bytes(b"secret")
+    planted = "xai-planted-os-path-secret"
+    real_open = os.open
+    leaf_fd: int | None = None
+
+    def recording_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        nonlocal leaf_fd
+        fd = real_open(path, flags, *args, **kwargs)
+        if path == source.name and not flags & os.O_DIRECTORY:
+            leaf_fd = fd
+        return fd
+
+    def failing_read(fd: int, amount: int) -> bytes:
+        raise OSError(planted)
+
+    monkeypatch.setattr(upload_module.os, "open", recording_open)
+    monkeypatch.setattr(upload_module.os, "read", failing_read)
+
+    error = _rejected_open(GrokUploadPolicy((root,)), str(source))
+    _assert_blocked(error, planted, str(source))
+    assert leaf_fd is not None
+    _assert_fd_closed(leaf_fd)
+
+
+def test_policy_fails_closed_when_required_posix_primitive_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    source = root / "source.txt"
+    source.write_text("data")
+    monkeypatch.delattr(upload_module.os, "O_NOFOLLOW")
+
+    _rejected_open(GrokUploadPolicy((root,)), str(source))
+
+
+def test_registry_records_and_validates_current_generation_ids() -> None:
+    registry = AttachmentRegistry()
+
+    registry.record(auth_generation=3, attachment_id="att_test_1")
+
+    assert registry.validate_many(3, ["att_test_1"]) == ("att_test_1",)
+    with pytest.raises(GrokError) as caught:
+        registry.validate_many(4, ["att_test_1"])
+    _assert_blocked(caught.value, "att_test_1")
+
+
+def test_registry_allows_no_attachments_before_any_upload() -> None:
+    assert AttachmentRegistry().validate_many(7, ()) == ()
+
+
+@pytest.mark.parametrize("generation", [True, -1, 1.5, "1", None])
+def test_registry_rejects_invalid_auth_generations(generation: object) -> None:
+    registry = AttachmentRegistry()
+
+    with pytest.raises(GrokError) as caught:
+        registry.record(generation, "att_test_1")  # type: ignore[arg-type]
+    _assert_blocked(caught.value)
+
+
+@pytest.mark.parametrize(
+    "attachment_id",
+    [
+        "",
+        " ",
+        "a" * 129,
+        "att/control\n",
+        "att/slash",
+        "att secret",
+        "att_☃",
+        3,
+        None,
+    ],
+)
+def test_registry_rejects_unbounded_or_invalid_server_ids(
+    attachment_id: object,
+) -> None:
+    registry = AttachmentRegistry()
+
+    with pytest.raises(GrokError) as caught:
+        registry.record(1, attachment_id)  # type: ignore[arg-type]
+    _assert_blocked(caught.value, str(attachment_id))
+
+
+def test_registry_rotates_generation_and_new_process_has_no_ids() -> None:
+    registry = AttachmentRegistry()
+    registry.record(3, "att_old")
+    registry.record(4, "att_new")
+
+    with pytest.raises(GrokError):
+        registry.validate_many(3, ["att_old"])
+    with pytest.raises(GrokError):
+        registry.validate_many(4, ["att_old"])
+    assert registry.validate_many(4, ["att_new"]) == ("att_new",)
+
+    with pytest.raises(GrokError):
+        AttachmentRegistry().validate_many(4, ["att_new"])
+
+
+def test_registry_rejects_generation_rollback_without_reactivating_old_ids() -> None:
+    registry = AttachmentRegistry()
+    registry.record(3, "att_old")
+    registry.record(4, "att_current")
+
+    with pytest.raises(GrokError):
+        registry.record(3, "att_stale")
+
+    assert registry.validate_many(4, ["att_current"]) == ("att_current",)
+    with pytest.raises(GrokError):
+        registry.validate_many(3, ["att_stale"])
+
+
+def test_registry_capacity_is_256_with_oldest_first_eviction() -> None:
+    registry = AttachmentRegistry()
+    for index in range(257):
+        registry.record(8, f"att_{index:03d}")
+
+    with pytest.raises(GrokError):
+        registry.validate_many(8, ["att_000"])
+    assert registry.validate_many(8, ["att_001", "att_256"]) == (
+        "att_001",
+        "att_256",
+    )
+
+
+def test_registry_rerecord_is_idempotent_without_refreshing_eviction_order() -> None:
+    registry = AttachmentRegistry()
+    registry.record(1, "att_oldest")
+    for index in range(255):
+        registry.record(1, f"att_{index:03d}")
+    registry.record(1, "att_oldest")
+    registry.record(1, "att_new")
+
+    with pytest.raises(GrokError):
+        registry.validate_many(1, ["att_oldest"])
+    assert registry.validate_many(1, ["att_new"]) == ("att_new",)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        "att_test_1",
+        b"att_test_1",
+        ["unknown"],
+        ["att_test_1", "att_test_1"],
+        [f"att_{index}" for index in range(21)],
+        ["att_test_1", "bad/id"],
+    ],
+)
+def test_registry_rejects_invalid_unknown_duplicate_and_overlong_lists(
+    values: object,
+) -> None:
+    registry = AttachmentRegistry()
+    registry.record(1, "att_test_1")
+
+    with pytest.raises(GrokError) as caught:
+        registry.validate_many(1, values)  # type: ignore[arg-type]
+    _assert_blocked(caught.value)
+
+
+def test_registry_returns_an_immutable_tuple_in_caller_order() -> None:
+    registry = AttachmentRegistry()
+    for value in ("att_a", "att_b", "att_c"):
+        registry.record(2, value)
+
+    result = registry.validate_many(2, ["att_c", "att_a", "att_b"])
+
+    assert result == ("att_c", "att_a", "att_b")
+    assert isinstance(result, tuple)

--- a/tests/test_grok_upload.py
+++ b/tests/test_grok_upload.py
@@ -4,6 +4,7 @@ import errno
 import os
 import socket
 import stat
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -47,6 +48,24 @@ def _assert_fd_closed(fd: int) -> None:
     with pytest.raises(OSError) as caught:
         os.fstat(fd)
     assert caught.value.errno == errno.EBADF
+
+
+def _assert_upload_traceback_locals_are_secret_free(
+    error: GrokError, planted: str, expected_function: str
+) -> None:
+    upload_frames: list[str] = []
+    traceback = error.__traceback__
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if Path(frame.f_code.co_filename).name == "grok_upload.py":
+            upload_frames.append(frame.f_code.co_name)
+            assert frame.f_locals.get("self") is None
+            for local_name, value in frame.f_locals.items():
+                assert planted not in repr(value), (
+                    f"{planted!r} retained by {frame.f_code.co_name}.{local_name}"
+                )
+        traceback = traceback.tb_next
+    assert upload_frames == [expected_function]
 
 
 def test_upload_contract_constants_are_fixed() -> None:
@@ -139,6 +158,43 @@ def test_parent_replacement_after_descriptor_open_cannot_redirect_leaf(
         os.close(upload.fd)
 
 
+def test_leaf_swap_immediately_before_open_is_blocked_and_closes_descriptors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    source = root / "source.txt"
+    source.write_bytes(b"contained")
+    outside_source = outside / "source.txt"
+    outside_source.write_bytes(b"outside")
+    real_open = os.open
+    acquired: list[int] = []
+    swapped = False
+
+    def racing_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        nonlocal swapped
+        if path == source.name and not flags & os.O_DIRECTORY and not swapped:
+            swapped = True
+            source.unlink()
+            source.symlink_to(outside_source)
+        fd = real_open(path, flags, *args, **kwargs)
+        acquired.append(fd)
+        return fd
+
+    monkeypatch.setattr(upload_module.os, "open", racing_open)
+
+    _rejected_open(GrokUploadPolicy((root,)), str(source))
+
+    assert swapped is True
+    assert source.is_symlink()
+    for fd in acquired:
+        _assert_fd_closed(fd)
+
+
 @pytest.mark.parametrize(
     "value",
     [None, 3, b"/tmp/file.txt", "", "   ", "bad\x00path.txt", "x" * 4_097],
@@ -147,6 +203,95 @@ def test_policy_rejects_invalid_and_overlong_paths(
     tmp_path: Path, value: object
 ) -> None:
     _rejected_open(GrokUploadPolicy((tmp_path,)), value)
+
+
+@pytest.mark.parametrize(
+    "unsafe_leaf",
+    [
+        "line\nbreak.txt",
+        "control\x1fname.txt",
+        "format\u200bname.txt",
+        f"{'é' * 126}.txt",
+    ],
+)
+def test_policy_rejects_nonprintable_and_encoded_overlong_leaf_components(
+    tmp_path: Path, unsafe_leaf: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    policy = GrokUploadPolicy((root,))
+    open_calls = 0
+    real_open = os.open
+
+    def recording_open(path: str, flags: int, *args: object, **kwargs: object) -> int:
+        nonlocal open_calls
+        open_calls += 1
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(upload_module.os, "open", recording_open)
+
+    _rejected_open(policy, str(root / unsafe_leaf))
+
+    assert open_calls == 0
+
+
+def test_policy_applies_a_cheap_character_bound_before_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    policy = GrokUploadPolicy((tmp_path,))
+    encode_calls = 0
+
+    def recording_encode(path: str) -> bytes:
+        nonlocal encode_calls
+        encode_calls += 1
+        return path.encode()
+
+    monkeypatch.setattr(upload_module.os, "fsencode", recording_encode)
+
+    _rejected_open(policy, "/" + "x" * 4_097)
+
+    assert encode_calls == 0
+
+
+def test_policy_applies_a_cheap_component_bound_before_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gpt2agent.grok_upload as upload_module
+
+    root = tmp_path / "root"
+    root.mkdir()
+    policy = GrokUploadPolicy((root,))
+    encode_calls = 0
+
+    def recording_encode(path: str) -> bytes:
+        nonlocal encode_calls
+        encode_calls += 1
+        return path.encode()
+
+    monkeypatch.setattr(upload_module.os, "fsencode", recording_encode)
+
+    _rejected_open(policy, str(root / f"{'x' * 256}.txt"))
+
+    assert encode_calls == 0
+
+
+def test_policy_deliberately_allows_printable_unicode_components(tmp_path: Path) -> None:
+    root = tmp_path / "资料"
+    root.mkdir()
+    source = root / "报告.txt"
+    source.write_text("safe unicode")
+
+    upload = GrokUploadPolicy((root,)).open(str(source))
+
+    try:
+        assert upload.name == "报告.txt"
+        assert os.read(upload.fd, 64) == b"safe unicode"
+    finally:
+        os.close(upload.fd)
 
 
 def test_policy_rejects_disabled_relative_parent_and_outside_paths(
@@ -416,6 +561,30 @@ def test_policy_fails_closed_when_required_posix_primitive_is_unavailable(
     _rejected_open(GrokUploadPolicy((root,)), str(source))
 
 
+def test_constructor_error_traceback_scrubs_raw_root_locals() -> None:
+    planted = "xaiCtorTraceSecret42"
+    unsafe_root = Path("/tmp") / planted / ".."
+
+    with pytest.raises(GrokError) as caught:
+        GrokUploadPolicy((unsafe_root,))
+
+    _assert_blocked(caught.value, planted)
+    _assert_upload_traceback_locals_are_secret_free(caught.value, planted, "__init__")
+
+
+def test_open_error_traceback_scrubs_raw_path_and_name_locals(tmp_path: Path) -> None:
+    planted = "xaiOpenTraceSecret42"
+    root = tmp_path / "root"
+    root.mkdir()
+    unsafe_path = str(root / f"{planted}\n.txt")
+
+    with pytest.raises(GrokError) as caught:
+        GrokUploadPolicy((root,)).open(unsafe_path)
+
+    _assert_blocked(caught.value, planted)
+    _assert_upload_traceback_locals_are_secret_free(caught.value, planted, "open")
+
+
 def test_registry_records_and_validates_current_generation_ids() -> None:
     registry = AttachmentRegistry()
 
@@ -462,6 +631,16 @@ def test_registry_rejects_unbounded_or_invalid_server_ids(
     with pytest.raises(GrokError) as caught:
         registry.record(1, attachment_id)  # type: ignore[arg-type]
     _assert_blocked(caught.value, str(attachment_id))
+
+
+def test_record_error_traceback_scrubs_raw_attachment_id_locals() -> None:
+    planted = "xaiRecordTraceSecret42"
+
+    with pytest.raises(GrokError) as caught:
+        AttachmentRegistry().record(1, f"att/{planted}")
+
+    _assert_blocked(caught.value, planted)
+    _assert_upload_traceback_locals_are_secret_free(caught.value, planted, "record")
 
 
 def test_registry_rotates_generation_and_new_process_has_no_ids() -> None:
@@ -549,3 +728,90 @@ def test_registry_returns_an_immutable_tuple_in_caller_order() -> None:
 
     assert result == ("att_c", "att_a", "att_b")
     assert isinstance(result, tuple)
+
+
+def test_registry_uses_one_bounded_iterator_instead_of_a_lying_length() -> None:
+    class LyingSequence(Sequence[str]):
+        def __init__(self) -> None:
+            self.pulls = 0
+
+        def __len__(self) -> int:
+            return 0
+
+        def __getitem__(self, index: int) -> str:
+            if index >= 21:
+                raise IndexError
+            self.pulls += 1
+            return f"att_{index:02d}"
+
+    registry = AttachmentRegistry()
+    for index in range(21):
+        registry.record(1, f"att_{index:02d}")
+    values = LyingSequence()
+
+    with pytest.raises(GrokError) as caught:
+        registry.validate_many(1, values)
+
+    _assert_blocked(caught.value)
+    assert values.pulls == 21
+
+
+def test_registry_does_not_call_mutating_sequence_length() -> None:
+    class MutatingLengthSequence(Sequence[str]):
+        def __init__(self) -> None:
+            self.values = ["att_safe"]
+            self.length_calls = 0
+
+        def __len__(self) -> int:
+            self.length_calls += 1
+            self.values.extend(f"att_added_{index}" for index in range(20))
+            return 1
+
+        def __getitem__(self, index: int) -> str:
+            return self.values[index]
+
+    registry = AttachmentRegistry()
+    registry.record(1, "att_safe")
+    values = MutatingLengthSequence()
+
+    assert registry.validate_many(1, values) == ("att_safe",)
+    assert values.length_calls == 0
+
+
+def test_registry_bounds_a_sequence_that_does_not_terminate_itself() -> None:
+    class GuardedNonterminatingSequence(Sequence[str]):
+        def __init__(self) -> None:
+            self.pulls = 0
+
+        def __len__(self) -> int:
+            return 0
+
+        def __getitem__(self, index: int) -> str:
+            self.pulls += 1
+            if self.pulls > 25:
+                raise RuntimeError("test guard: iteration was not bounded")
+            return "att_forever"
+
+    registry = AttachmentRegistry()
+    registry.record(1, "att_forever")
+    values = GuardedNonterminatingSequence()
+
+    with pytest.raises(GrokError) as caught:
+        registry.validate_many(1, values)
+
+    _assert_blocked(caught.value)
+    assert values.pulls == 21
+
+
+def test_validate_many_error_traceback_scrubs_raw_id_and_sequence_locals() -> None:
+    planted = "xaiValidateTraceSecret42"
+    registry = AttachmentRegistry()
+    registry.record(2, "att_safe")
+
+    with pytest.raises(GrokError) as caught:
+        registry.validate_many(2, [f"att_{planted}"])
+
+    _assert_blocked(caught.value, planted)
+    _assert_upload_traceback_locals_are_secret_free(
+        caught.value, planted, "validate_many"
+    )

--- a/tests/test_grok_web_auth.py
+++ b/tests/test_grok_web_auth.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from gpt2agent._secure_file import write_private_json
+from gpt2agent.grok_errors import GrokError
+from gpt2agent.grok_web_auth import (
+    GrokWebAuthStore,
+    supported_browser_impersonations,
+)
+
+
+def _cookie(
+    name: str,
+    value: str,
+    *,
+    expires: int,
+    domain: str = ".grok.com",
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "domain": domain,
+        "path": "/",
+        "expires": expires,
+        "secure": True,
+        "http_only": True,
+        "value": value,
+    }
+
+
+def _payload(*cookies: dict[str, Any], profile: str = "chrome131") -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source": "browser-use",
+        "browser_impersonation": profile,
+        "cookies": list(cookies),
+    }
+
+
+def _write_auth(path: Path, payload: dict[str, Any]) -> None:
+    write_private_json(path, payload)
+
+
+def test_supported_impersonations_come_from_exact_desktop_chrome_enums() -> None:
+    profiles = supported_browser_impersonations()
+
+    assert "chrome131" in profiles
+    assert all(profile.removeprefix("chrome").isdigit() for profile in profiles)
+    assert "chrome133a" not in profiles
+    assert "chrome99_android" not in profiles
+
+
+def test_snapshot_is_immutable_and_reloads_as_one_generation(tmp_path: Path) -> None:
+    now = int(time.time())
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    original_payload = _payload(
+        _cookie("sso", "first-secret", expires=now + 3_600),
+        _cookie("sso-rw", "first-rw-secret", expires=now + 7_200),
+    )
+    _write_auth(auth_path, original_payload)
+    store = GrokWebAuthStore(auth_path)
+
+    snapshot = store.snapshot()
+
+    assert snapshot.generation == 0
+    assert isinstance(snapshot.cookies, MappingProxyType)
+    assert set(snapshot.cookies) == {"sso", "sso-rw"}
+    assert snapshot.cookies["sso"] == "first-secret"
+    with pytest.raises(TypeError):
+        snapshot.cookies["sso"] = "mutation"  # type: ignore[index]
+
+    replacement = original_payload | {
+        "cookies": [
+            cookie | {"value": "rotated-secret"}
+            for cookie in original_payload["cookies"]
+        ]
+    }
+    _write_auth(auth_path, replacement)
+    next_snapshot = store.snapshot()
+
+    assert store.auth_generation == 1
+    assert next_snapshot.generation == 1
+    assert next_snapshot.cookies["sso"] == "rotated-secret"
+    assert snapshot.cookies["sso"] == "first-secret"
+
+
+def test_snapshot_reloads_atomic_replacement_with_preserved_mtime(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    original = _payload(
+        _cookie("sso", "first-secret", expires=now + 3_600),
+        _cookie("sso-rw", "first-secret", expires=now + 3_600),
+    )
+    replacement = _payload(
+        _cookie("sso", "later-secret", expires=now + 3_600),
+        _cookie("sso-rw", "later-secret", expires=now + 3_600),
+    )
+    _write_auth(auth_path, original)
+    original_stat = auth_path.stat()
+    store = GrokWebAuthStore(auth_path)
+    first = store.snapshot()
+
+    _write_auth(auth_path, replacement)
+    os.utime(
+        auth_path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    replacement_stat = auth_path.stat()
+
+    assert replacement_stat.st_size == original_stat.st_size
+    assert replacement_stat.st_mtime_ns == original_stat.st_mtime_ns
+    assert replacement_stat.st_ino != original_stat.st_ino
+    second = store.snapshot()
+    assert first.cookies["sso"] == "first-secret"
+    assert second.cookies["sso"] == "later-secret"
+    assert second.generation == 1
+
+
+def _invalid_payload_cases(now: int) -> list[tuple[str, Callable[[dict[str, Any]], None]]]:
+    def set_schema(payload: dict[str, Any]) -> None:
+        payload["schema_version"] = 2
+
+    def drop_required(payload: dict[str, Any]) -> None:
+        payload["cookies"].pop()
+
+    def duplicate(payload: dict[str, Any]) -> None:
+        payload["cookies"].append(dict(payload["cookies"][0]))
+
+    def unknown_cookie(payload: dict[str, Any]) -> None:
+        payload["cookies"].append(
+            _cookie("session", "planted-secret", expires=now + 3_600)
+        )
+
+    def wrong_domain(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["domain"] = ".example.com"
+
+    def wrong_path(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["path"] = "/rest"
+
+    def insecure(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["secure"] = False
+
+    def not_http_only(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["http_only"] = False
+
+    def expired(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["expires"] = now - 1
+
+    def huge(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["value"] = "x" * 16_385
+
+    def raw_user_agent(payload: dict[str, Any]) -> None:
+        payload["browser_impersonation"] = (
+            "Mozilla/5.0 Chrome/131.0.0.0 Safari/537.36"
+        )
+
+    def suffixed_profile(payload: dict[str, Any]) -> None:
+        payload["browser_impersonation"] = "chrome133a"
+
+    def unknown_root_field(payload: dict[str, Any]) -> None:
+        payload["identity"] = "planted-identity"
+
+    def unknown_cookie_field(payload: dict[str, Any]) -> None:
+        payload["cookies"][0]["same_site"] = "Lax"
+
+    return [
+        ("schema", set_schema),
+        ("required", drop_required),
+        ("duplicate", duplicate),
+        ("unknown-cookie", unknown_cookie),
+        ("domain", wrong_domain),
+        ("path", wrong_path),
+        ("secure", insecure),
+        ("http-only", not_http_only),
+        ("expired", expired),
+        ("bounded", huge),
+        ("raw-ua", raw_user_agent),
+        ("profile", suffixed_profile),
+        ("closed-root", unknown_root_field),
+        ("closed-cookie", unknown_cookie_field),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("case", "mutate"),
+    _invalid_payload_cases(int(time.time())),
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_snapshot_rejects_invalid_closed_schema_without_secret_echo(
+    tmp_path: Path,
+    case: str,
+    mutate: Callable[[dict[str, Any]], None],
+) -> None:
+    now = int(time.time())
+    planted = f"planted-{case}-secret"
+    payload = _payload(
+        _cookie("sso", planted, expires=now + 3_600),
+        _cookie("sso-rw", "planted-rw-secret", expires=now + 3_600),
+    )
+    mutate(payload)
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    _write_auth(auth_path, payload)
+
+    with pytest.raises(GrokError) as caught:
+        GrokWebAuthStore(auth_path).snapshot()
+
+    assert caught.value.code in {"GROK_WEB_AUTH_MISSING", "GROK_WEB_AUTH_EXPIRED"}
+    assert planted not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_status_is_bounded_and_contains_no_cookie_or_identity_values(
+    tmp_path: Path,
+) -> None:
+    now = int(time.time())
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    _write_auth(
+        auth_path,
+        _payload(
+            _cookie("sso", "planted-sso-secret", expires=now + 3_600),
+            _cookie("sso-rw", "planted-rw-secret", expires=now + 7_200),
+            _cookie("grok_device_id", "planted-device-secret", expires=now + 8_000),
+        ),
+    )
+
+    status = GrokWebAuthStore(auth_path).status()
+
+    assert status == {
+        "configured": True,
+        "authenticated": True,
+        "expires_at": now + 3_600,
+        "cookie_names": ["grok_device_id", "sso", "sso-rw"],
+    }
+    rendered = repr(status)
+    assert "planted" not in rendered
+    assert "identity" not in rendered
+    assert "browser_impersonation" not in rendered
+
+
+def test_missing_status_uses_only_the_public_status_shape(tmp_path: Path) -> None:
+    status = GrokWebAuthStore(tmp_path / "private" / "missing.json").status()
+
+    assert status == {
+        "configured": False,
+        "authenticated": False,
+        "expires_at": None,
+        "cookie_names": [],
+    }
+
+
+def test_cached_snapshot_becomes_expired_without_a_file_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import grok_web_auth
+
+    now = int(time.time())
+    auth_path = tmp_path / "private" / "grok-web-auth.json"
+    _write_auth(
+        auth_path,
+        _payload(
+            _cookie("sso", "planted-sso-secret", expires=now + 10),
+            _cookie("sso-rw", "planted-rw-secret", expires=now + 10),
+        ),
+    )
+    store = GrokWebAuthStore(auth_path)
+    assert store.snapshot().generation == 0
+
+    monkeypatch.setattr(grok_web_auth.time, "time", lambda: now + 11)
+
+    with pytest.raises(GrokError) as caught:
+        store.snapshot()
+    assert caught.value.code == "GROK_WEB_AUTH_EXPIRED"
+    assert store.status() == {
+        "configured": True,
+        "authenticated": False,
+        "expires_at": None,
+        "cookie_names": [],
+    }

--- a/tests/test_package_resources.py
+++ b/tests/test_package_resources.py
@@ -16,3 +16,18 @@ def test_both_resource_files_are_readable_from_package() -> None:
         data = package_root.joinpath("resources", name).read_bytes()
         assert data.endswith(b"\n")
         assert json.loads(data)["schema_version"] == "1"
+
+
+def test_tool_manifest_is_an_exact_ordered_provider_partition() -> None:
+    from gpt2agent.tool_manifest import (
+        CHATGPT_TOOL_NAMES,
+        GROK_TOOL_NAMES,
+        TOOL_NAMES,
+    )
+
+    assert TOOL_NAMES
+    assert len(TOOL_NAMES) == len(set(TOOL_NAMES))
+    assert CHATGPT_TOOL_NAMES
+    assert GROK_TOOL_NAMES
+    assert set(CHATGPT_TOOL_NAMES).isdisjoint(GROK_TOOL_NAMES)
+    assert CHATGPT_TOOL_NAMES + GROK_TOOL_NAMES == TOOL_NAMES

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -395,14 +395,115 @@ def test_release_workflow_uses_shared_exact_changelog_extractor() -> None:
     assert 'if ($0 ~ "## \\\\[" ver "\\\\]")' not in release
 
 
-def test_active_plugin_surfaces_advertise_current_tool_count() -> None:
+def test_active_product_surfaces_are_provider_aware_and_count_independent() -> None:
     marketplace = json.loads(
         (PROJECT_ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
     )
+    plugin = json.loads(
+        (PROJECT_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    server = json.loads((PROJECT_ROOT / "server.json").read_text(encoding="utf-8"))
     installer = (PROJECT_ROOT / "gpt2agent" / "install.py").read_text(encoding="utf-8")
+    active_prose = "\n".join(
+        (PROJECT_ROOT / relative).read_text(encoding="utf-8")
+        for relative in (
+            "README.md",
+            "SECURITY.md",
+            "docs/README.md",
+            "docs/configuration.md",
+            "docs/how-it-works.md",
+            "docs/quickstart.md",
+            "docs/troubleshooting.md",
+            "docs/faq.md",
+            "gpt2agent/skills/gpt2agent/SKILL.md",
+            "gpt2agent/skills/gpt2agent/tools-reference.md",
+        )
+    )
 
-    assert "32 MCP tools" in marketplace["plugins"][0]["description"]
-    assert "pre-approves all 32 MCP tools" in installer
+    for text in (
+        active_prose,
+        marketplace["plugins"][0]["description"],
+        plugin["description"],
+        server["description"],
+        installer,
+    ):
+        assert "32" + " MCP tools" not in text
+        assert "all 32 tools" not in text
+    assert (
+        "ChatGPT tools plus Grok Build tools"
+        in marketplace["plugins"][0]["description"]
+    )
+    assert "ChatGPT tools plus Grok Build tools" in plugin["description"]
+    assert "ChatGPT tools plus Grok Build tools" in server["description"]
+    assert "pre-approves all registered MCP tools" in installer
+
+
+def test_active_docs_cover_only_the_implemented_grok_build_surface() -> None:
+    config = (PROJECT_ROOT / "config.example.toml").read_text(encoding="utf-8")
+    docs = "\n".join(
+        (PROJECT_ROOT / relative).read_text(encoding="utf-8")
+        for relative in (
+            "README.md",
+            "SECURITY.md",
+            "docs/configuration.md",
+            "docs/how-it-works.md",
+            "docs/quickstart.md",
+            "docs/troubleshooting.md",
+            "docs/faq.md",
+            "gpt2agent/skills/gpt2agent/SKILL.md",
+            "gpt2agent/skills/gpt2agent/tools-reference.md",
+        )
+    )
+
+    expected_config = """[grok_build]
+command = "grok"
+# home = "~/.grok"
+# auth_path = "~/.grok/auth.json"
+roots = []
+timeout_seconds = 120
+max_output_bytes = 1048576
+default_max_turns = 20"""
+    assert expected_config in config
+    for tool_name in (
+        "grok_build_agent",
+        "grok_build_models",
+        "grok_build_status",
+    ):
+        assert tool_name in docs
+    for unavailable_tool in (
+        "grok_chat",
+        "grok_heavy",
+        "grok_web_status",
+        "grok_upload_file",
+    ):
+        assert unavailable_tool not in docs
+    for reference in (
+        "https://docs.x.ai/build/enterprise",
+        "https://docs.x.ai/build/cli/reference",
+        "https://docs.x.ai/build/cli/headless-scripting",
+        "https://docs.x.ai/build/modes-and-commands",
+    ):
+        assert reference in docs
+    for error_code in (
+        "GROK_BUILD_CLI_NOT_FOUND",
+        "GROK_BUILD_AUTH_MISSING",
+        "GROK_BUILD_QUOTA",
+        "GROK_BUILD_TIMEOUT",
+        "GROK_BUILD_OUTPUT_TOO_LARGE",
+        "GROK_BUILD_FAILED",
+    ):
+        assert error_code in docs
+
+
+def test_package_smoke_checks_source_and_installed_provider_manifests() -> None:
+    smoke = (PROJECT_ROOT / "scripts" / "package_smoke.sh").read_text(encoding="utf-8")
+
+    assert "len(TOOL_NAMES)" + " == 32" not in smoke
+    assert "CHATGPT_TOOL_NAMES" in smoke
+    assert "GROK_TOOL_NAMES" in smoke
+    assert "source_tool_names" in smoke
+    assert "assert list(TOOL_NAMES) == source_tool_names" in smoke
+    assert 'coverage["tools"] == list(CHATGPT_TOOL_NAMES)' in smoke
 
 
 @pytest.mark.parametrize(

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -40,11 +40,12 @@ def test_static_resource_reads_are_deterministic_valid_json() -> None:
 
 def test_feature_coverage_matches_manifest_and_defers_voice() -> None:
     from gpt2agent.capabilities import CAPABILITY_IDS
-    from gpt2agent.tool_manifest import TOOL_NAMES
+    from gpt2agent.tool_manifest import CHATGPT_TOOL_NAMES
 
     coverage = json.loads(resources.read_packaged_json("feature-coverage.v1.json"))
     assert coverage["schema_version"] == "1"
-    assert coverage["tools"] == list(TOOL_NAMES)
+    assert coverage["tools"] == list(CHATGPT_TOOL_NAMES)
+    assert not any(name.startswith("grok_") for name in coverage["tools"])
     capabilities = {item["id"]: item for item in coverage["capabilities"]}
     assert list(capabilities) == list(CAPABILITY_IDS)
     expected_fields = {

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from gpt2agent.tools._redact import redact
 from gpt2agent.tools.conversations import normalize_conversation_detail
 from gpt2agent.tools.instructions import normalize_custom_instructions
@@ -16,6 +18,11 @@ PRIVATE_KEY = (
     "U1lOVEhFVElDLU5PVC1BLVJFQUklWQVRFLUtFWQ==\n"
     "-----END " + "PRIVATE KEY-----"
 )
+GROK_CONVERSATION_ID = "conv-private-42"
+GROK_RESPONSE_ID = "resp-private-99"
+GROK_ATTACHMENT_ID = "attach-private-17"
+GROK_UUID_ID = "8cb6f8ef-b988-4f5a-a721-926c7e52e770"
+GROK_UUID_LIKE_ID = "00000000-0000-0000-0000-000000000042"
 
 
 def test_memory_projection_redacts_complete_provider_credentials() -> None:
@@ -136,4 +143,53 @@ def test_secret_redaction_preserves_noncredential_near_misses() -> None:
     )
 
     for value in near_misses:
+        assert redact(value) == value
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "sso=planted-sso-secret",
+        "sso-rw=planted-sso-rw-secret",
+        'sso="planted-quoted-cookie-secret"',
+        "cf_clearance=planted-clearance-secret",
+        "grok_device_id=planted-device-secret",
+        "Cookie: sso=planted-cookie-secret",
+        "Set-Cookie: sso-rw=planted-set-cookie-secret",
+        "xai-planted-api-token-1234567890",
+        "/asset?X-Amz-Credential=planted-credential&X-Amz-Signature=planted-signature"
+        "&X-Amz-Security-Token=planted-security-token",
+        "identity_id=identity-private-3 accountId=account-private-8",
+    ],
+)
+def test_grok_free_text_redacts_credentials_and_identity_fields(source: str) -> None:
+    rendered = redact(source)
+
+    assert isinstance(rendered, str)
+    for secret in (
+        "planted-sso-secret",
+        "planted-sso-rw-secret",
+        "planted-quoted-cookie-secret",
+        "planted-clearance-secret",
+        "planted-device-secret",
+        "planted-cookie-secret",
+        "planted-set-cookie-secret",
+        "xai-planted-api-token-1234567890",
+        "planted-credential",
+        "planted-signature",
+        "planted-security-token",
+        "identity-private-3",
+        "account-private-8",
+    ):
+        assert secret not in rendered
+
+
+def test_grok_opaque_ids_are_not_globally_erased_from_structured_fields() -> None:
+    for value in (
+        GROK_CONVERSATION_ID,
+        GROK_RESPONSE_ID,
+        GROK_ATTACHMENT_ID,
+        GROK_UUID_ID,
+        GROK_UUID_LIKE_ID,
+    ):
         assert redact(value) == value

--- a/tests/test_secure_local_writes.py
+++ b/tests/test_secure_local_writes.py
@@ -133,6 +133,65 @@ def test_read_private_json_hides_low_level_read_errors(
     assert "planted-read-secret" not in str(caught.value)
 
 
+def test_read_private_json_hides_close_errors_after_closing_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import _secure_file
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b"{}")
+    original_close = _secure_file.os.close
+    descriptor_closed = False
+
+    def close_then_fail(fd: int) -> None:
+        nonlocal descriptor_closed
+        original_close(fd)
+        descriptor_closed = True
+        raise OSError("planted-close-secret")
+
+    monkeypatch.setattr(_secure_file.os, "close", close_then_fail)
+
+    with pytest.raises(RuntimeError, match="could not be closed") as caught:
+        _secure_file.read_private_json(path)
+
+    assert descriptor_closed is True
+    assert str(path) in str(caught.value)
+    assert "planted-close-secret" not in str(caught.value)
+
+
+def test_read_private_json_preserves_primary_error_when_close_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import _secure_file
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b"{}")
+    original_close = _secure_file.os.close
+    descriptor_closed = False
+
+    def fail_read(fd: int, maximum: int) -> bytes:
+        raise OSError("planted-read-secret")
+
+    def close_then_fail(fd: int) -> None:
+        nonlocal descriptor_closed
+        original_close(fd)
+        descriptor_closed = True
+        raise OSError("planted-close-secret")
+
+    monkeypatch.setattr(_secure_file.os, "read", fail_read)
+    monkeypatch.setattr(_secure_file.os, "close", close_then_fail)
+
+    with pytest.raises(RuntimeError, match="could not be read as private JSON") as caught:
+        _secure_file.read_private_json(path)
+
+    assert descriptor_closed is True
+    assert str(path) in str(caught.value)
+    assert "planted-read-secret" not in str(caught.value)
+    assert "planted-close-secret" not in str(caught.value)
+
+
 def test_read_private_json_hides_decoder_value_errors(tmp_path: Path) -> None:
     from gpt2agent._secure_file import read_private_json
 

--- a/tests/test_secure_local_writes.py
+++ b/tests/test_secure_local_writes.py
@@ -27,6 +27,27 @@ def test_read_private_json_accepts_bounded_current_user_file(tmp_path: Path) -> 
     assert read_private_json(path) == {"access_token": "planted-token"}
 
 
+def test_grok_web_auth_write_is_private_and_round_trips_closed_fixture(
+    tmp_path: Path,
+) -> None:
+    from gpt2agent._secure_file import read_private_json, write_private_json
+
+    path = tmp_path / "private" / "grok-web-auth.json"
+    payload = {
+        "schema_version": 1,
+        "source": "manual",
+        "browser_impersonation": "chrome131",
+        "cookies": [],
+    }
+
+    write_private_json(path, payload)
+
+    assert read_private_json(path) == payload
+    if os.name == "posix":
+        assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
 @pytest.mark.parametrize(
     ("content", "invariant"),
     [

--- a/tests/test_secure_local_writes.py
+++ b/tests/test_secure_local_writes.py
@@ -12,6 +12,151 @@ from pathlib import Path
 import pytest
 
 
+def _write_private_fixture(path: Path, content: bytes) -> None:
+    path.write_bytes(content)
+    if os.name == "posix":
+        path.chmod(0o600)
+
+
+def test_read_private_json_accepts_bounded_current_user_file(tmp_path: Path) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "grok-auth.json"
+    _write_private_fixture(path, b'{"access_token":"planted-token"}')
+
+    assert read_private_json(path) == {"access_token": "planted-token"}
+
+
+@pytest.mark.parametrize(
+    ("content", "invariant"),
+    [
+        (b"", "positive bounded size"),
+        (b"{not-json}", "valid UTF-8 JSON"),
+        (b'"\xff"', "valid UTF-8 JSON"),
+    ],
+)
+def test_read_private_json_rejects_invalid_content_without_echo(
+    tmp_path: Path,
+    content: bytes,
+    invariant: str,
+) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, content)
+
+    with pytest.raises(RuntimeError, match=invariant) as caught:
+        read_private_json(path)
+
+    assert "not-json" not in str(caught.value)
+    assert "\\xff" not in str(caught.value)
+
+
+def test_read_private_json_rejects_oversized_file_without_reading_content(
+    tmp_path: Path,
+) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b'"planted-oversized-secret"')
+
+    with pytest.raises(RuntimeError, match="positive bounded size") as caught:
+        read_private_json(path, maximum_bytes=8)
+
+    assert "planted-oversized-secret" not in str(caught.value)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes are unavailable")
+def test_read_private_json_rejects_group_or_world_access(tmp_path: Path) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "private.json"
+    path.write_text("{}", encoding="utf-8")
+    path.chmod(0o640)
+
+    with pytest.raises(RuntimeError, match="owner-only mode"):
+        read_private_json(path)
+
+
+def test_read_private_json_rejects_symlink(tmp_path: Path) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    target = tmp_path / "target.json"
+    _write_private_fixture(target, b"{}")
+    link = tmp_path / "private.json"
+    link.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="regular non-symlink file"):
+        read_private_json(link)
+
+
+def test_read_private_json_rejects_lstat_fstat_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import _secure_file
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b"{}")
+    original_fstat = _secure_file.os.fstat
+
+    def mismatched_fstat(fd: int) -> os.stat_result:
+        observed = original_fstat(fd)
+        values = list(observed)
+        values[stat.ST_INO] += 1
+        return os.stat_result(values)
+
+    monkeypatch.setattr(_secure_file.os, "fstat", mismatched_fstat)
+
+    with pytest.raises(RuntimeError, match="changed while being validated"):
+        _secure_file.read_private_json(path)
+
+
+def test_read_private_json_hides_low_level_read_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import _secure_file
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b"{}")
+
+    def fail_read(fd: int, maximum: int) -> bytes:
+        raise OSError("planted-read-secret")
+
+    monkeypatch.setattr(_secure_file.os, "read", fail_read)
+
+    with pytest.raises(RuntimeError, match="could not be read") as caught:
+        _secure_file.read_private_json(path)
+
+    assert str(path) in str(caught.value)
+    assert "planted-read-secret" not in str(caught.value)
+
+
+def test_read_private_json_hides_decoder_value_errors(tmp_path: Path) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "private.json"
+    _write_private_fixture(path, b"9" * 5000)
+
+    with pytest.raises(RuntimeError, match="valid UTF-8 JSON") as caught:
+        read_private_json(path)
+
+    assert str(path) in str(caught.value)
+    assert "digit" not in str(caught.value).lower()
+
+
+def test_read_private_json_invalid_bound_names_only_path_and_invariant(
+    tmp_path: Path,
+) -> None:
+    from gpt2agent._secure_file import read_private_json
+
+    path = tmp_path / "private.json"
+
+    with pytest.raises(ValueError, match=str(path)):
+        read_private_json(path, maximum_bytes=0)
+
+
 @pytest.mark.parametrize("path_kind", ["bare", "absolute-cwd", "traversal", "root"])
 def test_private_json_rejects_paths_without_a_dedicated_parent(
     path_kind: str,

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -50,6 +50,9 @@ _EXPECTED: dict[str, tuple[bool, bool, bool, bool]] = {
     "sites_access": (True, False, True, False),
     "list_sites": (True, False, True, False),
     "account_capabilities": (True, False, True, False),
+    "grok_build_agent": (False, True, False, True),
+    "grok_build_models": (True, False, True, False),
+    "grok_build_status": (True, False, True, False),
 }
 
 class _RecordingMCP:


### PR DESCRIPTION
## Draft / do not merge

This is a partial stacked feature PR for the v0.0.16 Grok dual-account release. It depends on PR #30 and the predecessor v0.0.12-v0.0.15 release sequence. It deliberately contains no version bump and must not merge in its current state.

The website surface is not complete. Both reviewed Chrome profiles currently render grok.com signed out, so the private website contract for ordinary chat, continuation, Heavy reconnect, history, deletion, and upload could not be captured without fabricating routes. That work remains blocked until an authenticated grok.com composer is available.

## Problem and user impact

The Grok subscription has two independent capability and authentication surfaces: the official Grok Build CLI for repository agent work, and the private grok.com session for website chat features. Treating them as one token would blur security boundaries, make failures ambiguous, and prevent MCP agents from using the already-available official Build subscription safely.

This stack exposes the verified Build lane now while retaining strict separation from ChatGPT auth and from the unfinished website lane. It also establishes the shared security primitives needed by the final dual-surface release.

## Implemented in this partial stack

- Closed Grok error codes, route/identifier redaction, and owner-private bounded JSON reads.
- Provider-neutral bounded subprocess execution with timeout/output caps and descendant cleanup.
- Configured-root Grok Build client using the official CLI, account catalog/status discovery, bounded plan/apply agent execution, sanitized results, and no API-key fallback.
- Three explicit MCP tools: `grok_build_agent`, `grok_build_models`, and `grok_build_status`.
- Probe-free server startup and provider-separated ChatGPT/Grok tool manifests.
- Secure `gpt2agent grok-setup` website-auth storage/import boundary, without claiming live website compatibility.
- Route-independent, descriptor-safe upload policy and process-local attachment registry; no speculative upload HTTP route or MCP tool is exposed.
- Opt-in Grok Build live gate with one minimal plan-mode call and a sanitized receipt.
- Count-independent package checks and truthful Build-only configuration, security, troubleshooting, and bundled agent guidance.

## Security boundaries

- ChatGPT auth, Grok Build OAuth, and the future grok.com cookie session never fall back to one another.
- Build subprocesses are constrained to configured roots and bounded by time/output limits.
- `XAI_API_KEY` and `GROK_CODE_XAI_API_KEY` are removed from the child environment.
- `grok_build_agent` defaults to plan/read-only behavior; apply is an explicit destructive choice and the MCP annotation remains conservative.
- Upload file opens are descriptor-relative with no-follow checks, regular-file/size/stability validation, closed error tracebacks, and caller-owned success descriptors.
- No credential values, live session IDs, raw model output, or website response bodies are committed.

## Verification

- Full offline suite: `1965 passed, 11 skipped`.
- Focused Build MCP/docs gate: `166 passed`.
- Upload security gate: `76 passed`; related Grok boundary gate: `52 passed`.
- Ruff and `git diff --check`: passed.
- Isolated wheel and sdist builds plus package smoke: passed; installed/source manifests match exactly.
- Authorized Build live gate: CLI `0.2.101`, two account models, exact sentinel true, session ID present, changed-files empty, one plan-mode dispatch.
- Independent task reviews: Build MCP, Build live gate, upload core, and Build docs all reached spec PASS and quality/security approval after fixes.

## Remaining work before replacement/final PR

1. Authenticate a reviewed Chrome profile on grok.com and capture only value-free live protocol evidence.
2. Implement and independently review bounded website transport, models/modes, ordinary chat/history, Heavy reconnect, and upload integration.
3. Register the remaining website MCP tools and run separate opt-in website/Heavy gates with sanitized receipts.
4. Complete full two-stage correctness/security review.
5. After v0.0.15 is verified, replay the exact Grok commit range onto that tag, open the replacement PR to `main`, update coordinated metadata to v0.0.16, merge, tag, publish, and verify a clean install.

Website integration will use a private unsupported grok.com contract. Heavy evidence is quota-bearing and must be retained only as a sanitized local receipt.
