### PR TITLE
chore: refresh model defaults against the live account and bound the mcp dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 | `chat` | Talk to any model on your account (`gpt-5-6` default, override via `model=`). Pass `gpt-5-5-pro`, `o3-pro`, `gpt-5-6-thinking`, … |
 | `agent` | **Agent Mode** — 262K context with autonomous browsing, code execution, tool use |
 | `deep_research` | Web-augmented research with citations (~30–120 s). Auto-confirms by default |
-| `deep_research_heavy` | Long-form DR via `gpt-5-5-pro` + connector (5–30 min, monthly quota). Configurable via `[models].heavy_dr` |
+| `deep_research_heavy` | Long-form DR via `gpt-6-pro` + connector (5–30 min, monthly quota). Configurable via `[models].heavy_dr` |
 | `gpt_chat` | Talk through one of your private Custom GPTs (`g-p-*`) — *experimental* |
 
 ### Image & file management
@@ -222,7 +222,7 @@ port = 9000
 [models]
 chat     = "gpt-5-6"        # default for chat tool
 agent    = "agent-mode"     # default for agent tool
-heavy_dr = "gpt-5-5-pro"    # override slug for deep_research_heavy
+heavy_dr = "gpt-6-pro"      # override slug for deep_research_heavy
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 
 | Tool | What it does |
 |---|---|
-| `chat` | Talk to any model on your account (`gpt-5-3` default, override via `model=`). Pass `gpt-5-5-pro`, `o3-pro`, `gpt-5-4-thinking`, … |
+| `chat` | Talk to any model on your account (`gpt-5-6` default, override via `model=`). Pass `gpt-5-5-pro`, `o3-pro`, `gpt-5-6-thinking`, … |
 | `agent` | **Agent Mode** — 262K context with autonomous browsing, code execution, tool use |
 | `deep_research` | Web-augmented research with citations (~30–120 s). Auto-confirms by default |
 | `deep_research_heavy` | Long-form DR via `gpt-5-5-pro` + connector (5–30 min, monthly quota). Configurable via `[models].heavy_dr` |
@@ -220,7 +220,7 @@ host = "127.0.0.1"   # loopback only; the HTTP transport is UNAUTHENTICATED
 port = 9000
 
 [models]
-chat     = "gpt-5-3"        # default for chat tool
+chat     = "gpt-5-6"        # default for chat tool
 agent    = "agent-mode"     # default for agent tool
 heavy_dr = "gpt-5-5-pro"    # override slug for deep_research_heavy
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,7 @@ port = 9000
 
 [models]
 # Default model for the `chat` tool
-chat = "gpt-5-3"
+chat = "gpt-5-6"
 
 # Override the model for `agent` (default: agent-mode)
 # agent = "agent-mode"

--- a/config.example.toml
+++ b/config.example.toml
@@ -15,5 +15,5 @@ chat = "gpt-5-6"
 # Override the model for `agent` (default: agent-mode)
 # agent = "agent-mode"
 
-# Override the model for `deep_research_heavy` (default: gpt-5-5-pro)
-# heavy_dr = "gpt-5-5-pro"
+# Override the model for `deep_research_heavy` (default: gpt-6-pro)
+# heavy_dr = "gpt-6-pro"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ port = 9000
 [models]
 chat     = "gpt-5-6"      # default model for the `chat` tool
 agent    = "agent-mode"   # default for the `agent` tool
-heavy_dr = "gpt-5-5-pro"  # override slug for `deep_research_heavy`
+heavy_dr = "gpt-6-pro"  # override slug for `deep_research_heavy`
 ```
 
 CLI flags override the file: `gpt2agent run --host 127.0.0.1 --port 9001`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ host = "127.0.0.1"
 port = 9000
 
 [models]
-chat     = "gpt-5-3"      # default model for the `chat` tool
+chat     = "gpt-5-6"      # default model for the `chat` tool
 agent    = "agent-mode"   # default for the `agent` tool
 heavy_dr = "gpt-5-5-pro"  # override slug for `deep_research_heavy`
 ```

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -28,7 +28,7 @@ _DEFAULTS: dict[str, Any] = {
     # full ChatGPT account, so binding all interfaces would expose the account to
     # the LAN/WAN. Set host explicitly (and GPT2AGENT_ALLOW_REMOTE=1) to opt in.
     "server": {"host": "127.0.0.1", "port": 9000},
-    "models": {"chat": "gpt-5-3"},
+    "models": {"chat": "gpt-5-6"},
 }
 
 # Hosts that keep the unauthenticated HTTP transport reachable only from the
@@ -108,7 +108,7 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         log_level="WARNING",
     )
 
-    chat_model = models.get("chat", "gpt-5-3")
+    chat_model = models.get("chat", "gpt-5-6")
     agent_model = models.get("agent", "agent-mode")
     heavy_dr_model = models.get("heavy_dr")  # None → ConversationClient uses sse.HEAVY_DR_MODEL
 
@@ -122,7 +122,7 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         """Chat with any ChatGPT model on your account.
 
         Pass `model` to switch slugs — e.g. `gpt-5-5-pro` (410K, pro reasoning),
-        `o3-pro`, `gpt-5-4-thinking`, `gpt-5-3` (default). Call `list_models`
+        `gpt-6-pro`, `gpt-5-6-thinking`, `gpt-5-6` (default). Call `list_models`
         first to enumerate what your account has access to.
 
         Set `temporary=False` to allow tool-based features (image gen, code

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -122,7 +122,7 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
         """Chat with any ChatGPT model on your account.
 
         Pass `model` to switch slugs — e.g. `gpt-5-5-pro` (410K, pro reasoning),
-        `gpt-6-pro`, `gpt-5-6-thinking`, `gpt-5-6` (default). Call `list_models`
+        `gpt-6-pro`, `o3-pro`, `gpt-5-6-thinking`, `gpt-5-6` (default). Call `list_models`
         first to enumerate what your account has access to.
 
         Set `temporary=False` to allow tool-based features (image gen, code
@@ -196,7 +196,7 @@ def build_server(cfg: dict[str, Any]) -> FastMCP:
 
     @mcp.tool()
     async def deep_research_heavy(query: str, auto_confirm: bool = True) -> str:
-        """Long-form Deep Research using gpt-5-5-pro (5–30 min, uses monthly DR quota — check /backend-api/conversation/init for remaining). For short web-augmented answers use `deep_research` instead.
+        """Long-form Deep Research using gpt-6-pro (5–30 min, uses monthly DR quota — check /backend-api/conversation/init for remaining). For short web-augmented answers use `deep_research` instead.
 
         When `auto_confirm` is True (default), an imperative prefix is prepended
         so the model proceeds without asking "Do you want me to start?".

--- a/gpt2agent/setup.py
+++ b/gpt2agent/setup.py
@@ -179,7 +179,7 @@ MCP_PORT = 9000
 def write_mcp_config(plan: str) -> None:
     from gpt2agent.install import _atomic_write, _backup
 
-    chat_model = "gpt-5-5-pro" if plan == "pro" else "gpt-5-3"
+    chat_model = "gpt-6-pro" if plan == "pro" else "gpt-5-6"
     cfg = f"""[server]
 # Loopback only — the HTTP transport is unauthenticated and proxies your full
 # ChatGPT account. To expose it, set host explicitly AND GPT2AGENT_ALLOW_REMOTE=1.

--- a/gpt2agent/skills/deep-research/SKILL.md
+++ b/gpt2agent/skills/deep-research/SKILL.md
@@ -3,7 +3,7 @@ name: deep-research
 version: 0.1.2
 description: |
   ChatGPT Pro Deep Research via gpt2agent. Two modes: light (model=research,
-  30-120s, citations preserved) and heavy (gpt-5-5-pro + connector, 5-30 min,
+  30-120s, citations preserved) and heavy (gpt-6-pro + connector, 5-30 min,
   long-form report recovered from the connector widget state, citations included).
   Reuses `$CODEX_HOME/auth.json` (or `~/.codex/auth.json`) or the manual
   `~/.gpt2agent/token.json` fallback.
@@ -39,7 +39,7 @@ test -f "${CODEX_HOME:-$HOME/.codex}/auth.json" || test -f "$HOME/.gpt2agent/tok
 ```
 
 - Default mode: **light** (`deep_research`, ~1 min, citations included).
-- `--heavy`: **deep_research_heavy** (5-30 min, gpt-5-5-pro + connector). The
+- `--heavy`: **deep_research_heavy** (5-30 min, gpt-6-pro + connector). The
   connector renders an embedded-UI widget; the report is recovered from the
   hidden widget state (`widget_state.report_message`) via
   `?include_visually_hidden_messages=true&include_widget_state=true` — see

--- a/gpt2agent/skills/gpt2agent/SKILL.md
+++ b/gpt2agent/skills/gpt2agent/SKILL.md
@@ -157,7 +157,7 @@ port = 9000
 [models]
 chat = "gpt-5-6"
 # agent = "agent-mode"
-# heavy_dr = "gpt-5-5-pro"
+# heavy_dr = "gpt-6-pro"
 ```
 
 ## Troubleshooting

--- a/gpt2agent/skills/gpt2agent/SKILL.md
+++ b/gpt2agent/skills/gpt2agent/SKILL.md
@@ -80,7 +80,7 @@ If any precondition fails, stop and tell the user the exact fix command.
 
 | Need | Tool | Notes |
 |---|---|---|
-| Quick Q&A with a ChatGPT model | `chat` | Default: gpt-5-3, temporary=True |
+| Quick Q&A with a ChatGPT model | `chat` | Default: gpt-5-6, temporary=True |
 | Chat that needs image gen / code / canvas | `chat(temporary=False)` | Temporary chats block these features |
 | Multi-step task with browsing + code exec | `agent` | 262K context, autonomous |
 | Web research with citations (30-120s) | `deep_research` | Costs 1 DR quota |
@@ -155,7 +155,7 @@ host = "127.0.0.1"   # loopback only; HTTP transport is unauthenticated
 port = 9000
 
 [models]
-chat = "gpt-5-3"
+chat = "gpt-5-6"
 # agent = "agent-mode"
 # heavy_dr = "gpt-5-5-pro"
 ```

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -23,7 +23,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Purpose**: Send a single prompt to any ChatGPT model and get a text response.
 - **Parameters**:
   - `prompt` (str, required) -- the user message to send.
-  - `model` (str, default: value from `config.toml` `[models].chat`, fallback `"gpt-5-3"`) -- model slug. Run `list_models` to see all available slugs.
+  - `model` (str, default: value from `config.toml` `[models].chat`, fallback `"gpt-5-6"`) -- model slug. Run `list_models` to see all available slugs.
   - `temporary` (bool, default: `True`) -- when `True`, sets `history_and_training_disabled=True` which prevents the conversation from being saved and **blocks tool-based features** (image gen, code interpreter, canvas, memory persistence). Set `False` to enable those features.
 - **Returns**: `str` -- the assistant's reply text.
 - **When to use**: General Q&A, text generation, translation, summarization. Default choice for single-turn queries.
@@ -31,12 +31,12 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
   ```python
   chat("Explain the difference between LTP and LTD in hippocampal neurons.")
   chat("Summarize this abstract:", model="o3")
-  chat("Generate a chart of this data", model="gpt-5-3", temporary=False)
+  chat("Generate a chart of this data", model="gpt-5-6", temporary=False)
   ```
 - **Notes**:
   - `temporary=True` (default) means the conversation is ephemeral -- not saved to ChatGPT history, cannot use image gen / code interpreter / canvas.
   - If you need tool-based features (image gen, code interpreter, canvas), you **must** pass `temporary=False`.
-  - Available model slugs depend on your subscription tier. Pro plan unlocks `gpt-5-5-pro`, `gpt-5-4-pro`, `o3-pro`, etc.
+  - Available model slugs depend on your subscription tier. Pro plan unlocks `gpt-5-5-pro`, `gpt-5-6-pro`, `o3-pro`, etc.
 
 ---
 
@@ -139,7 +139,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Purpose**: Generate an image using ChatGPT's built-in image generation (DALL-E).
 - **Parameters**:
   - `prompt` (str, required) -- description of the image to generate.
-  - `model` (str, default: `"gpt-5-3"`) -- model to use (must have `image_gen_tool_enabled`).
+  - `model` (str, default: `"gpt-5-6"`) -- model to use (must have `image_gen_tool_enabled`).
 - **Returns**: `dict` with keys:
   - `conversation_id` (str)
   - `assets` (list) -- each asset contains: `asset_pointer`, `file_id`, `width`, `height`, `size_bytes`, `download_url`, `file_name`, `mime_type`
@@ -201,7 +201,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Purpose**: Execute Python code in ChatGPT's sandboxed code interpreter.
 - **Parameters**:
   - `prompt` (str, required) -- the code or instruction to execute (e.g., `"Run this Python code: ..."`).
-  - `model` (str, default: `"gpt-5-3"`) -- model to use.
+  - `model` (str, default: `"gpt-5-6"`) -- model to use.
 - **Returns**: `dict` with keys:
   - `conversation_id` (str)
   - `text` (str) -- assistant's explanation of the output
@@ -231,7 +231,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Purpose**: Execute code via ChatGPT's Canvas feature -- a live editing environment.
 - **Parameters**:
   - `prompt` (str, required) -- the code or instruction (e.g., `"Create a React component that..."`).
-  - `model` (str, default: `"gpt-5-3"`) -- model to use.
+  - `model` (str, default: `"gpt-5-6"`) -- model to use.
 - **Returns**: `dict` with keys: `conversation_id`, `text`, `tool_calls`, `tool_responses`.
 - **When to use**: Create and test interactive documents, React components, HTML pages, code with live preview.
 - **Example**:
@@ -281,7 +281,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Purpose**: Return all available ChatGPT models with full metadata.
 - **Parameters**: None.
 - **Returns**: `list[dict]` -- each dict contains:
-  - `slug` (str) -- model identifier (e.g., `"gpt-5-3"`, `"o3-pro"`)
+  - `slug` (str) -- model identifier (e.g., `"gpt-5-6"`, `"o3-pro"`)
   - `title` (str) -- display name
   - `description` (str)
   - `max_tokens` (int)
@@ -491,7 +491,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
   - **Workaround**: `POST /backend-api/memories` returns 405 (Method Not Allowed). ChatGPT only allows model-initiated memory writes. This tool asks the model to remember the content directly.
   - Uses `temporary=False` (memory persistence requires non-temporary conversations).
   - The model may paraphrase or summarize rather than store verbatim. Use `memory_search` to verify.
-  - Uses `gpt-5-3` by default (from config).
+  - Uses `gpt-5-6` by default (from config).
 
 ---
 

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -84,7 +84,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 
 ### deep_research_heavy
 
-- **Purpose**: Long-form Deep Research using gpt-5-5-pro with the DR connector. Produces extended multi-section reports.
+- **Purpose**: Long-form Deep Research using gpt-6-pro with the DR connector. Produces extended multi-section reports.
 - **Parameters**:
   - `query` (str, required) -- the research question.
   - `auto_confirm` (bool, default: `True`) -- same behavior as `deep_research`.
@@ -103,7 +103,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
   - **Quota**: limits and reset timing are account-reported and can change. Run the bundled `deep-research/bin/quota.sh` before heavy calls.
   - Takes 5-30 minutes. Use `run_in_background` for shell integration.
   - Uses `/backend-api/f/conversation` (frontend endpoint), not the standard `/backend-api/conversation`.
-  - Model slug configurable via `[models].heavy_dr` in `config.toml` (default: `gpt-5-5-pro`).
+  - Model slug configurable via `[models].heavy_dr` in `config.toml` (default: `gpt-6-pro`).
   - **Report + citations recovered from the connector widget state** (fixed in 0.0.4): the connector never writes the report as an assistant text node, so the poll fetches the conversation with `include_widget_state=true` and recovers `widget_state.report_message` (text + `content_references`). Grouped source URLs are usually present but not guaranteed; if absent, the model may have cited sources inline in the body.
   - If the DR connector is unavailable, a warning is appended explaining how to enable it in chatgpt.com Settings > Connectors.
 

--- a/gpt2agent/skills/gpt2agent/tools-reference.md
+++ b/gpt2agent/skills/gpt2agent/tools-reference.md
@@ -30,7 +30,7 @@ Source: `gpt2agent/server.py` and `gpt2agent/tools/*.py`.
 - **Example**:
   ```python
   chat("Explain the difference between LTP and LTD in hippocampal neurons.")
-  chat("Summarize this abstract:", model="o3")
+  chat("Summarize this abstract:", model="o3-pro")
   chat("Generate a chart of this data", model="gpt-5-6", temporary=False)
   ```
 - **Notes**:

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -76,7 +76,7 @@ _F_CONV_URL = _BASE + "/backend-api/f/conversation"
 DR_MODEL = "research"
 
 #: Model slug for heavy Deep Research — gpt-5-5-pro with extended thinking + DR connector
-HEAVY_DR_MODEL = "gpt-5-5-pro"
+HEAVY_DR_MODEL = "gpt-6-pro"
 
 #: System hint for heavy Deep Research (connector identifier from chatgpt.com frontend)
 HEAVY_DR_HINT = "connector:connector_openai_deep_research"
@@ -796,7 +796,7 @@ class ConversationClient:
         self,
         prompt: str,
         *,
-        model: str = "gpt-5-3",
+        model: str = "gpt-5-6",
         poll_interval: float = 5.0,
         max_wait: float = 300.0,
     ) -> dict:
@@ -971,7 +971,7 @@ class ConversationClient:
         self,
         prompt: str,
         *,
-        model: str = "gpt-5-3",
+        model: str = "gpt-5-6",
         temporary: bool = False,
         poll_interval: float = 5.0,
         max_wait: float = 300.0,

--- a/gpt2agent/sse.py
+++ b/gpt2agent/sse.py
@@ -75,7 +75,7 @@ _F_CONV_URL = _BASE + "/backend-api/f/conversation"
 #: Model slug for legacy Deep Research (resolves to i-mini-m / web-search backend)
 DR_MODEL = "research"
 
-#: Model slug for heavy Deep Research — gpt-5-5-pro with extended thinking + DR connector
+#: Model slug for heavy Deep Research — gpt-6-pro with extended thinking + DR connector
 HEAVY_DR_MODEL = "gpt-6-pro"
 
 #: System hint for heavy Deep Research (connector identifier from chatgpt.com frontend)
@@ -465,7 +465,7 @@ def _build_heavy_dr_payload(query: str, *, model: str | None = None) -> dict:
     (2026-04-23).  Key differences from legacy DR:
 
     * URL target: /backend-api/f/conversation  (frontend endpoint)
-    * model: gpt-5-5-pro
+    * model: gpt-6-pro
     * system_hints: ["connector:connector_openai_deep_research"]
     * thinking_effort: "extended"
     * message.metadata contains deep_research_version / venus_model_variant / caterpillar fields
@@ -1396,7 +1396,7 @@ class ConversationClient:
         Payload + endpoint ground-truth reverse-engineered from
         chatgpt.com/deep-research browser traffic (2026-04-23):
 
-            model = gpt-5-5-pro
+            model = gpt-6-pro
             system_hints = ["connector:connector_openai_deep_research"]
             thinking_effort = "extended"
             message.metadata.deep_research_version = "standard"

--- a/gpt2agent/tools/account.py
+++ b/gpt2agent/tools/account.py
@@ -38,7 +38,7 @@ def register(mcp, client: BackendClient) -> None:
         """List the models available on your account.
 
         Returns a list of model dicts; the `slug` field of each (e.g.
-        "gpt-6-pro", "o3-pro") is exactly what you pass as `model=` to the
+        "gpt-5-5-pro", "o3-pro") is exactly what you pass as `model=` to the
         `chat` tool. Other keys: title, description, max_tokens, reasoning_type,
         capabilities, enabled_tools.
         """

--- a/gpt2agent/tools/account.py
+++ b/gpt2agent/tools/account.py
@@ -38,7 +38,7 @@ def register(mcp, client: BackendClient) -> None:
         """List the models available on your account.
 
         Returns a list of model dicts; the `slug` field of each (e.g.
-        "gpt-5-5-pro", "o3-pro") is exactly what you pass as `model=` to the
+        "gpt-6-pro", "o3-pro") is exactly what you pass as `model=` to the
         `chat` tool. Other keys: title, description, max_tokens, reasoning_type,
         capabilities, enabled_tools.
         """

--- a/gpt2agent/tools/images.py
+++ b/gpt2agent/tools/images.py
@@ -11,7 +11,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
     @mcp.tool()
     async def generate_image(
         prompt: str,
-        model: str = "gpt-5-3",
+        model: str = "gpt-5-6",
     ) -> dict:
         """Generate an image using ChatGPT's built-in image generation.
 
@@ -21,7 +21,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
         Args:
             prompt: Description of the image to generate.
             model: ChatGPT model to use (must have image_gen_tool_enabled).
-                   Defaults to gpt-5-3.
+                   Defaults to gpt-5-6.
 
         Returns:
             Dict with: conversation_id, assets (list with asset_pointer, file_id,

--- a/gpt2agent/tools/tools_features.py
+++ b/gpt2agent/tools/tools_features.py
@@ -9,7 +9,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
     @mcp.tool()
     async def code_interpreter(
         prompt: str,
-        model: str = "gpt-5-3",
+        model: str = "gpt-5-6",
     ) -> dict:
         """Execute code via ChatGPT's code interpreter.
 
@@ -18,7 +18,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
 
         Args:
             prompt: The code or instruction to execute (e.g. "Run this Python code: ...").
-            model: ChatGPT model to use. Defaults to gpt-5-3.
+            model: ChatGPT model to use. Defaults to gpt-5-6.
 
         Returns:
             Dict with: conversation_id, text (assistant explanation),
@@ -35,7 +35,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
     @mcp.tool()
     async def canvas_execute(
         prompt: str,
-        model: str = "gpt-5-3",
+        model: str = "gpt-5-6",
     ) -> dict:
         """Execute code via ChatGPT's Canvas feature.
 
@@ -44,7 +44,7 @@ def register(mcp, client: BackendClient, conv=None) -> None:
 
         Args:
             prompt: The code or instruction (e.g. "Create a React component that...").
-            model: ChatGPT model to use. Defaults to gpt-5-3.
+            model: ChatGPT model to use. Defaults to gpt-5-6.
 
         Returns:
             Dict with: conversation_id, text, tool_calls, tool_responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-asyncio>=0.24", "ruff>=0.6"]
+dev = ["pytest>=7", "pytest-asyncio>=0.24", "ruff>=0.6,<0.16"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.27,<2",
     "uvicorn>=0.30.0",
     "tomli>=2.0.0; python_version < '3.11'",
     "curl_cffi>=0.11.0",

--- a/tests/test_audit_2026_07_02.py
+++ b/tests/test_audit_2026_07_02.py
@@ -137,7 +137,7 @@ def _patched_setup(monkeypatch, tmp_path):
 def test_write_mcp_config_creates_file_and_parent(monkeypatch, tmp_path) -> None:
     setup_mod, cfg_path = _patched_setup(monkeypatch, tmp_path)
     setup_mod.write_mcp_config("pro")
-    assert 'chat = "gpt-5-5-pro"' in cfg_path.read_text()
+    assert 'chat = "gpt-6-pro"' in cfg_path.read_text()
 
 
 def test_write_mcp_config_backs_up_existing(monkeypatch, tmp_path) -> None:
@@ -147,7 +147,7 @@ def test_write_mcp_config_backs_up_existing(monkeypatch, tmp_path) -> None:
     setup_mod.write_mcp_config("plus")
     bak = cfg_path.with_name(cfg_path.name + ".bak-gpt2agent")
     assert bak.read_text() == "# user-edited config\n"
-    assert 'chat = "gpt-5-3"' in cfg_path.read_text()
+    assert 'chat = "gpt-5-6"' in cfg_path.read_text()
 
 
 def test_write_mcp_config_same_content_is_noop(monkeypatch, tmp_path) -> None:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -71,7 +71,7 @@ def test_heavy_dr_payload_structure():
     payload = _build_heavy_dr_payload("What is the tallest mountain?")
 
     # Core fields
-    assert payload["model"] == "gpt-5-5-pro", f"model mismatch: {payload['model']}"
+    assert payload["model"] == "gpt-6-pro", f"model mismatch: {payload['model']}"
     assert payload["system_hints"] == ["connector:connector_openai_deep_research"]
     assert payload["thinking_effort"] == "extended"
     assert payload["conversation_mode"] == {"kind": "primary_assistant"}


### PR DESCRIPTION
## Why

The chat default `gpt-5-3` **no longer exists on the account.** Listing models through the package's own backend client returns 22 slugs — identical from macOS and Linux — and `gpt-5-3` is not among them. Only `gpt-5-3-mini` survives. Anything falling back to that default was requesting a retired model.

`gpt-5-4-thinking` and `gpt-5-4-pro`, both named in the docs, are gone too.

## Model changes

| Where | Before | After |
|---|---|---|
| chat default (server, tools, sse, setup) | `gpt-5-3` ❌ retired | `gpt-5-6` (GPT-5.6 Sol) |
| pro plan + `HEAVY_DR_MODEL` | `gpt-5-5-pro` | `gpt-6-pro` (GPT-6 Pro) |
| docs examples | `gpt-5-4-thinking`, `gpt-5-4-pro` ❌ retired | `gpt-5-6-thinking`, `gpt-5-6-pro` |

Both new defaults carry image generation. `gpt-5-5-pro` and `o3-pro` are still live, so references to those are **left alone**, and `CHANGELOG.md` keeps its historical names.

## The mcp dependency needed an upper bound

`pyproject.toml` asked for `mcp>=1.26.0` with nothing above it, so a fresh install today resolves **mcp 2.2.0**, where `FastMCP` was renamed to `MCPServer`. The package then dies on import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'.
This is mcp 2.x, where FastMCP was renamed to MCPServer …
```

That is not hypothetical — it is what a clean venv did before this change.

The 2026-07-10 cross-model review already concluded `mcp>=1.27,<2`; this only applies it. A dry-run resolve now lands on `mcp-1.30.0`.

## Tests

Three assertions hardcoded the old slugs and were updated to match: the two `write_mcp_config` cases and the heavy deep-research payload.

```
322 passed, 10 skipped
```

## Not fixed here — follow-up

The conversation endpoints (`complete`, `image_gen`) currently fail with:

```
RuntimeError: required Turnstile challenge could not be solved
```

from **both** machines, while read-only GETs such as `/backend-api/models` still succeed. That is a live-service change against `sentinel.py`, unrelated to this refresh, and it means the account path cannot currently generate images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q8zsVfnQnZoNkjk3wSyhp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated default chat, image generation, code interpreter, Canvas, and tool-calling models to GPT-5-6.
  * Updated heavy deep-research defaults to GPT-6-Pro.
  * Pro plans now use GPT-6-Pro; other plans use GPT-5-6.

* **Documentation**
  * Updated configuration guides, examples, and usage references to reflect the new model defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->