### PR TITLE
chore(release): v0.0.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-09-08
+
+Maintenance release. `0.0.11` cannot be installed from PyPI on a fresh
+environment, and every open pull request was red on the same required check.
+Both causes were unbounded dependency ranges.
+
+### Fixed
+
+- Bound `mcp` to `>=1.27,<2`. The range was `>=1.26.0` with no upper bound,
+  so a clean install resolved mcp 2.2.0, where `FastMCP` was renamed to
+  `MCPServer`, and the package died at
+  `from mcp.server.fastmcp import FastMCP`. The 2026-07-10 cross-model review
+  had already settled on this bound; it had not reached `pyproject.toml`.
+- `sse.py` no longer assumes a present key holds a dict. `msg.get("author", {})`
+  returns `None` when the server sends `"author": null`, so the following
+  `.get("role")` raised `AttributeError` mid-stream and lost the response.
+  Author, content and metadata lookups now use `or {}` (#34).
+- A missing ChatGPT token exits with a one-line message instead of a
+  traceback. `get_token` raises a new `TokenNotFoundError`, a `RuntimeError`
+  subclass so existing handlers and tests keep working, which lets the CLI
+  tell "not logged in yet" apart from a real backend failure (#33).
+- Bound `ruff` to `>=0.6,<0.16`. The range was `>=0.6` with no upper bound,
+  so CI installed whatever was newest and the lint gate failed on `main`
+  itself with 112 errors, blocking the entire pull request queue. Bisecting
+  released versions against an untouched checkout puts the break at 0.16.0
+  exactly: 0.12.0, 0.13.0, 0.14.0 and 0.15.0 all pass.
+
+### Changed
+
+- Pinned GitHub Actions moved up: `actions/checkout` 4.3.1 to 7.0.0 (#25),
+  `actions/upload-artifact` 4.6.2 to 7.0.1 (#35) and
+  `softprops/action-gh-release` 2.6.2 to 3.0.2 (#36).
+- Refreshed model defaults against the live account. `gpt-5-3` is no longer
+  served: listing `/backend-api/models` returns 22 slugs and it is not among
+  them, so every code path falling back to that default was requesting a
+  retired model. The chat default is now `gpt-5-6` (GPT-5.6 Sol); the pro
+  plan and `HEAVY_DR_MODEL` now use `gpt-6-pro` (GPT-6 Pro). Both carry image
+  generation. `gpt-5-5-pro` and `o3-pro` remain live and are unchanged.
+- Replaced the retired `gpt-5-4-thinking` and `gpt-5-4-pro` in documentation
+  and skills with `gpt-5-6-thinking` and `gpt-5-6-pro`.
+
+### Known issues
+
+- The conversation endpoints (`complete`, `image_gen`) fail with
+  `required Turnstile challenge could not be solved` from every machine
+  tested, while read-only requests such as `/backend-api/models` still
+  succeed. This is a live-service change against `sentinel.py` and is not
+  addressed by this release.
+
+
 ## [0.0.11] - 2026-07-10
 
 Recovery release carrying forward every change in the

--- a/gpt2agent/__init__.py
+++ b/gpt2agent/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.11"
+version = "0.0.12"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },


### PR DESCRIPTION
Maintenance release. `0.0.11` cannot be installed from PyPI into a clean environment, and every open PR was red on the same required check — both from dependency ranges with no upper bound.

**Fixed**
- `mcp>=1.27,<2` — was unbounded, so a clean resolve picked up mcp 2.2.0 where `FastMCP` became `MCPServer` and the package died on import
- `ruff>=0.6,<0.16` — was unbounded; 0.16.0 fails the lint gate with 112 errors on untouched `main`. Bisected: 0.12/0.13/0.14/0.15 all pass
- SSE null-field guards (#34), clean no-token exit (#33)

**Changed**
- Model defaults refreshed against the live account: `gpt-5-3` is retired, chat now `gpt-5-6`, pro plan and heavy DR now `gpt-6-pro`
- Pinned action bumps (#25, #35, #36)

**Known issue**
- Conversation endpoints fail with `required Turnstile challenge could not be solved`; read-only requests still work. Live-service change against `sentinel.py`, not addressed here.

Version synchronised across all four files; `verify_release.py` agrees. 326 passed, 10 skipped, ruff clean. Cross-reviewed by grok and GLM-5.3 — both PASS after two rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q8zsVfnQnZoNkjk3wSyhp