### PR TITLE
chore(deps): bump actions/download-artifact from 4.3.0 to 8.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
     permissions:
       id-token: write   # OIDC for PyPI trusted publishing
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
@@ -230,7 +230,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Recreates dependabot #26 on current `main` — the original branch conflicted after the other action bumps landed and could not be resolved via update-branch.

Three call sites, all in `release.yml`. Held until v0.0.12 shipped: that is the workflow which publishes to PyPI, and this repo already lost one release to a pipeline change (v0.0.10 tagged, never published). The bump now gets a full cycle before the next release depends on it.

Supersedes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q8zsVfnQnZoNkjk3wSyhp