### PR TITLE
feat(doctor): report upstream breakage honestly and add a self-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ uv.lock
 research/dr-*/events.jsonl
 gpt2agent-raw-dump*.jsonl
 .gpt2agent-raw-dump*.jsonl
+
+# Internal design specs, plans and cross-model reviews. Local only —
+# this repo is public and these describe unreleased work and host paths.
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `gpt2agent doctor`: a new subcommand next to `setup`, `install` and `run`
+  that probes every read-only surface against the live account and prints a
+  status table plus a one-line summary. It never sends a message, never creates
+  a conversation and never spends quota — read-only GETs plus one sentinel
+  probe to classify the challenge state — and it reports the write tools
+  (`custom_instructions_set`, `codex_task_create`) as `UNVERIFIED` rather than
+  pretending it probed them, because probing them means writing to the account.
+  Exits 0 when everything it could check is healthy, non-zero otherwise, and 2
+  with a clean message when no token is configured.
+
+### Changed
+
+- Upstream breakage now raises a named error instead of a bare `RuntimeError`.
+  `UpstreamChallengeError` is raised from the three "challenge could not be
+  solved" paths in `sentinel.py` (proof-of-work, missing Turnstile payload,
+  unsolved Turnstile) and `UpstreamEndpointError` from `list_apps` when its
+  endpoint returns HTTP 405. Both subclass `RuntimeError`, so existing
+  `except RuntimeError` handlers and `pytest.raises(RuntimeError, ...)`
+  assertions keep passing. The message states that the breakage is on
+  ChatGPT's side rather than the user's token or configuration, names the
+  affected tool families, and notes that the read-only tools still work.
+
+### Fixed
+
+- `list_apps` no longer surfaces a raw `HTTP 405 for /backend-api/apps/list`
+  error when ChatGPT moves that endpoint; it raises `UpstreamEndpointError`
+  naming the endpoint instead.
+
+### Documented
+
+- `README.md` gained a clearly marked status section describing what works and
+  what is blocked upstream, pointing at `gpt2agent doctor`, and the affected
+  tool tables and Limitations are annotated. No feature documentation was
+  removed.
+
 ## [0.0.12] - 2026-09-08
 
 Maintenance release. `0.0.11` cannot be installed from PyPI on a fresh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,62 @@ Zed, and any MCP client.
 
 ---
 
+## Status — read-only tools work, conversation tools are blocked upstream
+
+> Checked 2026-09-08 against a live account. Re-check your own account any time
+> with **`gpt2agent doctor`** (below).
+
+ChatGPT changed the Sentinel challenge that guards `/backend-api/conversation`.
+The proof-of-work stage still solves, but the Turnstile stage no longer completes,
+so **every tool that opens a conversation fails**. That is an upstream change at
+chatgpt.com — not a token, login, or configuration problem on your side, so
+re-logging in will not fix it.
+
+| State | Tools |
+|---|---|
+| ✅ Working (probed) | `list_models`, `account_status`, `list_conversations`, `get_conversation`, `list_custom_gpts`, `custom_instructions_get`, `memory_list`, `memory_search`, `list_tasks`, `list_apps`, `list_codex_envs`, `list_codex_tasks` |
+| 🚫 Blocked upstream (sentinel challenge) | `chat`, `agent`, `gpt_chat`, `deep_research`, `deep_research_heavy`, `generate_image`, `code_interpreter`, `canvas_execute`, `memory_create_via_chat` |
+| ❓ Unverified | `custom_instructions_set`, `codex_task_create` — plain REST writes that bypass the sentinel gate; not probed, because probing them means writing to your account. `get_file_info`, `get_file_download_url` — need a `file_id` there is no read-only way to discover. |
+
+
+The blocked tools raise `gpt2agent.backend.UpstreamChallengeError` (a
+`RuntimeError` subclass, so existing handlers keep working) with a message that
+says all three of those things. Everything else below is still documented as
+designed — the annotations mark what is currently blocked, they do not remove
+the feature.
+
+### `gpt2agent doctor`
+
+```bash
+gpt2agent doctor
+```
+
+Probes each read-only surface and prints a status table plus a one-line summary.
+It never sends a message, never creates a conversation, and never spends quota —
+read-only GETs plus one sentinel probe — and it says `UNVERIFIED` for the write
+tools rather than pretending it probed them. Exit code is 0 when everything it
+could check is healthy, non-zero otherwise (including a clean message and exit 2
+when no token is configured).
+
+```text
+$ gpt2agent doctor
+tool                      result     detail
+list_models               OK         22 models
+account_status            OK         chatgptpro plan, US
+memory_list               OK         67 memories
+list_apps                 OK         94 apps/connectors
+sentinel (chat-requirements) BLOCKED    turnstile required, solver returns no token — changed upstream
+chat                      BLOCKED    upstream challenge — see the sentinel row above
+custom_instructions_set   UNVERIFIED plain POST, bypasses the sentinel gate — not probed (would overwrite your instructions)
+
+blocked tools need ChatGPT's sentinel challenge, which changed upstream — not a token or configuration problem. Read-only tools still work.
+gpt2agent doctor: 12 OK, 0 failed, 10 blocked upstream, 4 unverified
+```
+
+*(abridged — the real table has one row per MCP tool, 26 in total)*
+
+---
+
 ## What it does
 
 gpt2agent exposes **25 MCP tools** that forward requests directly to ChatGPT's backend API.
@@ -130,6 +186,10 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 
 ### Chat & reasoning
 
+> ⚠ **Blocked upstream** — every tool in this table opens a conversation and so
+> needs the Sentinel challenge, which changed upstream (see **Status** above).
+> They fail with `UpstreamChallengeError` until the challenge is handled again.
+
 | Tool | What it does |
 |---|---|
 | `chat` | Talk to any model on your account (`gpt-5-6` default, override via `model=`). Pass `gpt-5-5-pro`, `o3-pro`, `gpt-5-6-thinking`, … |
@@ -142,11 +202,14 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 
 | Tool | What it does |
 |---|---|
-| `generate_image` | Generate images via ChatGPT's built-in DALL-E. Returns download URLs + metadata |
+| `generate_image` | Generate images via ChatGPT's built-in DALL-E. Returns download URLs + metadata — ⚠ *blocked upstream* |
 | `get_file_info` | Metadata for any ChatGPT file (images, uploads) |
 | `get_file_download_url` | Temporary download URL for a ChatGPT file (~1h expiry) |
 
 ### Code execution
+
+> ⚠ **Blocked upstream** — both tools go through the conversation endpoint (see
+> **Status** above).
 
 | Tool | What it does |
 |---|---|
@@ -171,7 +234,7 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 |---|---|
 | `memory_list` | List all ChatGPT memory entries (emails/phones redacted) |
 | `memory_search` | Keyword filter over memories |
-| `memory_create_via_chat` | Add a memory (model-initiated workaround — POST `/memories` is 405) |
+| `memory_create_via_chat` | Add a memory (model-initiated workaround — POST `/memories` is 405) — ⚠ *blocked upstream: it needs a conversation* |
 | `custom_instructions_get` | Read your current `about_user` / `about_model` |
 | `custom_instructions_set` | Update them (read-modify-write, preserves unspecified fields) |
 
@@ -190,7 +253,8 @@ the selected Codex auth file on mtime change so long calls don't 401 mid-flight.
 Native Python implementation — no proxy. The server calls
 `/backend-api/conversation` (SSE) directly using `curl_cffi` for TLS
 impersonation. Vendored POW and Turnstile solvers handle the OpenAI Sentinel
-challenge. Token is reloaded from disk on each request, so codex's background
+challenge (the Turnstile stage currently does not pass — see **Status** above).
+Token is reloaded from disk on each request, so codex's background
 refresh propagates transparently. See [NOTICES](./NOTICES.md) for attribution.
 
 ```
@@ -229,6 +293,13 @@ heavy_dr = "gpt-6-pro"      # override slug for deep_research_heavy
 
 ## Limitations
 
+- **Conversation tools are blocked upstream.** chatgpt.com changed its Sentinel
+  challenge; the proof-of-work stage still solves but the Turnstile stage does
+  not, so `chat`, `agent`, `gpt_chat`, both Deep Research tools,
+  `generate_image`, `code_interpreter`, `canvas_execute` and
+  `memory_create_via_chat` all fail with `UpstreamChallengeError`. This is not a
+  token or configuration problem, and re-logging in will not fix it. Read-only
+  tools are unaffected — run `gpt2agent doctor` for a live check.
 - **Deep Research quota:** limits and reset timing are account-reported and can
   change. Run the bundled `deep-research/bin/quota.sh` before heavy work and run
   heavy Deep Research serially.

--- a/gpt2agent/backend.py
+++ b/gpt2agent/backend.py
@@ -30,6 +30,30 @@ class TokenNotFoundError(RuntimeError):
     """
 
 
+class UpstreamChallengeError(RuntimeError):
+    """ChatGPT's Sentinel challenge changed and can no longer be satisfied.
+
+    A ``RuntimeError`` subclass so existing ``except RuntimeError`` handlers and
+    ``pytest.raises(RuntimeError, ...)`` assertions keep working, while callers
+    that need to tell "chatgpt.com moved the goalposts" apart from "your token
+    expired" can catch this specific type. Raised by ``sentinel.py`` when the
+    proof-of-work or Turnstile stage of ``sentinel/chat-requirements`` cannot be
+    completed — the read-only REST endpoints keep working, so this is never a
+    login or configuration problem on the user's side.
+    """
+
+
+class UpstreamEndpointError(RuntimeError):
+    """A backend-api endpoint changed or disappeared upstream.
+
+    A ``RuntimeError`` subclass so existing ``except RuntimeError`` handlers and
+    ``pytest.raises(RuntimeError, ...)`` assertions keep working. Raised where a
+    tool's endpoint returns a permanent protocol-level refusal (e.g. HTTP 405
+    where a GET used to be served) — retrying or re-authenticating cannot help,
+    so the tool is broken until gpt2agent is updated to match the new surface.
+    """
+
+
 def _load_token_with_source() -> tuple[str, Path | None]:
     """Load the ChatGPT bearer token and return its source file for mtime tracking.
 

--- a/gpt2agent/doctor.py
+++ b/gpt2agent/doctor.py
@@ -1,0 +1,368 @@
+"""``gpt2agent doctor`` — a truthful, read-only health report.
+
+Answers one question: *which tools work against the live account right now?*
+
+Every probe here is a read-only GET on the same path the corresponding MCP tool
+uses, plus exactly one sentinel probe to classify the challenge state. Doctor
+never sends a message, never creates a conversation, and never spends quota —
+which is why the write tools are *classified from the code*, not exercised, and
+reported as UNVERIFIED rather than pretending they were probed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from gpt2agent.backend import BackendClient, TokenNotFoundError, UpstreamChallengeError
+from gpt2agent.sentinel import SentinelGate
+from gpt2agent.tools._backend import async_get
+
+# Result column values. OK/FAIL come from a real probe; BLOCKED is inferred from
+# the sentinel probe (the tool needs the gate, the gate is broken); UNVERIFIED
+# means doctor has no safe way to check that tool and says so instead of guessing.
+_OK = "OK"
+_FAIL = "FAIL"
+_BLOCKED = "BLOCKED"
+_UNVERIFIED = "UNVERIFIED"
+
+_TOOL_W = 25
+_RESULT_W = 10
+_DETAIL_W = 88
+
+# Tools that go through ConversationClient -> SentinelGate (sse.py) and are
+# therefore all blocked together when the challenge cannot be solved. Doctor
+# cannot exercise any of them without sending a real message, so their result is
+# a copy of the sentinel row's, not an independent measurement.
+_GATE_TOOLS = (
+    "chat",
+    "agent",
+    "gpt_chat",
+    "deep_research",
+    "deep_research_heavy",
+    "generate_image",
+    "code_interpreter",
+    "canvas_execute",
+    "memory_create_via_chat",
+)
+
+
+@dataclass
+class Row:
+    tool: str
+    result: str
+    detail: str
+
+
+def _short(text: str, limit: int = _DETAIL_W) -> str:
+    """First line of *text*, truncated to one table row."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return "(no detail)"
+    line = stripped.splitlines()[0]
+    if len(line) > limit:
+        return line[: limit - 1] + "…"
+    return line
+
+
+# ── read-only probes ─────────────────────────────────────────────────────────
+#
+# Each probe mirrors one MCP tool's GET and returns the detail cell. Probes run
+# sequentially on purpose — a burst of parallel requests to the backend looks
+# like exactly the abnormal traffic the sentinel gate exists to stop.
+
+
+async def _p_list_models(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client,
+        "/backend-api/models?history_and_training_disabled=false",
+        target_path="/backend-api/models",
+    )
+    return f"{len((data or {}).get('models') or [])} models"
+
+
+async def _p_account_status(client: BackendClient, ctx: dict[str, Any]) -> str:
+    me = await async_get(client, "/backend-api/me", target_path="/backend-api/me") or {}
+    check = await async_get(
+        client,
+        "/backend-api/accounts/check/v4-2023-04-27",
+        target_path="/backend-api/accounts/check/v4-2023-04-27",
+    )
+    accounts = (check or {}).get("accounts") or {}
+    first = next(iter(accounts.values()), {})
+    plan = (first.get("entitlement") or {}).get("subscription_plan")
+    return f"{plan or 'unknown'} plan, {me.get('country') or 'unknown country'}"
+
+
+async def _p_list_conversations(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client,
+        "/backend-api/conversations?offset=0&limit=5&order=updated",
+        target_path="/backend-api/conversations",
+    )
+    items = (data or {}).get("items") or []
+    # Hand the newest conversation id to the get_conversation probe.
+    ctx["conversation_ids"] = [c.get("id") for c in items if c.get("id")]
+    return f"{len(items)} recent conversations"
+
+
+class _NotProbed(Exception):
+    """Raised by a probe that cannot run because a probe it depends on failed."""
+
+
+async def _p_get_conversation(client: BackendClient, ctx: dict[str, Any]) -> str:
+    if "conversation_ids" not in ctx:
+        # list_conversations failed, so its id list was never populated. Saying
+        # OK here would report a tool as working that was never exercised.
+        raise _NotProbed("depends on list_conversations, which failed above")
+    ids = ctx["conversation_ids"]
+    if not ids:
+        return "no conversation to inspect (account has none)"
+    data = await async_get(client, f"/backend-api/conversation/{ids[0]}") or {}
+    return f"newest conversation readable ({len(data.get('mapping') or {})} nodes)"
+
+
+async def _p_list_custom_gpts(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client,
+        "/backend-api/gizmos/snorlax/sidebar",
+        target_path="/backend-api/gizmos/snorlax/sidebar",
+    )
+    return f"{len((data or {}).get('items') or [])} custom GPTs"
+
+
+async def _p_custom_instructions_get(
+    client: BackendClient, ctx: dict[str, Any]
+) -> str:
+    ci = await async_get(
+        client,
+        "/backend-api/user_system_messages",
+        target_path="/backend-api/user_system_messages",
+    )
+    return f"enabled={(ci or {}).get('enabled')!r}"
+
+
+async def _p_memory_list(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client, "/backend-api/memories", target_path="/backend-api/memories"
+    )
+    return f"{len((data or {}).get('memories') or [])} memories"
+
+
+async def _p_memory_search(client: BackendClient, ctx: dict[str, Any]) -> str:
+    # Same GET as memory_list plus a local filter (tools/memory.py), so it is a
+    # real probe of the tool's only network dependency, not an inference.
+    data = await async_get(
+        client, "/backend-api/memories", target_path="/backend-api/memories"
+    )
+    return f"searchable over {len((data or {}).get('memories') or [])} memories"
+
+
+async def _p_list_tasks(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client, "/backend-api/tasks?limit=1", target_path="/backend-api/tasks"
+    )
+    return f"{len((data or {}).get('tasks') or [])} tasks"
+
+
+async def _p_list_codex_envs(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client,
+        "/backend-api/codex/environments",
+        target_path="/backend-api/codex/environments",
+    )
+    envs = data if isinstance(data, list) else ((data or {}).get("environments") or [])
+    return f"{len(envs)} environments"
+
+
+async def _p_list_codex_tasks(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client, "/backend-api/codex/tasks?limit=1", target_path="/backend-api/codex/tasks"
+    )
+    return f"{len((data or {}).get('items') or [])} tasks"
+
+
+async def _p_list_apps(client: BackendClient, ctx: dict[str, Any]) -> str:
+    data = await async_get(
+        client, "/backend-api/apps/list", target_path="/backend-api/apps/list"
+    )
+    return f"{len((data or {}).get('apps') or [])} apps/connectors"
+
+
+# (tool name, probe) in report order.
+_PROBES: list[tuple[str, Callable[[BackendClient, dict[str, Any]], Awaitable[str]]]] = [
+    ("list_models", _p_list_models),
+    ("account_status", _p_account_status),
+    ("list_conversations", _p_list_conversations),
+    ("get_conversation", _p_get_conversation),
+    ("list_custom_gpts", _p_list_custom_gpts),
+    ("custom_instructions_get", _p_custom_instructions_get),
+    ("memory_list", _p_memory_list),
+    ("memory_search", _p_memory_search),
+    ("list_tasks", _p_list_tasks),
+    ("list_codex_envs", _p_list_codex_envs),
+    ("list_codex_tasks", _p_list_codex_tasks),
+    ("list_apps", _p_list_apps),
+]
+
+
+# ── sentinel probe ───────────────────────────────────────────────────────────
+
+
+async def _classify_gate(client: BackendClient) -> tuple[str, str]:
+    """Classify the sentinel gate with one real ``chat-requirements`` round trip.
+
+    Reuses ``SentinelGate.get_tokens()`` so doctor reports whatever the actual
+    conversation path would hit, rather than a re-implementation that could drift.
+    """
+    try:
+        tokens = await SentinelGate(client).get_tokens()
+    except UpstreamChallengeError as exc:
+        # Compress the (deliberately verbose) exception into one table cell; the
+        # full explanation stays in the exception for MCP client logs.
+        first = str(exc).splitlines()[0]
+        if "POW" in first:
+            detail = "proof-of-work stage no longer solvable — challenge changed upstream"
+        elif "no challenge payload" in first:
+            detail = "turnstile demanded without a challenge payload — changed upstream"
+        else:
+            detail = "turnstile required, solver returns no token — changed upstream"
+        return _BLOCKED, detail
+    except RuntimeError as exc:
+        # Gate failed for some other reason (auth, transport, response shape) —
+        # that is a probe failure, not a classified upstream breakage.
+        return _FAIL, _short(str(exc))
+    if tokens.get("turnstile"):
+        return _OK, "turnstile solved"
+    return _OK, "no turnstile required"
+
+
+# ── classification from code, not from probing ───────────────────────────────
+#
+# These tools POST to REST endpoints directly (tools/writes.py) and never touch
+# the sentinel gate, so the challenge breakage does not reach them — but doctor
+# will not verify that by writing to the account. Files tools need a file_id we
+# have no way to discover read-only.
+
+
+_UNVERIFIED_TOOLS: list[tuple[str, str]] = [
+    (
+        "custom_instructions_set",
+        "plain POST, bypasses the sentinel gate — not probed (would overwrite "
+        "your instructions)",
+    ),
+    (
+        "codex_task_create",
+        "plain POST, bypasses the sentinel gate — not probed (would spend quota)",
+    ),
+    ("get_file_info", "needs a file_id — not probed"),
+    ("get_file_download_url", "needs a file_id — not probed"),
+]
+
+
+_GATE_DETAIL = {
+    _OK: "gate open — conversation not probed (would send a message)",
+    _BLOCKED: "upstream challenge — see the sentinel row above",
+}
+
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+
+async def collect(client: BackendClient) -> list[Row]:
+    """Run every probe and return the report rows. One row per tool."""
+    rows: list[Row] = []
+    ctx: dict[str, Any] = {}
+
+    for tool, probe in _PROBES:
+        try:
+            detail = await probe(client, ctx)
+        except _NotProbed as exc:
+            rows.append(Row(tool, _UNVERIFIED, str(exc)))
+            continue
+        except Exception as exc:  # one failed probe must not kill the whole report
+            message = str(exc) or type(exc).__name__
+            if "405" in message:
+                # Method Not Allowed on a GET that used to be served: the
+                # endpoint moved upstream. Retrying or re-logging in won't help.
+                rows.append(Row(tool, _FAIL, "HTTP 405 — endpoint changed upstream"))
+            else:
+                rows.append(Row(tool, _FAIL, _short(message)))
+            continue
+        rows.append(Row(tool, _OK, detail))
+
+    gate_result, gate_detail = await _classify_gate(client)
+    rows.append(Row("sentinel (chat-requirements)", gate_result, gate_detail))
+    for tool in _GATE_TOOLS:
+        # Not an independent measurement: these all share the one gate probe
+        # above, and exercising any of them would send a real message.
+        detail = _GATE_DETAIL.get(gate_result, gate_detail)
+        rows.append(Row(tool, gate_result, detail))
+
+    rows.extend(Row(tool, _UNVERIFIED, detail) for tool, detail in _UNVERIFIED_TOOLS)
+    return rows
+
+
+def _format_table(rows: list[Row]) -> str:
+    lines = [f"{'tool':<{_TOOL_W}} {'result':<{_RESULT_W}} detail"]
+    for row in rows:
+        lines.append(f"{row.tool:<{_TOOL_W}} {row.result:<{_RESULT_W}} {row.detail}")
+    return "\n".join(lines)
+
+
+def summarize(rows: list[Row]) -> str:
+    """One-line summary of the table."""
+    n: dict[str, int] = {}
+    for row in rows:
+        n[row.result] = n.get(row.result, 0) + 1
+    parts = [
+        f"{n.get(_OK, 0)} OK",
+        f"{n.get(_FAIL, 0)} failed",
+        f"{n.get(_BLOCKED, 0)} blocked upstream",
+        f"{n.get(_UNVERIFIED, 0)} unverified",
+    ]
+    return "gpt2agent doctor: " + ", ".join(parts)
+
+
+def _blocked_note(rows: list[Row]) -> str | None:
+    """Context line for a blocked gate — the table cell is too short to carry it."""
+    if not any(r.result == _BLOCKED for r in rows):
+        return None
+    return (
+        "blocked tools need ChatGPT's sentinel challenge, which changed upstream — "
+        "not a token or configuration problem. Read-only tools still work."
+    )
+
+
+def exit_code(rows: list[Row]) -> int:
+    """0 when everything doctor could check is healthy, 1 otherwise.
+
+    UNVERIFIED rows are not failures — doctor never claimed to check them.
+    """
+    return 0 if all(r.result not in (_FAIL, _BLOCKED) for r in rows) else 1
+
+
+def run_doctor(stream=print) -> int:
+    """Entry point for the ``doctor`` subcommand. Returns the process exit code."""
+    from gpt2agent import __version__
+
+    stream(f"gpt2agent doctor {__version__} — probing read-only surfaces")
+    try:
+        client = BackendClient()
+    except TokenNotFoundError as exc:
+        stream("")
+        stream(f"no token: {exc}")
+        stream("Nothing was probed. Log in, then run `gpt2agent doctor` again.")
+        return 2
+
+    rows = asyncio.run(collect(client))
+    stream("")
+    stream(_format_table(rows))
+    stream("")
+    note = _blocked_note(rows)
+    if note:
+        stream(note)
+    stream(summarize(rows))
+    return exit_code(rows)

--- a/gpt2agent/sentinel.py
+++ b/gpt2agent/sentinel.py
@@ -12,6 +12,7 @@ from curl_cffi.requests import AsyncSession
 from gpt2agent._log_redact import redact_error as _redact_error
 from gpt2agent._vendored import pow as _pow
 from gpt2agent._vendored import turnstile as _turn
+from gpt2agent.backend import UpstreamChallengeError
 
 if TYPE_CHECKING:
     from gpt2agent.backend import BackendClient
@@ -22,6 +23,18 @@ _CHAT_UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/131.0.0.0 Safari/537.36"
+)
+
+# Appended to every "the challenge could not be solved" raise. The unsolved
+# stage is named on the first line of the message; this explains what that means
+# for the user. Kept short — the whole message lands in MCP client logs.
+_UPSTREAM_CHALLENGE_NOTE = (
+    "This is a change on ChatGPT's side, not a problem with your token or "
+    "configuration — re-logging in will not fix it.\n"
+    "Blocked tools: chat, agent, gpt_chat, deep_research, deep_research_heavy, "
+    "generate_image, code_interpreter, canvas_execute, memory_create_via_chat.\n"
+    "Read-only tools (list_models, list_conversations, memory_list, ...) are "
+    "unaffected. Run `gpt2agent doctor` for a live status table."
 )
 
 
@@ -80,7 +93,10 @@ class SentinelGate:
                 raise RuntimeError(f"sentinel POW missing seed/difficulty: {pow_block}")
             proof = await asyncio.to_thread(_pow.solve_pow, seed, diff, ua)
             if not proof:
-                raise RuntimeError("required POW challenge could not be solved")
+                raise UpstreamChallengeError(
+                    "required POW challenge could not be solved.\n"
+                    + _UPSTREAM_CHALLENGE_NOTE
+                )
             out["proof"] = proof
         else:
             out["proof"] = ""
@@ -89,13 +105,21 @@ class SentinelGate:
         if turn_block.get("required"):
             dx = turn_block.get("dx")
             if not dx:
-                raise RuntimeError("required Turnstile challenge could not be solved")
+                raise UpstreamChallengeError(
+                    "required Turnstile challenge could not be solved "
+                    "(chat-requirements demanded Turnstile but sent no challenge "
+                    "payload).\n" + _UPSTREAM_CHALLENGE_NOTE
+                )
             proof_for_xor = out.get("proof") or p
             tok = await asyncio.to_thread(
                 _turn.solve_turnstile, dx, proof_for_xor
             )
             if not tok:
-                raise RuntimeError("required Turnstile challenge could not be solved")
+                raise UpstreamChallengeError(
+                    "required Turnstile challenge could not be solved "
+                    "(the vendored solver returned no token for the challenge "
+                    "chatgpt.com sent).\n" + _UPSTREAM_CHALLENGE_NOTE
+                )
             out["turnstile"] = tok
 
         return out

--- a/gpt2agent/server.py
+++ b/gpt2agent/server.py
@@ -326,6 +326,12 @@ def main() -> None:
     # setup subcommand
     sub.add_parser("setup", help="First-time setup wizard (login + register)")
 
+    # doctor subcommand — read-only health check against the live account
+    sub.add_parser(
+        "doctor",
+        help="Probe the account read-only and report which tools work right now",
+    )
+
     # install subcommand — register gpt2agent with one or more MCP clients
     from gpt2agent.install import SUPPORTED_CLIENTS
 
@@ -385,6 +391,11 @@ def main() -> None:
 
         run_setup()
         return
+
+    if args.command == "doctor":
+        from gpt2agent.doctor import run_doctor
+
+        raise SystemExit(run_doctor())
 
     if args.command == "install":
         from gpt2agent.install import run_install

--- a/gpt2agent/tools/apps.py
+++ b/gpt2agent/tools/apps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from gpt2agent.backend import BackendClient
+from gpt2agent.backend import BackendClient, UpstreamEndpointError
 from gpt2agent.tools._backend import async_get
 
 
@@ -16,11 +16,26 @@ def register(mcp, client: BackendClient) -> None:
     @mcp.tool()
     async def list_apps() -> list:
         """Return ChatGPT connected apps/connectors. Names unresolvable — IDs with type classification returned."""
-        data = await async_get(
-            client,
-            "/backend-api/apps/list",
-            target_path="/backend-api/apps/list",
-        ) or {}
+        try:
+            data = await async_get(
+                client,
+                "/backend-api/apps/list",
+                target_path="/backend-api/apps/list",
+            ) or {}
+        except RuntimeError as exc:
+            # 405 = the endpoint no longer accepts this request shape at all.
+            # Surface it as a named upstream change instead of a raw HTTP error:
+            # retrying or re-logging in cannot fix a moved endpoint.
+            if "405" in str(exc):
+                raise UpstreamEndpointError(
+                    f"list_apps is broken upstream: {exc}.\n"
+                    "ChatGPT moved or removed this endpoint, so the installed "
+                    "gpt2agent can no longer list connected apps. This is not a "
+                    "problem with your token or configuration. Other read-only "
+                    "tools still work — run `gpt2agent doctor` for a live "
+                    "status table."
+                ) from exc
+            raise
         return [
             {
                 "id": a.get("id"),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,360 @@
+"""Tests for ``gpt2agent doctor`` — all offline, against a fake backend.
+
+Doctor's whole point is honesty: it reports what it actually probed, and says
+UNVERIFIED for the tools it deliberately did not exercise. These tests pin that
+contract — including "doctor never POSTs", which is what makes it safe to run
+against a live account.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+import pytest
+
+from gpt2agent import doctor as doctor_mod
+from gpt2agent.backend import UpstreamChallengeError
+
+
+class FakeClient:
+    """Exact-match canned GET responses. Any POST is a test failure."""
+
+    def __init__(self, routes: dict[str, Any] | None = None) -> None:
+        self.routes = routes or {}
+        self.gets: list[str] = []
+        self.posts: list[str] = []
+
+    def get(self, path: str, target_path: str | None = None, **_: Any) -> Any:
+        self.gets.append(path)
+        if path not in self.routes:
+            raise RuntimeError(f"HTTP 404 for {path}")
+        value = self.routes[path]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def post(self, path: str, *_: Any, **__: Any) -> Any:
+        self.posts.append(path)
+        raise AssertionError("doctor must never POST")
+
+
+_ROUTES: dict[str, Any] = {
+    "/backend-api/models?history_and_training_disabled=false": {"models": [{"slug": "gpt-5-6"}] * 3},
+    "/backend-api/me": {"country": "US"},
+    "/backend-api/accounts/check/v4-2023-04-27": {
+        "accounts": {"acc_1": {"entitlement": {"subscription_plan": "plus"}}}
+    },
+    "/backend-api/conversations?offset=0&limit=5&order=updated": {
+        "items": [{"id": "conv_1"}, {"id": "conv_2"}]
+    },
+    "/backend-api/conversation/conv_1": {"mapping": {"a": {}, "b": {}, "c": {}}},
+    "/backend-api/gizmos/snorlax/sidebar": {"items": [{"gizmo": {"name": "G"}}]},
+    "/backend-api/user_system_messages": {"enabled": True},
+    "/backend-api/memories": {"memories": [{"id": "m"}, {"id": "m"}]},
+    "/backend-api/tasks?limit=1": {"tasks": [{"task_id": "t"}]},
+    "/backend-api/codex/environments": {"environments": [{"id": "e"}]},
+    "/backend-api/codex/tasks?limit=1": {"items": [{"task": {"id": "t"}}]},
+    "/backend-api/apps/list": {"apps": ["connector_x"]},
+}
+
+
+class _GateOk:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def get_tokens(self) -> dict[str, str]:
+        return {"chat-requirements": "t", "proof": "p", "turnstile": "tok"}
+
+
+class _GateBlocked:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def get_tokens(self) -> dict[str, str]:
+        raise UpstreamChallengeError(
+            "required Turnstile challenge could not be solved.\n"
+            "This is a change on ChatGPT's side, not a problem with your token."
+        )
+
+
+def _collect(client: FakeClient) -> list[doctor_mod.Row]:
+    return asyncio.run(doctor_mod.collect(client))
+
+
+def _patch_gate(monkeypatch: pytest.MonkeyPatch, gate) -> None:
+    monkeypatch.setattr(doctor_mod, "SentinelGate", gate)
+
+
+def _row(rows: list[doctor_mod.Row], tool: str) -> doctor_mod.Row:
+    matches = [r for r in rows if r.tool == tool]
+    assert matches, f"{tool} missing from the doctor report"
+    return matches[0]
+
+
+# ── happy path ───────────────────────────────────────────────────────────────
+
+
+def test_read_only_probes_report_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    assert _row(rows, "list_models").result == "OK"
+    assert "3 models" in _row(rows, "list_models").detail
+    assert _row(rows, "account_status").result == "OK"
+    assert _row(rows, "get_conversation").result == "OK"
+    assert _row(rows, "list_apps").result == "OK"
+
+
+def test_doctor_never_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Doctor is read-only by construction — a POST would write or spend quota."""
+    _patch_gate(monkeypatch, _GateOk)
+    client = FakeClient(dict(_ROUTES))
+    asyncio.run(doctor_mod.collect(client))
+    assert client.posts == []
+
+
+def test_probes_use_the_real_tool_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Doctor reports the paths the MCP tools actually call, not approximations."""
+    _patch_gate(monkeypatch, _GateOk)
+    client = FakeClient(dict(_ROUTES))
+    asyncio.run(doctor_mod.collect(client))
+    for path in _ROUTES:
+        assert path in client.gets, f"doctor never probed {path}"
+
+
+def test_get_conversation_without_history_is_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    routes = dict(_ROUTES)
+    routes["/backend-api/conversations?offset=0&limit=5&order=updated"] = {"items": []}
+    rows = _collect(FakeClient(routes))
+
+    row = _row(rows, "get_conversation")
+    assert row.result == "OK"
+    assert "no conversation" in row.detail
+
+
+# ── failures ─────────────────────────────────────────────────────────────────
+
+
+def test_probe_failure_does_not_abort_the_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    routes = dict(_ROUTES)
+    routes["/backend-api/memories"] = RuntimeError("HTTP 500 for /backend-api/memories")
+    rows = _collect(FakeClient(routes))
+
+    assert _row(rows, "memory_list").result == "FAIL"
+    assert _row(rows, "list_models").result == "OK"
+    assert _row(rows, "list_apps").result == "OK"
+
+
+def test_405_is_reported_as_an_upstream_endpoint_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    routes = dict(_ROUTES)
+    routes["/backend-api/apps/list"] = RuntimeError("HTTP 405 for /backend-api/apps/list")
+    rows = _collect(FakeClient(routes))
+
+    row = _row(rows, "list_apps")
+    assert row.result == "FAIL"
+    assert "405" in row.detail
+    assert "endpoint changed upstream" in row.detail
+
+
+# ── the sentinel gate ────────────────────────────────────────────────────────
+
+
+def test_blocked_gate_blocks_the_chat_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_gate(monkeypatch, _GateBlocked)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    assert _row(rows, "sentinel (chat-requirements)").result == "BLOCKED"
+    for tool in doctor_mod._GATE_TOOLS:
+        assert _row(rows, tool).result == "BLOCKED", f"{tool} should be blocked"
+    assert doctor_mod.exit_code(rows) == 1
+
+
+def test_open_gate_leaves_chat_reported_as_not_probed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A passing gate is not a passing chat tool — doctor must not overclaim."""
+    _patch_gate(monkeypatch, _GateOk)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    row = _row(rows, "chat")
+    assert row.result == "OK"
+    assert "not probed" in row.detail
+    assert doctor_mod.exit_code(rows) == 0
+
+
+def test_gate_failure_for_another_reason_is_fail_not_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Gate403:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        async def get_tokens(self) -> dict[str, str]:
+            raise RuntimeError("sentinel/chat-requirements HTTP 403: denied")
+
+    _patch_gate(monkeypatch, _Gate403)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    assert _row(rows, "sentinel (chat-requirements)").result == "FAIL"
+    assert _row(rows, "chat").result == "FAIL"
+    assert doctor_mod.exit_code(rows) == 1
+
+
+# ── unverified tools ─────────────────────────────────────────────────────────
+
+
+def test_write_tools_are_reported_unverified_not_probed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """custom_instructions_set / codex_task_create bypass the gate; doctor
+    classifies them from the code instead of mutating the account to test them."""
+    _patch_gate(monkeypatch, _GateOk)
+    client = FakeClient(dict(_ROUTES))
+    rows = asyncio.run(doctor_mod.collect(client))
+
+    instructions = _row(rows, "custom_instructions_set")
+    codex = _row(rows, "codex_task_create")
+    for row in (instructions, codex):
+        assert row.result == "UNVERIFIED"
+        assert "not probed" in row.detail
+        assert "sentinel gate" in row.detail  # the code-read classification
+    # Nothing was written while classifying them.
+    assert client.posts == []
+
+
+def test_unverified_rows_do_not_fail_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    assert any(r.result == "UNVERIFIED" for r in rows)
+    assert doctor_mod.exit_code(rows) == 0
+
+
+# ── the report itself ────────────────────────────────────────────────────────
+
+
+def test_table_has_a_row_per_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gate(monkeypatch, _GateBlocked)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    table = doctor_mod._format_table(rows)
+    assert table.splitlines()[0].split() == ["tool", "result", "detail"]
+    for row in rows:
+        assert f"{row.tool:<25}" in table
+
+
+def test_summary_line_counts_every_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gate(monkeypatch, _GateBlocked)
+    rows = _collect(FakeClient(dict(_ROUTES)))
+
+    summary = doctor_mod.summarize(rows)
+    blocked = sum(1 for r in rows if r.result == "BLOCKED")
+    assert summary.startswith("gpt2agent doctor:")
+    assert f"{blocked} blocked upstream" in summary
+    assert "0 failed" in summary
+    assert "unverified" in summary
+
+
+def test_blocked_note_only_appears_when_something_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_gate(monkeypatch, _GateOk)
+    ok_rows = _collect(FakeClient(dict(_ROUTES)))
+    assert doctor_mod._blocked_note(ok_rows) is None
+
+    _patch_gate(monkeypatch, _GateBlocked)
+    blocked_rows = _collect(FakeClient(dict(_ROUTES)))
+    note = doctor_mod._blocked_note(blocked_rows)
+    assert note is not None
+    assert "not a token or configuration problem" in note
+
+
+# ── entry point ──────────────────────────────────────────────────────────────
+
+
+def test_run_doctor_without_token_says_so_and_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent.backend import TokenNotFoundError
+
+    def _no_token() -> Any:
+        raise TokenNotFoundError("No ChatGPT token found — run `codex login`")
+
+    monkeypatch.setattr(doctor_mod, "BackendClient", _no_token)
+
+    lines: list[str] = []
+    assert doctor_mod.run_doctor(stream=lines.append) == 2
+    text = "\n".join(lines)
+    assert "no token" in text
+    assert "Nothing was probed" in text
+    # No status table: a report with zero probes would read as "all broken".
+    assert "list_models" not in text
+
+
+def test_run_doctor_prints_the_table_and_returns_its_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor_mod, "BackendClient", lambda: FakeClient(dict(_ROUTES)))
+    monkeypatch.setattr(doctor_mod, "SentinelGate", _GateOk)
+
+    lines: list[str] = []
+    assert doctor_mod.run_doctor(stream=lines.append) == 0
+
+    text = "\n".join(lines)
+    assert text.splitlines()[0].startswith("gpt2agent doctor")
+    assert "list_models" in text
+    assert text.rstrip().splitlines()[-1] == (
+        "gpt2agent doctor: 22 OK, 0 failed, 0 blocked upstream, 4 unverified"
+    )
+
+
+def test_cli_doctor_subcommand_wires_the_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt2agent import server as server_mod
+
+    monkeypatch.setattr(doctor_mod, "run_doctor", lambda: 3)
+    monkeypatch.setattr(sys, "argv", ["gpt2agent", "doctor"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        server_mod.main()
+
+    assert excinfo.value.code == 3
+
+
+def test_get_conversation_is_unverified_when_the_listing_probe_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe whose dependency failed must not report OK.
+
+    ``_p_get_conversation`` reuses the id list that ``_p_list_conversations``
+    puts in ``ctx``. When the listing probe raises, ``collect`` records its
+    failure and moves on, leaving ``ctx`` untouched — so an "empty means fine"
+    reading of the missing key reported a tool as working that was never
+    exercised. It has to come back UNVERIFIED instead.
+    """
+    routes = dict(_ROUTES)
+    routes["/backend-api/conversations?offset=0&limit=5&order=updated"] = RuntimeError(
+        "HTTP 500 for /backend-api/conversations"
+    )
+    monkeypatch.setattr(doctor_mod, "SentinelGate", _GateOk)
+
+    rows = asyncio.run(doctor_mod.collect(FakeClient(routes)))
+    by_tool = {row.tool: row for row in rows}
+
+    assert by_tool["list_conversations"].result == doctor_mod._FAIL
+    assert by_tool["get_conversation"].result == doctor_mod._UNVERIFIED
+    assert "list_conversations" in by_tool["get_conversation"].detail

--- a/tests/test_upstream_errors.py
+++ b/tests/test_upstream_errors.py
@@ -1,0 +1,287 @@
+"""Tests for the upstream-breakage error types and their raise sites.
+
+chatgpt.com changed its Sentinel challenge (see the 0.0.12 "Known issues" entry):
+the conversation path cannot be opened while every read-only REST surface still
+answers. The contract pinned here is that this failure surfaces as a *specific*
+``RuntimeError`` subclass carrying an honest explanation — existing
+``except RuntimeError`` handlers and ``pytest.raises(RuntimeError, ...)``
+assertions keep working, while new code can tell upstream breakage apart from a
+token or configuration problem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from gpt2agent import sentinel as sentinel_mod
+from gpt2agent import sse as sse_mod
+from gpt2agent.backend import UpstreamChallengeError, UpstreamEndpointError
+
+
+# ── the types themselves ─────────────────────────────────────────────────────
+
+
+def test_upstream_errors_subclass_runtimeerror() -> None:
+    """Both must remain catchable as RuntimeError — existing handlers depend on it."""
+    assert issubclass(UpstreamChallengeError, RuntimeError)
+    assert issubclass(UpstreamEndpointError, RuntimeError)
+
+
+@pytest.mark.parametrize("exc_type", [UpstreamChallengeError, UpstreamEndpointError])
+def test_upstream_errors_satisfy_runtimeerror_assertions(exc_type: type) -> None:
+    with pytest.raises(RuntimeError, match="upstream"):
+        raise exc_type("an upstream change broke this tool")
+
+
+# ── sentinel raise sites ─────────────────────────────────────────────────────
+
+
+class _SentinelBackend:
+    class _Session:
+        headers: dict[str, str] = {"User-Agent": "test-agent"}
+
+    _session = _Session()
+
+
+def _patch_sentinel_response(
+    monkeypatch: pytest.MonkeyPatch, payload: dict
+) -> None:
+    class _Response:
+        status_code = 200
+        text = json.dumps(payload)
+
+        def json(self) -> dict:
+            return payload
+
+    class _Session:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Session":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def post(self, *_: Any, **__: Any) -> _Response:
+            return _Response()
+
+    monkeypatch.setattr(sentinel_mod, "AsyncSession", _Session)
+    monkeypatch.setattr(sentinel_mod._pow, "get_requirements_token", lambda _: "p")
+
+
+def _unsolvable_turnstile(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_sentinel_response(
+        monkeypatch,
+        {
+            "token": "chat-token",
+            "proofofwork": {"required": False},
+            "turnstile": {"required": True, "dx": "challenge"},
+        },
+    )
+    monkeypatch.setattr(sentinel_mod._turn, "solve_turnstile", lambda *_: None)
+
+
+def test_turnstile_unsolved_raises_upstream_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _unsolvable_turnstile(monkeypatch)
+    gate = sentinel_mod.SentinelGate(_SentinelBackend())  # type: ignore[arg-type]
+
+    with pytest.raises(UpstreamChallengeError) as excinfo:
+        asyncio.run(gate.get_tokens())
+
+    # The stage that failed stays on the first line — see also the older
+    # assertions in test_audit_2026_07_09_streaming.py, which match on it.
+    assert "required Turnstile challenge could not be solved" in str(excinfo.value)
+
+
+def test_turnstile_without_dx_raises_upstream_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sentinel_response(
+        monkeypatch,
+        {
+            "token": "chat-token",
+            "proofofwork": {"required": False},
+            "turnstile": {"required": True},
+        },
+    )
+    gate = sentinel_mod.SentinelGate(_SentinelBackend())  # type: ignore[arg-type]
+
+    with pytest.raises(UpstreamChallengeError):
+        asyncio.run(gate.get_tokens())
+
+
+def test_pow_unsolved_raises_upstream_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The POW stage is the same class of failure: the gate cannot be satisfied."""
+    _patch_sentinel_response(
+        monkeypatch,
+        {
+            "token": "chat-token",
+            "proofofwork": {"required": True, "seed": "s", "difficulty": "d"},
+            "turnstile": {"required": False},
+        },
+    )
+    monkeypatch.setattr(sentinel_mod._pow, "solve_pow", lambda *_: None)
+    gate = sentinel_mod.SentinelGate(_SentinelBackend())  # type: ignore[arg-type]
+
+    with pytest.raises(UpstreamChallengeError) as excinfo:
+        asyncio.run(gate.get_tokens())
+
+    assert "required POW challenge could not be solved" in str(excinfo.value)
+
+
+def test_challenge_message_tells_the_user_the_three_things(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not their token/config, which tools are affected, what still works."""
+    _unsolvable_turnstile(monkeypatch)
+    gate = sentinel_mod.SentinelGate(_SentinelBackend())  # type: ignore[arg-type]
+
+    with pytest.raises(UpstreamChallengeError) as excinfo:
+        asyncio.run(gate.get_tokens())
+
+    message = str(excinfo.value)
+    # 1. upstream change, not the user's token or configuration
+    assert "not a problem with your token or configuration" in message
+    assert "re-logging in will not fix it" in message
+    # 2. which tool families are affected
+    for tool in (
+        "chat",
+        "agent",
+        "deep_research",
+        "generate_image",
+        "memory_create_via_chat",
+    ):
+        assert tool in message, f"{tool} missing from the affected-tool list"
+    # 3. read-only tools still work, and where to get a live status
+    assert "Read-only tools" in message
+    assert "gpt2agent doctor" in message
+
+
+def test_conversation_path_surfaces_challenge_error_as_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP chat/DR/agent tools see the specific error, still a RuntimeError."""
+
+    class _BlockedGate:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        async def get_tokens(self) -> dict[str, str]:
+            raise UpstreamChallengeError(
+                "required Turnstile challenge could not be solved.\n"
+                "This is a change on ChatGPT's side."
+            )
+
+    class _Backend:
+        class _Session:
+            headers: dict[str, str] = {"User-Agent": "test-agent"}
+
+        _session = _Session()
+
+        def _reload_token_if_stale(self) -> None:
+            pass
+
+    monkeypatch.setattr(sse_mod, "SentinelGate", _BlockedGate)
+
+    with pytest.raises(UpstreamChallengeError):
+        asyncio.run(
+            sse_mod.ConversationClient(_Backend()).complete(  # type: ignore[arg-type]
+                "gpt-5-6", [{"role": "user", "content": "hi"}]
+            )
+        )
+
+
+# ── list_apps endpoint change ────────────────────────────────────────────────
+
+
+class _MCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, *a: Any, **k: Any):
+        def deco(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return deco
+
+
+class _Client:
+    def __init__(self, error: Exception | None = None, payload: dict | None = None):
+        self.error = error
+        self.payload = payload
+
+    def get(self, path: str, target_path: str | None = None, **_: Any) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+
+def test_list_apps_405_raises_upstream_endpoint_error() -> None:
+    from gpt2agent.tools import apps
+
+    client = _Client(error=RuntimeError("HTTP 405 for /backend-api/apps/list"))
+    mcp = _MCP()
+    apps.register(mcp, client)
+
+    with pytest.raises(UpstreamEndpointError) as excinfo:
+        asyncio.run(mcp.tools["list_apps"]())
+
+    message = str(excinfo.value)
+    assert "/backend-api/apps/list" in message
+    assert "405" in message
+    assert "not a problem with your token" in message
+
+
+def test_list_apps_405_from_post_shape_also_classified() -> None:
+    """backend.get and backend.post spell the 405 differently; both must map."""
+    from gpt2agent.tools import apps
+
+    client = _Client(error=RuntimeError("405 Method Not Allowed: /backend-api/apps/list"))
+    mcp = _MCP()
+    apps.register(mcp, client)
+
+    with pytest.raises(UpstreamEndpointError):
+        asyncio.run(mcp.tools["list_apps"]())
+
+
+def test_list_apps_other_errors_pass_through_unchanged() -> None:
+    from gpt2agent.tools import apps
+
+    client = _Client(error=RuntimeError("401 Unauthorized — token expired"))
+    mcp = _MCP()
+    apps.register(mcp, client)
+
+    with pytest.raises(RuntimeError, match="401") as excinfo:
+        asyncio.run(mcp.tools["list_apps"]())
+
+    assert not isinstance(excinfo.value, UpstreamEndpointError)
+
+
+def test_list_apps_success_path_unchanged() -> None:
+    from gpt2agent.tools import apps
+
+    client = _Client(
+        payload={
+            "apps": [
+                {"id": "connector_openai_codex_tasks", "enabled": True, "is_connected": True},
+                {"id": "asdk_app_1", "enabled": False, "connected": False},
+                "not-a-dict",
+            ]
+        }
+    )
+    mcp = _MCP()
+    apps.register(mcp, client)
+
+    out = asyncio.run(mcp.tools["list_apps"]())
+    assert [a["id"] for a in out] == ["connector_openai_codex_tasks", "asdk_app_1"]
+    assert out[1]["connected"] is False  # explicit False survives


### PR DESCRIPTION
Ten tools have been failing since ChatGPT's sentinel challenge changed upstream, and the failure surfaced as a bare `RuntimeError` traceback in MCP client logs — nothing told a user whether their token had expired, their config was wrong, or the service had moved.

This branch does not add features. It makes that breakage honest and gives users a way to check it themselves.

## Measured state

```
chat-requirements   HTTP 200          account auth is fine
proofofwork         solved            POW works
turnstile.dx        ~30 000 chars     challenge payload arrives
solve_turnstile()   returns None      the vendored solver cannot parse it
```

Identical from two machines. `_vendored/` is untouched and deliberately out of scope.

## Changes

**Named errors.** `UpstreamChallengeError` and `UpstreamEndpointError`, both `RuntimeError` subclasses so existing `except RuntimeError` handlers and `pytest.raises(RuntimeError, ...)` assertions keep passing — the `TokenNotFoundError` precedent from #33. The three sentinel raise sites keep their old first-line strings as a prefix so older `match=` assertions still hit.

**`gpt2agent doctor`.** One row per MCP tool, 26 in total. Live output:

```
gpt2agent doctor: 12 OK, 0 failed, 10 blocked upstream, 4 unverified
```

It never sends a message, creates a conversation or spends quota. Every probe is a GET; the write tools are classified from the code and reported `UNVERIFIED` rather than exercised; the gate tools copy the single sentinel probe instead of each sending a message.

**`.gitignore`** now excludes `docs/superpowers/` — internal design specs for unreleased work, in a public repo.

## Two review findings fixed rather than shipped

Cross-reviewed by two models; both returned FAIL on the same points, both fixed here:

- **`get_conversation` reported OK when it was never probed.** It reuses the id list `list_conversations` puts in the context and read a missing key as "no conversations, fine" — so when the listing probe *failed*, the context was never populated and an unexercised tool came back OK. Now raises and reports `UNVERIFIED`. The regression test was verified against the old code: revert the fix and it fails.
- **The README status table contradicted doctor.** `get_file_info` and `get_file_download_url` were listed as probed when nothing probes them, next to a quoted doctor summary counting them as unverified. Table now matches doctor's output, and `memory_search` gained the row it was missing.

Plus the simplifications both reviewers asked for: the identity expression and if/elif chain in the gate loop, the `_Unverified` dataclass that existed only to be unpacked, and a redundant empty-dict guard.

## Verification

```
ruff check gpt2agent tests scripts   All checks passed
pytest -q                            356 passed, 10 skipped   (baseline 326)
scripts/verify_release.py            release metadata verified: 0.0.12
gpt2agent doctor                     ran against the live account
```

## Not done, on purpose

No work on the Turnstile solver or `_vendored/`. Classifying the breakage is in scope; defeating it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q8zsVfnQnZoNkjk3wSyhp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gpt2agent doctor`, a read-only account health check with status reporting and meaningful exit codes.
  * Added checks for account access, available tools, and upstream service health without sending messages or creating conversations.

* **Bug Fixes**
  * Improved messaging when upstream security challenges prevent conversation-based tools from working.
  * Clarified handling of unavailable upstream endpoints, including app-listing failures.

* **Documentation**
  * Updated the README and changelog with health-check usage, status guidance, and current service limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->