### PR TITLE
chore(release): v0.0.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gpt2agent",
   "displayName": "gpt2agent",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Your ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent mode) as 25 MCP tools — reuses your codex login. Requires the gpt2agent CLI on PATH (pipx install gpt2agent).",
   "author": {
     "name": "robotlearning123",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-09-09
+
 ### Added
 
 - `gpt2agent doctor`: a new subcommand next to `setup`, `install` and `run`

--- a/gpt2agent/__init__.py
+++ b/gpt2agent/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt2agent"
-version = "0.0.12"
+version = "0.0.13"
 description = "Use your ChatGPT Plus/Pro in Claude Code and other AI agents — one command setup"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.robotlearning123/gpt2agent",
   "title": "gpt2agent",
   "description": "ChatGPT Plus/Pro account (chat, deep research, image gen, code, agent) as 25 MCP tools.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "repository": {
     "url": "https://github.com/robotlearning123/gpt2agent",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "gpt2agent",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "transport": { "type": "stdio" },
       "packageArguments": [
         { "type": "positional", "value": "run" },


### PR DESCRIPTION
Ships the honest-failure work from #42.

Ten tools have been failing since ChatGPT's sentinel challenge changed upstream; until now that surfaced as a bare `RuntimeError` traceback with nothing to tell a user whether their token had expired, their config was wrong, or the service had moved.

**Added** — `UpstreamChallengeError` / `UpstreamEndpointError` (both `RuntimeError` subclasses, so existing handlers and `pytest.raises` assertions keep passing), and `gpt2agent doctor`: one row per MCP tool, no message sent, no conversation created, no quota spent. Live output today: `12 OK, 0 failed, 10 blocked upstream, 4 unverified`.

**Not done on purpose** — no work on the challenge itself or `_vendored/`. Classifying the breakage is in scope; defeating it is not.

Verified: ruff clean, 356 passed 10 skipped, metadata consistent across all four version files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q8zsVfnQnZoNkjk3wSyhp